### PR TITLE
Rename submit_transaction to send_transaction and notify unsupported

### DIFF
--- a/rpc/core/src/eth.rs
+++ b/rpc/core/src/eth.rs
@@ -115,9 +115,10 @@ pub trait EthApi {
 	#[rpc(name = "eth_sendRawTransaction")]
 	fn send_raw_transaction(&self, _: Bytes) -> BoxFuture<H256>;
 
-	/// @alias of `eth_sendRawTransaction`.
-	#[rpc(name = "eth_submitTransaction")]
-	fn submit_transaction(&self, _: Bytes) -> Result<H256>;
+	/// Creates new message call transaction 
+	/// or a contract creation, if the data field contains code.
+	#[rpc(name = "eth_sendTransaction")]
+	fn send_transaction(&self, _: CallRequest) -> Result<H256>;
 
 	/// Call contract, returning the output data.
 	#[rpc(name = "eth_call")]

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -411,8 +411,8 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 		)
 	}
 
-	fn submit_transaction(&self, _: Bytes) -> Result<H256> {
-		unimplemented!("submit_transaction");
+	fn send_transaction(&self, _: CallRequest) -> Result<H256> {
+		Err(internal_err("methods that require stored private keys are unsupported"))
 	}
 
 	fn call(&self, _: CallRequest, _: Option<BlockNumber>) -> BoxFuture<Bytes> {


### PR DESCRIPTION
- Rename `eth_submitTransaction` - not in the https://eth.wiki/json-rpc/API spec - to `eth_sendTransaction`.
- On method call, return an unsupported InternalError code: `methods that require stored private keys are unsupported`