### PR TITLE
Support for additional Receipt fields #2

### DIFF
--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -260,6 +260,11 @@ impl<T: Trait> Module<T> {
 		TransactionStatuses::get(hash)
 	}
 
+	// Requires returning a Vec<Receipt> to enable cumulative calculations in the rpc-end.
+	// 
+	// - `cumulative_gas_used`: the sum of `used_gas` for this and all previous transactions 
+	// in the block. 
+	// - `log_index`: each Log's index, block wise.
 	pub fn transaction_by_hash(hash: H256) -> Option<(
 		ethereum::Transaction,
 		ethereum::Block,

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -250,13 +250,13 @@ impl<T: Trait> Module<T> {
 		ethereum::Transaction,
 		ethereum::Block,
 		TransactionStatus,
-		ethereum::Receipt
+		Vec<ethereum::Receipt>
 	)> {
 		let (block_hash, transaction_index) = Transactions::get(hash)?;
 		let transaction_status = TransactionStatuses::get(hash)?;
 		let (block, receipts) = BlocksAndReceipts::get(block_hash)?;
 		let transaction = &block.transactions[transaction_index as usize];
-		Some((transaction.clone(), block, transaction_status, receipts[transaction_index as usize].clone()))
+		Some((transaction.clone(), block, transaction_status, receipts))
 	}
 
 	pub fn transaction_by_block_hash_and_index(

--- a/rpc/core/src/types/log.rs
+++ b/rpc/core/src/types/log.rs
@@ -40,9 +40,6 @@ pub struct Log {
 	pub log_index: Option<U256>,
 	/// Log Index in Transaction
 	pub transaction_log_index: Option<U256>,
-	/// Log Type
-	#[serde(rename = "type")]
-	pub log_type: String,
 	/// Whether Log Type is Removed (Geth Compatibility Field)
 	#[serde(default)]
 	pub removed: bool,

--- a/rpc/primitives/src/lib.rs
+++ b/rpc/primitives/src/lib.rs
@@ -77,7 +77,7 @@ sp_api::decl_runtime_apis! {
 			EthereumTransaction,
 			EthereumBlock,
 			TransactionStatus,
-			EthereumReceipt
+			Vec<EthereumReceipt>
 		)>;
 		fn transaction_by_block_hash_and_index(
 			hash: H256,

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -613,7 +613,7 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 							)),
 							transaction_log_index: Some(U256::from(i)),
 							log_type: Default::default(), // TODO
-							removed: false, // TODO
+							removed: false,
 						}
 					}).collect()
 				},

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -600,7 +600,7 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 					}).collect()
 				},
 				state_root: Some(receipt.state_root),
-				logs_bloom: Default::default(), // TODO
+				logs_bloom: receipt.logs_bloom,
 				status_code: None,
 			}))
 		}

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -592,7 +592,7 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 				gas_used: Some(receipt.used_gas),
 				contract_address: status.contract_address,
 				logs: {
-					receipt.logs.iter().map(|log| {
+					receipt.logs.iter().enumerate().map(|(i, log)| {
 						Log {
 							address: log.address,
 							topics: log.topics.clone(),
@@ -602,7 +602,7 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 							transaction_hash: Some(hash),
 							transaction_index: Some(status.transaction_index.into()),
 							log_index: None, // TODO
-							transaction_log_index: None, // TODO
+							transaction_log_index: Some(U256::from(i)),
 							log_type: Default::default(), // TODO
 							removed: false, // TODO
 						}

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -612,7 +612,6 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 								(pre_receipts_log_index.unwrap_or(0)) + i as u32
 							)),
 							transaction_log_index: Some(U256::from(i)),
-							log_type: Default::default(), // TODO
 							removed: false,
 						}
 					}).collect()

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -549,7 +549,7 @@ impl_runtime_apis! {
 			EthereumTransaction,
 			EthereumBlock,
 			TransactionStatus,
-			EthereumReceipt)> {
+			Vec<EthereumReceipt>)> {
 			<ethereum::Module<Runtime>>::transaction_by_hash(hash)
 		}
 


### PR DESCRIPTION
rel #7 `transaction_receipt`

This PR adds support for the remaining fields in the `transaction_receipt` rpc call: `logs_bloom`, `cumulative_gas_used`, `transaction_log_index`, `log_index` and `removed`.

- `log_type` field is removed from the rpc core `Log` struct.
- `transaction_by_hash` runtime api now returns a `Vec<Receipt>`, necessary for calculating `cumulative_gas_used` and the `log_index`. 