### PR TITLE
Add StorageProvider trait bound to Client

### DIFF
--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -17,6 +17,9 @@ sp-runtime = { path = "../vendor/substrate/primitives/runtime" }
 sp-api = { path = "../vendor/substrate/primitives/api" }
 sp-consensus = { path = "../vendor/substrate/primitives/consensus/common" }
 sp-transaction-pool = { path = "../vendor/substrate/primitives/transaction-pool" }
+sp-storage = { path = "../vendor/substrate/primitives/storage" } 
+sc-service = { path = "../vendor/substrate/client/service" }
+sc-client-api = { path = "../vendor/substrate/client/api" }
 ethereum = { version = "0.2", features = ["codec"] }
 codec = { package = "parity-scale-codec", version = "1.0.0" }
 rlp = "0.4"

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -25,6 +25,8 @@ use sp_transaction_pool::TransactionPool;
 use sp_blockchain::{Error as BlockChainError, HeaderMetadata, HeaderBackend};
 use sp_consensus::SelectChain;
 use sc_rpc_api::DenyUnsafe;
+use sc_client_api::backend::{StorageProvider, Backend, StateBackend};
+use sp_runtime::traits::BlakeTwo256;
 
 /// Light client extra dependencies.
 pub struct LightDeps<C, F, P> {
@@ -51,10 +53,12 @@ pub struct FullDeps<C, P, SC> {
 }
 
 /// Instantiate all Full RPC extensions.
-pub fn create_full<C, P, M, SC>(
+pub fn create_full<C, P, M, SC, BE>(
 	deps: FullDeps<C, P, SC>,
 ) -> jsonrpc_core::IoHandler<M> where
-	C: ProvideRuntimeApi<Block>,
+	BE: Backend<Block> + 'static,
+	BE::State: StateBackend<BlakeTwo256>,
+	C: ProvideRuntimeApi<Block> + StorageProvider<Block, BE>,
 	C: HeaderBackend<Block> + HeaderMetadata<Block, Error=BlockChainError> + 'static,
 	C: Send + Sync + 'static,
 	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,


### PR DESCRIPTION
Add support to access and use the sc_service::client::Client StorageProvider implementation through the client's instance. 

https://crates.parity.io/sc_client_api/backend/trait.StorageProvider.html

