### PR TITLE
Implement work for EthApi

### DIFF
--- a/rpc/core/src/eth.rs
+++ b/rpc/core/src/eth.rs
@@ -189,7 +189,7 @@ pub trait EthApi {
 
 	/// Returns the hash of the current block, the seedHash, and the boundary condition to be met.
 	#[rpc(name = "eth_getWork")]
-	fn work(&self, _: Option<u64>) -> Result<Work>;
+	fn work(&self) -> Result<Work>;
 
 	/// Used for submitting a proof-of-work solution.
 	#[rpc(name = "eth_submitWork")]

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -421,18 +421,11 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 	}
 
 	fn work(&self) -> Result<Work> {
-		let header = self
-			.select_chain
-			.best_chain()
-			.map_err(|_| internal_err("fetch header failed"))?;
-		
 		Ok(Work {
-			pow_hash: H256::from(header.hash()),
+			pow_hash: H256::default(),
 			seed_hash: H256::default(),
 			target: H256::default(),
-			number: Some(
-				header.number().clone().unique_saturated_into() as u64
-			),
+			number: None,
 		})
 	}
 

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -420,8 +420,20 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 		unimplemented!("logs");
 	}
 
-	fn work(&self, _: Option<u64>) -> Result<Work> {
-		unimplemented!("work");
+	fn work(&self) -> Result<Work> {
+		let header = self
+			.select_chain
+			.best_chain()
+			.map_err(|_| internal_err("fetch header failed"))?;
+		
+		Ok(Work {
+			pow_hash: H256::from(header.hash()),
+			seed_hash: H256::default(),
+			target: H256::default(),
+			number: Some(
+				header.number().clone().unique_saturated_into() as u64
+			),
+		})
 	}
 
 	fn submit_work(&self, _: H64, _: H256, _: H256) -> Result<bool> {


### PR DESCRIPTION
rel #7 

Removed the u64 optional parameter as it is not part of the spec:
https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getwork