### PR TITLE
Support for additional Transaction fields

### DIFF
--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -151,7 +151,7 @@ fn transaction_build(
 		},
 		standard_v: U256::from(transaction.signature.standard_v()),
 		v: U256::from(transaction.signature.v()),
-		r: U256::zero(), // TODO
+		r: U256::from(transaction.signature.r().as_bytes()),
 		s: U256::zero(), // TODO
 		condition: None // TODO
 	}

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -142,7 +142,13 @@ fn transaction_build(
 		creates: status.contract_address,
 		raw: Bytes(rlp::encode(&transaction)),
 		public_key: None, // TODO
-		chain_id: None, // TODO
+		chain_id: {
+			if let Some(chain_id) = transaction.signature.chain_id() {
+				Some(U64::from(chain_id))
+			} else {
+				None
+			}
+		},
 		standard_v: U256::zero(), // TODO
 		v: U256::zero(), // TODO
 		r: U256::zero(), // TODO

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -149,7 +149,7 @@ fn transaction_build(
 				None
 			}
 		},
-		standard_v: U256::zero(), // TODO
+		standard_v: U256::from(transaction.signature.standard_v()),
 		v: U256::zero(), // TODO
 		r: U256::zero(), // TODO
 		s: U256::zero(), // TODO

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -150,7 +150,7 @@ fn transaction_build(
 			}
 		},
 		standard_v: U256::from(transaction.signature.standard_v()),
-		v: U256::zero(), // TODO
+		v: U256::from(transaction.signature.v()),
 		r: U256::zero(), // TODO
 		s: U256::zero(), // TODO
 		condition: None // TODO

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -142,13 +142,7 @@ fn transaction_build(
 		creates: status.contract_address,
 		raw: Bytes(rlp::encode(&transaction)),
 		public_key: None, // TODO
-		chain_id: {
-			if let Some(chain_id) = transaction.signature.chain_id() {
-				Some(U64::from(chain_id))
-			} else {
-				None
-			}
-		},
+		chain_id: transaction.signature.chain_id().map(U64::from),
 		standard_v: U256::from(transaction.signature.standard_v()),
 		v: U256::from(transaction.signature.v()),
 		r: U256::from(transaction.signature.r().as_bytes()),

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -138,9 +138,9 @@ fn transaction_build(
 		value: transaction.value,
 		gas_price: transaction.gas_price,
 		gas: transaction.gas_limit,
-		input: Bytes(transaction.input),
+		input: Bytes(transaction.clone().input),
 		creates: status.contract_address,
-		raw: Bytes(vec![]), // TODO
+		raw: Bytes(rlp::encode(&transaction)),
 		public_key: None, // TODO
 		chain_id: None, // TODO
 		standard_v: U256::zero(), // TODO

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -152,7 +152,7 @@ fn transaction_build(
 		standard_v: U256::from(transaction.signature.standard_v()),
 		v: U256::from(transaction.signature.v()),
 		r: U256::from(transaction.signature.r().as_bytes()),
-		s: U256::zero(), // TODO
+		s: U256::from(transaction.signature.s().as_bytes()),
 		condition: None // TODO
 	}
 }


### PR DESCRIPTION
rel #7 transaction_by_hash, transaction_by_block_hash_and_index, transaction_by_block_number_and_index.

This PR adds support for the `Transaction` fields: `raw`, `chain_id`, `standard_v`, `v`, `r`, `s`.

