### PR TITLE
Implement transaction_by_hash Runtime API

### DIFF
--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -32,7 +32,7 @@ use sp_runtime::{
 };
 use sha3::{Digest, Keccak256};
 
-pub use frontier_rpc_primitives::TransactionStatus;
+pub use frontier_rpc_primitives::{TransactionStatus, Transaction as FullTransaction};
 pub use ethereum::{Transaction, Log, Block};
 
 /// A type alias for the balance type from this pallet's point of view.
@@ -61,6 +61,7 @@ decl_storage! {
 		BlockNumbers: map hasher(blake2_128_concat) T::BlockNumber => H256;
 		PendingTransactionsAndReceipts: Vec<(ethereum::Transaction, ethereum::Receipt)>;
 		TransactionStatuses: map hasher(blake2_128_concat) H256 => Option<TransactionStatus>;
+		Transactions: map hasher(blake2_128_concat) H256 => Option<FullTransaction>;
 	}
 }
 
@@ -187,12 +188,51 @@ decl_module! {
 
 			let block = ethereum::Block {
 				header,
-				transactions,
+				transactions: transactions.clone(),
 				ommers,
 			};
 
 			BlocksAndReceipts::insert(hash, (block, receipts));
 			BlockNumbers::<T>::insert(n, hash);
+
+			for t in &transactions {
+				let transaction_hash = H256::from_slice(
+					Keccak256::digest(&rlp::encode(t)).as_slice()
+				);
+				if let Some(transaction_status) = TransactionStatuses::get(transaction_hash) {
+					let full_transaction = FullTransaction {
+						hash: transaction_hash,
+						nonce: t.nonce,
+						block_hash: Some(hash),
+						block_number: Some(U256::from(
+							UniqueSaturatedInto::<u128>::unique_saturated_into(n)
+						)),
+						transaction_index: Some(U256::from(
+							UniqueSaturatedInto::<u32>::unique_saturated_into(
+								transaction_status.transaction_index
+							)
+						)),
+						from: transaction_status.from,
+						to: transaction_status.to,
+						value: t.value,
+						gas_price: t.gas_price,
+						gas: t.gas_limit,
+						input: t.input.clone(),
+						creates: transaction_status.contract_address,
+						raw: vec![], // TODO,
+						public_key: None, // TODO,
+						chain_id: None, // TODO
+						standard_v: U256::zero(), // TODO
+						v: U256::zero(), // TODO
+						r: U256::zero(), // TODO
+						s: U256::zero(), // TODO
+						// Option<TransactionCondition>, Not supported? By now all pending 
+						// transactions are stored on chain on_finalize.
+						condition: None, 
+					};
+					Transactions::insert(transaction_hash, full_transaction);
+				};
+			}
 		}
 
 		// A runtime code run after every block and have access to extended set of APIs.

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -265,6 +265,10 @@ impl<T: Trait> Module<T> {
 	pub fn transaction_status(hash: H256) -> Option<TransactionStatus> {
 		TransactionStatuses::get(hash)
 	}
+	
+	pub fn transaction_by_hash(hash: H256) -> Option<FullTransaction> {
+		Transactions::get(hash)
+	}
 
 	pub fn block_by_number(number: T::BlockNumber) -> Option<ethereum::Block> {
 		if <BlockNumbers<T>>::contains_key(number) {

--- a/rpc/core/src/eth.rs
+++ b/rpc/core/src/eth.rs
@@ -129,7 +129,7 @@ pub trait EthApi {
 
 	/// Get transaction by its hash.
 	#[rpc(name = "eth_getTransactionByHash")]
-	fn transaction_by_hash(&self, _: H256) -> BoxFuture<Option<Transaction>>;
+	fn transaction_by_hash(&self, _: H256) -> Result<Option<Transaction>>;
 
 	/// Returns transaction at given block hash and index.
 	#[rpc(name = "eth_getTransactionByBlockHashAndIndex")]

--- a/rpc/primitives/src/lib.rs
+++ b/rpc/primitives/src/lib.rs
@@ -16,8 +16,8 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use sp_core::{H160, H256, H512, U256};
-use ethereum::{Log, Block as EthereumBlock};
+use sp_core::{H160, H256, U256};
+use ethereum::{Log, Block as EthereumBlock, Transaction as EthereumTransaction};
 use ethereum_types::Bloom;
 use codec::{Encode, Decode};
 use sp_std::vec::Vec;
@@ -33,30 +33,6 @@ pub struct TransactionStatus {
 	pub logs_bloom: Bloom,
 }
 
-#[derive(Eq, PartialEq, Clone, Encode, Decode, sp_runtime::RuntimeDebug)]
-pub struct Transaction {
-	pub hash: H256,
-	pub nonce: U256,
-	pub block_hash: Option<H256>,
-	pub block_number: Option<U256>,
-	pub transaction_index: Option<U256>,
-	pub from: H160,
-	pub to: Option<H160>,
-	pub value: U256,
-	pub gas_price: U256,
-	pub gas: U256,
-	pub input: Vec<u8>,
-	pub creates: Option<H160>,
-	pub raw: Vec<u8>,
-	pub public_key: Option<H512>,
-	pub chain_id: Option<u64>,
-	pub standard_v: U256,
-	pub v: U256,
-	pub r: U256,
-	pub s: U256,
-	pub condition: Option<u64>,
-}
-
 sp_api::decl_runtime_apis! {
 	/// API necessary for Ethereum-compatibility layer.
 	pub trait EthereumRuntimeApi {
@@ -69,7 +45,11 @@ sp_api::decl_runtime_apis! {
 		fn block_by_number(number: u32) -> Option<EthereumBlock>;
 		fn block_transaction_count_by_number(number: u32) -> Option<U256>;
 		fn block_by_hash(hash: H256) -> Option<EthereumBlock>;
-		fn transaction_by_hash(hash: H256) -> Option<Transaction>;
+		fn transaction_by_hash(hash: H256) -> Option<(
+			EthereumTransaction,
+			EthereumBlock,
+			TransactionStatus
+		)>;
 	}
 }
 

--- a/rpc/primitives/src/lib.rs
+++ b/rpc/primitives/src/lib.rs
@@ -16,7 +16,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use sp_core::{H160, H256, U256};
+use sp_core::{H160, H256, H512, U256};
 use ethereum::{Log, Block as EthereumBlock};
 use ethereum_types::Bloom;
 use codec::{Encode, Decode};
@@ -31,6 +31,30 @@ pub struct TransactionStatus {
 	pub contract_address: Option<H160>,
 	pub logs: Vec<Log>,
 	pub logs_bloom: Bloom,
+}
+
+#[derive(Eq, PartialEq, Clone, Encode, Decode, sp_runtime::RuntimeDebug)]
+pub struct Transaction {
+	pub hash: H256,
+	pub nonce: U256,
+	pub block_hash: Option<H256>,
+	pub block_number: Option<U256>,
+	pub transaction_index: Option<U256>,
+	pub from: H160,
+	pub to: Option<H160>,
+	pub value: U256,
+	pub gas_price: U256,
+	pub gas: U256,
+	pub input: Vec<u8>,
+	pub creates: Option<H160>,
+	pub raw: Vec<u8>,
+	pub public_key: Option<H512>,
+	pub chain_id: Option<u64>,
+	pub standard_v: U256,
+	pub v: U256,
+	pub r: U256,
+	pub s: U256,
+	pub condition: Option<u64>,
 }
 
 sp_api::decl_runtime_apis! {

--- a/rpc/primitives/src/lib.rs
+++ b/rpc/primitives/src/lib.rs
@@ -67,6 +67,7 @@ sp_api::decl_runtime_apis! {
 		fn account_code_at(address: H160) -> Vec<u8>;
 		fn author() -> H160;
 		fn block_by_number(number: u32) -> Option<EthereumBlock>;
+		fn transaction_by_hash(hash: H256) -> Option<Transaction>;
 	}
 }
 

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -308,8 +308,31 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 		unimplemented!("estimate_gas");
 	}
 
-	fn transaction_by_hash(&self, _: H256) -> BoxFuture<Option<Transaction>> {
-		unimplemented!("transaction_by_hash");
+	fn transaction_by_hash(&self, hash: H256) -> Result<Option<Transaction>> {
+		Ok(Some(
+			Transaction {
+				hash: H256::default(),
+				nonce: U256::zero(),
+				block_hash: None, //Option<H256>,
+				block_number: None, //Option<U256>,
+				transaction_index: None, //Option<U256>,
+				from: H160::default(),
+				to: None, //Option<H160>,
+				value: U256::zero(),
+				gas_price: U256::zero(),
+				gas: U256::zero(),
+				input: Bytes(vec![]),
+				creates: None, //Option<H160>,
+				raw: Bytes(vec![]),
+				public_key: None, //Option<H512>,
+				chain_id: None, //Option<U64>,
+				standard_v: U256::zero(),
+				v: U256::zero(),
+				r: U256::zero(),
+				s: U256::zero(),
+				condition: None, //Option<TransactionCondition>,
+			}
+		))
 	}
 
 	fn transaction_by_block_hash_and_index(

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -59,6 +59,7 @@ pub use frame_support::{
 	StorageValue,
 };
 use ethereum::Block as EthereumBlock;
+use frontier_rpc_primitives::Transaction as FullTransaction;
 
 
 #[cfg(any(feature = "std", test))]
@@ -476,6 +477,10 @@ impl_runtime_apis! {
 
 		fn block_by_number(number: u32) -> Option<EthereumBlock> {
 			<ethereum::Module<Runtime>>::block_by_number(number)
+		}
+
+		fn transaction_by_hash(hash: H256) -> Option<FullTransaction> {
+			<ethereum::Module<Runtime>>::transaction_by_hash(hash)
 		}
 	}
 

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -58,8 +58,8 @@ pub use frame_support::{
 	},
 	StorageValue,
 };
-use ethereum::Block as EthereumBlock;
-use frontier_rpc_primitives::Transaction as FullTransaction;
+use ethereum::{Block as EthereumBlock, Transaction as EthereumTransaction};
+use frontier_rpc_primitives::{TransactionStatus};
 
 
 #[cfg(any(feature = "std", test))]
@@ -490,7 +490,10 @@ impl_runtime_apis! {
 			<ethereum::Module<Runtime>>::block_by_hash(hash)
 		}
 
-		fn transaction_by_hash(hash: H256) -> Option<FullTransaction> {
+		fn transaction_by_hash(hash: H256) -> Option<(
+			EthereumTransaction, 
+			EthereumBlock, 
+			TransactionStatus)> {
 			<ethereum::Module<Runtime>>::transaction_by_hash(hash)
 		}
 	}


### PR DESCRIPTION
rel #7 

- pallet-ethereum: add `Transactions` StorageMap.
- `Transactions` insert `on_finalize`.
- New `frontier_rpc_primitives::Transaction` type.
- `transaction_by_hash` Runtime API implementation