### PR TITLE
Support for additional RichBlock fields

### DIFF
--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -30,8 +30,9 @@ use sp_runtime::{
 	traits::UniqueSaturatedInto,
 	transaction_validity::{TransactionValidity, TransactionSource, ValidTransaction}
 };
-use rlp;
-use sha3::{Digest, Keccak256};
+// Some convenience re-exports to access from impl_runtime_apis
+pub use rlp;
+pub use sha3::{Digest, Keccak256};
 
 pub use frontier_rpc_primitives::TransactionStatus;
 pub use ethereum::{Transaction, Log, Block};

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -30,9 +30,8 @@ use sp_runtime::{
 	traits::UniqueSaturatedInto,
 	transaction_validity::{TransactionValidity, TransactionSource, ValidTransaction}
 };
-// Some convenience re-exports to access from impl_runtime_apis
-pub use rlp;
-pub use sha3::{Digest, Keccak256};
+use rlp;
+use sha3::{Digest, Keccak256};
 
 pub use frontier_rpc_primitives::TransactionStatus;
 pub use ethereum::{Transaction, Log, Block};
@@ -310,6 +309,17 @@ impl<T: Trait> Module<T> {
 			return Some(block)
 		}
 		None
+	}
+
+	pub fn block_transaction_statuses(
+		block: &Block
+	) -> Vec<Option<TransactionStatus>> {
+		block.transactions.iter().map(|transaction|{
+			let transaction_hash = H256::from_slice(
+				Keccak256::digest(&rlp::encode(transaction)).as_slice()
+			);
+			<Module<T>>::transaction_status(transaction_hash)
+		}).collect()
 	}
 
 	/// Execute an Ethereum transaction, ignoring transaction signatures.

--- a/rpc/primitives/src/lib.rs
+++ b/rpc/primitives/src/lib.rs
@@ -66,7 +66,7 @@ sp_api::decl_runtime_apis! {
 			gas_price: U256,
 			nonce: Option<U256>,
 		) -> Option<(Vec<u8>, U256)>;
-		fn block_by_number(number: u32) -> Option<EthereumBlock>;
+		fn block_by_number(number: u32) -> (Option<EthereumBlock>, Vec<Option<TransactionStatus>>);
 		fn block_transaction_count_by_number(number: u32) -> Option<U256>;
 		fn block_by_hash(hash: H256) -> Option<EthereumBlock>;
 		fn block_by_hash_with_statuses(hash: H256) -> (Option<EthereumBlock>, Vec<Option<TransactionStatus>>);

--- a/rpc/primitives/src/lib.rs
+++ b/rpc/primitives/src/lib.rs
@@ -33,6 +33,20 @@ pub struct TransactionStatus {
 	pub logs_bloom: Bloom,
 }
 
+impl Default for TransactionStatus {
+	fn default() -> Self {
+		TransactionStatus {
+			transaction_hash: H256::default(),
+			transaction_index: 0 as u32,
+			from: H160::default(),
+			to: None,
+			contract_address: None,
+			logs: Vec::new(),
+			logs_bloom: Bloom::default(),
+		}
+	}
+}
+
 sp_api::decl_runtime_apis! {
 	/// API necessary for Ethereum-compatibility layer.
 	pub trait EthereumRuntimeApi {
@@ -55,6 +69,7 @@ sp_api::decl_runtime_apis! {
 		fn block_by_number(number: u32) -> Option<EthereumBlock>;
 		fn block_transaction_count_by_number(number: u32) -> Option<U256>;
 		fn block_by_hash(hash: H256) -> Option<EthereumBlock>;
+		fn block_by_hash_with_statuses(hash: H256) -> (Option<EthereumBlock>, Vec<Option<TransactionStatus>>);
 		fn block_transaction_count_by_hash(hash: H256) -> Option<U256>;
 		fn transaction_by_hash(hash: H256) -> Option<(
 			EthereumTransaction,

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -84,7 +84,7 @@ fn rich_block_build(block: ethereum::Block, hash: Option<H256>) -> RichBlock {
 			number: Some(block.header.number),
 			gas_used: block.header.gas_used,
 			gas_limit: block.header.gas_limit,
-			extra_data: Bytes(vec![]), // TODO H256 to Vec<u8>
+			extra_data: Bytes(block.header.extra_data.as_bytes().to_vec()),
 			logs_bloom: Some(block.header.logs_bloom),
 			timestamp: U256::from(block.header.timestamp),
 			difficulty: block.header.difficulty,

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -66,10 +66,14 @@ impl<B: BlockT, C, SC, P, CT, BE> EthApi<B, C, SC, P, CT, BE> {
 	}
 }
 
-fn rich_block_build(block: ethereum::Block) -> RichBlock {
+fn rich_block_build(block: ethereum::Block, hash: Option<H256>) -> RichBlock {
 	Rich {
 		inner: Block {
-			hash: None, // TODO
+			hash: Some(hash.unwrap_or_else(|| {
+				H256::from_slice(
+					Keccak256::digest(&rlp::encode(&block.header)).as_slice()
+				)
+			})),
 			parent_hash: block.header.parent_hash,
 			uncles_hash: H256::zero(), // TODO
 			author: H160::default(), // TODO
@@ -300,7 +304,7 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 			&BlockId::Hash(header.hash()),
 			hash
 		) {
-			Ok(Some(rich_block_build(block)))
+			Ok(Some(rich_block_build(block, Some(hash))))
 		} else {
 			Ok(None)
 		}
@@ -314,7 +318,7 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 				&BlockId::Hash(header.hash()),
 				native_number
 			) {
-				return Ok(Some(rich_block_build(block)));
+				return Ok(Some(rich_block_build(block, None)));
 			}
 		}
 		Ok(None)

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -89,7 +89,10 @@ fn rich_block_build(block: ethereum::Block, hash: Option<H256>) -> RichBlock {
 			timestamp: U256::from(block.header.timestamp),
 			difficulty: block.header.difficulty,
 			total_difficulty: None, // TODO
-			seal_fields: vec![], // TODO
+			seal_fields: vec![
+				Bytes(block.header.mix_hash.as_bytes().to_vec()),
+				Bytes(block.header.nonce.as_bytes().to_vec())
+			],
 			uncles: vec![], // TODO
 			// TODO expected struct `frontier_rpc_core::types::transaction::Transaction`,
 			// found struct `ethereum::transaction::Transaction`

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -99,7 +99,7 @@ fn rich_block_build(
 			],
 			uncles: vec![], // TODO
 			transactions: BlockTransactions::Full(
-				block.transactions.iter().enumerate().map(|(index,transaction)|{
+				block.transactions.iter().enumerate().map(|(index, transaction)|{
 					let mut status = statuses[index].clone();
 					// A fallback to default check
 					if status.is_none() {

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -328,11 +328,11 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 		let header = self.select_chain.best_chain()
 			.map_err(|_| internal_err("fetch header failed"))?;
 		if let Ok(Some(native_number)) = self.native_block_number(Some(number)) {
-			if let Ok(Some(block)) = self.client.runtime_api().block_by_number(
+			if let Ok((Some(block), statuses)) = self.client.runtime_api().block_by_number(
 				&BlockId::Hash(header.hash()),
 				native_number
 			) {
-				return Ok(Some(rich_block_build(block, vec![], None)));
+				return Ok(Some(rich_block_build(block, statuses, None)));
 			}
 		}
 		Ok(None)

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -57,7 +57,7 @@ pub use frame_support::{
 	},
 	StorageValue,
 };
-use ethereum::{Block as EthereumBlock, Transaction as EthereumTransaction, Digest, Keccak256, rlp};
+use ethereum::{Block as EthereumBlock, Transaction as EthereumTransaction};
 use frontier_rpc_primitives::{TransactionStatus};
 
 
@@ -509,13 +509,11 @@ impl_runtime_apis! {
 			Option<EthereumBlock>, Vec<Option<ethereum::TransactionStatus>>
 		) {
 			if let Some(block) = <ethereum::Module<Runtime>>::block_by_number(number) {
-				let statuses = block.transactions.iter().map(|transaction|{
-					let transaction_hash = H256::from_slice(
-						Keccak256::digest(&rlp::encode(transaction)).as_slice()
-					);
-					ethereum::Module::<Runtime>::transaction_status(transaction_hash)
-				}).collect();
-				return (Some(block), statuses);
+				let statuses = <ethereum::Module<Runtime>>::block_transaction_statuses(&block);
+				return (
+					Some(block), 
+					statuses
+				);
 			}
 			(None,vec![])
 		}
@@ -542,13 +540,11 @@ impl_runtime_apis! {
 			Option<EthereumBlock>, Vec<Option<ethereum::TransactionStatus>>
 		) {
 			if let Some(block) = <ethereum::Module<Runtime>>::block_by_hash(hash) {
-				let statuses = block.transactions.iter().map(|transaction|{
-					let transaction_hash = H256::from_slice(
-						Keccak256::digest(&rlp::encode(transaction)).as_slice()
-					);
-					ethereum::Module::<Runtime>::transaction_status(transaction_hash)
-				}).collect();
-				return (Some(block), statuses);
+				let statuses = <ethereum::Module<Runtime>>::block_transaction_statuses(&block);
+				return (
+					Some(block), 
+					statuses
+				);
 			}
 			(None,vec![])
 		}

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -546,7 +546,7 @@ impl_runtime_apis! {
 					statuses
 				);
 			}
-			(None,vec![])
+			(None, vec![])
 		}
 
 		fn transaction_by_hash(hash: H256) -> Option<(


### PR DESCRIPTION
Rel #7 `block_by_hash` and `block_by_number`.

Adds support for `RichBlock` fields: `hash`, `extra_data`, `seal_fields`, `transactions`.

- Added a new `block_by_hash_with_statuses` rpc primitive function that returns a `(Block, Vec<TransactionStatus>)`. This is used to perform the `RichBlock::transactions` conversion.
- Updated the `block_by_number` rpc function to behave the same way.
- `seal_fields` returns a Vec<Bytes> containing block header's `mix_hash` and `nonce`.

**Additional note**

Originally `block_by_number` and `block_by_hash` rpc primitive functions returned the same response type (Block) accepting different parameters (hash or number).

Now they differ on the response type because `block_by_hash` alone is used for other pursposes (supporting the `BlockNumber` enum parameter in rpc requests) unlike `block_by_number` that is solely used for building a `RichBlock` response.

That is the reason for including the additional `block_by_hash_with_statuses` rpc primitive function.