### PR TITLE
Support for additional Receipt fields

### DIFF
--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -34,7 +34,7 @@ use rlp;
 use sha3::{Digest, Keccak256};
 
 pub use frontier_rpc_primitives::TransactionStatus;
-pub use ethereum::{Transaction, Log, Block};
+pub use ethereum::{Transaction, Log, Block, Receipt};
 
 #[cfg(all(feature = "std", test))]
 mod tests;
@@ -249,13 +249,14 @@ impl<T: Trait> Module<T> {
 	pub fn transaction_by_hash(hash: H256) -> Option<(
 		ethereum::Transaction,
 		ethereum::Block,
-		TransactionStatus
+		TransactionStatus,
+		ethereum::Receipt
 	)> {
 		let (block_hash, transaction_index) = Transactions::get(hash)?;
 		let transaction_status = TransactionStatuses::get(hash)?;
-		let (block,_receipt) = BlocksAndReceipts::get(block_hash)?;
+		let (block, receipts) = BlocksAndReceipts::get(block_hash)?;
 		let transaction = &block.transactions[transaction_index as usize];
-		Some((transaction.clone(), block, transaction_status))
+		Some((transaction.clone(), block, transaction_status, receipts[transaction_index as usize].clone()))
 	}
 
 	pub fn transaction_by_block_hash_and_index(

--- a/rpc/primitives/src/lib.rs
+++ b/rpc/primitives/src/lib.rs
@@ -17,7 +17,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use sp_core::{H160, H256, U256};
-use ethereum::{Log, Block as EthereumBlock, Transaction as EthereumTransaction};
+use ethereum::{
+	Log, Block as EthereumBlock, Transaction as EthereumTransaction, 
+	Receipt as EthereumReceipt
+};
 use ethereum_types::Bloom;
 use codec::{Encode, Decode};
 use sp_std::vec::Vec;
@@ -38,7 +41,6 @@ sp_api::decl_runtime_apis! {
 	pub trait EthereumRuntimeApi {
 		fn chain_id() -> u64;
 		fn account_basic(address: H160) -> pallet_evm::Account;
-		fn transaction_status(hash: H256) -> Option<TransactionStatus>;
 		fn gas_price() -> U256;
 		fn account_code_at(address: H160) -> Vec<u8>;
 		fn author() -> H160;
@@ -59,7 +61,8 @@ sp_api::decl_runtime_apis! {
 		fn transaction_by_hash(hash: H256) -> Option<(
 			EthereumTransaction,
 			EthereumBlock,
-			TransactionStatus
+			TransactionStatus,
+			EthereumReceipt
 		)>;
 		fn transaction_by_block_hash_and_index(
 			hash: H256,

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -483,7 +483,7 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 			.best_chain()
 			.map_err(|_| internal_err("fetch header failed"))?;
 
-		if let Ok(Some((transaction, block, status))) = self.client.runtime_api()
+		if let Ok(Some((transaction, block, status, _receipt))) = self.client.runtime_api()
 			.transaction_by_hash(&BlockId::Hash(header.hash()), hash) {
 			return Ok(Some(transaction_build(
 				transaction,
@@ -548,28 +548,45 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 	fn transaction_receipt(&self, hash: H256) -> Result<Option<Receipt>> {
 		let header = self.select_chain.best_chain()
 			.map_err(|_| internal_err("fetch header failed"))?;
-		let status = self.client.runtime_api()
-			.transaction_status(&BlockId::Hash(header.hash()), hash)
-			.map_err(|_| internal_err("fetch runtime transaction status failed"))?;
-		let receipt = status.map(|status| {
-			Receipt {
+		if let Ok(Some((_transaction, block, status, receipt))) = self.client.runtime_api()
+			.transaction_by_hash(&BlockId::Hash(header.hash()), hash) {
+			
+			let block_hash = H256::from_slice(
+				Keccak256::digest(&rlp::encode(&block.header)).as_slice()
+			);
+			return Ok(Some(Receipt {
 				transaction_hash: Some(status.transaction_hash),
 				transaction_index: Some(status.transaction_index.into()),
-				block_hash: Some(Default::default()),
+				block_hash: Some(block_hash),
 				from: Some(status.from),
 				to: status.to,
-				block_number: Some(Default::default()),
-				cumulative_gas_used: Default::default(),
-				gas_used: Some(Default::default()),
+				block_number: Some(block.header.number),
+				cumulative_gas_used: Default::default(), // TODO
+				gas_used: Some(receipt.used_gas),
 				contract_address: status.contract_address,
-				logs: Vec::new(),
-				state_root: None,
-				logs_bloom: Default::default(),
+				logs: {
+					receipt.logs.iter().map(|log| {
+						Log {
+							address: log.address,
+							topics: log.topics.clone(),
+							data: Bytes(log.data.clone()),
+							block_hash: Some(block_hash),
+							block_number: Some(block.header.number),
+							transaction_hash: Some(hash),
+							transaction_index: Some(status.transaction_index.into()),
+							log_index: None, // TODO
+							transaction_log_index: None, // TODO
+							log_type: Default::default(), // TODO
+							removed: false, // TODO
+						}
+					}).collect()
+				},
+				state_root: Some(receipt.state_root),
+				logs_bloom: Default::default(), // TODO
 				status_code: None,
-			}
-		});
-
-		Ok(receipt)
+			}))
+		}
+		Ok(None)
 	}
 
 	fn uncle_by_block_hash_and_index(&self, _: H256, _: Index) -> Result<Option<RichBlock>> {

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -57,7 +57,7 @@ pub use frame_support::{
 	},
 	StorageValue,
 };
-use ethereum::{Block as EthereumBlock, Transaction as EthereumTransaction};
+use ethereum::{Block as EthereumBlock, Transaction as EthereumTransaction, Receipt as EthereumReceipt};
 use frontier_rpc_primitives::{TransactionStatus};
 
 
@@ -455,10 +455,6 @@ impl_runtime_apis! {
 			evm::Module::<Runtime>::accounts(address)
 		}
 
-		fn transaction_status(hash: H256) -> Option<ethereum::TransactionStatus> {
-			ethereum::Module::<Runtime>::transaction_status(hash)
-		}
-
 		fn gas_price() -> U256 {
 			FixedGasPrice::min_gas_price()
 		}
@@ -530,7 +526,8 @@ impl_runtime_apis! {
 		fn transaction_by_hash(hash: H256) -> Option<(
 			EthereumTransaction,
 			EthereumBlock,
-			TransactionStatus)> {
+			TransactionStatus,
+			EthereumReceipt)> {
 			<ethereum::Module<Runtime>>::transaction_by_hash(hash)
 		}
 


### PR DESCRIPTION
Rel #7 `transaction_receipt`

This PR adds support for the `Receipt` fields: `block_hash`, `block_number`, `gas_used`, `logs` and `state_root` .

- Removed `transaction_status` rpc primitive function in favor of `transaction_by_hash`.
- Now `transaction_by_hash` additionally returns `ethereum::Receipt` by transaction index.