### PR TITLE
Support for additional RichBlock fields #2

### DIFF
--- a/frame/ethereum/Cargo.toml
+++ b/frame/ethereum/Cargo.toml
@@ -18,6 +18,7 @@ pallet-evm = { version = "2.0.0-dev", default-features = false, path = "../../ve
 sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../vendor/substrate/primitives/runtime" }
 sp-std = { version = "2.0.0-dev", default-features = false, path = "../../vendor/substrate/primitives/std" }
 sp-io = { version = "2.0.0-dev", default-features = false, path = "../../vendor/substrate/primitives/io" }
+sp-application-crypto = { version = "2.0.0-dev", default-features = false, path = "../../vendor/substrate/primitives/application-crypto" }
 ethereum = { version = "0.2", default-features = false, features = ["codec"] }
 ethereum-types = { version = "0.9", default-features = false }
 rlp = { version = "0.4", default-features = false }
@@ -48,4 +49,5 @@ std = [
 	"sha3/std",
 	"libsecp256k1/std",
 	"frontier-rpc-primitives/std",
+	"sp-application-crypto/std",
 ]

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -79,7 +79,7 @@ fn rich_block_build(
 				)
 			})),
 			parent_hash: block.header.parent_hash,
-			uncles_hash: H256::zero(), // TODO
+			uncles_hash: H256::zero(),
 			author: H160::default(), // TODO
 			miner: H160::default(), // TODO
 			state_root: block.header.state_root,
@@ -92,20 +92,19 @@ fn rich_block_build(
 			logs_bloom: Some(block.header.logs_bloom),
 			timestamp: U256::from(block.header.timestamp),
 			difficulty: block.header.difficulty,
-			total_difficulty: None, // TODO
+			total_difficulty: None,
 			seal_fields: vec![
 				Bytes(block.header.mix_hash.as_bytes().to_vec()),
 				Bytes(block.header.nonce.as_bytes().to_vec())
 			],
-			uncles: vec![], // TODO
+			uncles: vec![],
 			transactions: BlockTransactions::Full(
 				block.transactions.iter().enumerate().map(|(index, transaction)|{
-					let mut status = statuses[index].clone();
-					// A fallback to default check
-					if status.is_none() {
-						status = Some(TransactionStatus::default());
-					}
-					transaction_build(transaction.clone(), block.clone(), status.unwrap())
+					transaction_build(
+						transaction.clone(), 
+						block.clone(), 
+						statuses[index].clone().unwrap_or_default()
+					)
 				}).collect()
 			),
 			size: Some(U256::from(rlp::encode(&block).len() as u32))

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -80,8 +80,8 @@ fn rich_block_build(
 			})),
 			parent_hash: block.header.parent_hash,
 			uncles_hash: H256::zero(),
-			author: H160::default(), // TODO
-			miner: H160::default(), // TODO
+			author: block.header.beneficiary,
+			miner: block.header.beneficiary,
 			state_root: block.header.state_root,
 			transactions_root: block.header.transactions_root,
 			receipts_root: block.header.receipts_root,

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -108,7 +108,7 @@ fn rich_block_build(
 					transaction_build(transaction.clone(), block.clone(), status.unwrap())
 				}).collect()
 			),
-			size: None // TODO
+			size: Some(U256::from(rlp::encode(&block).len() as u32))
 		},
 		extra_info: BTreeMap::new()
 	}


### PR DESCRIPTION
rel #7 `block_by_hash` and `block_by_number`.

- Adds support for RichBlock field `author` and `miner`.
- Adds support for RichBlock field `size`.
- Cleanup.