### PR TITLE
Support for additional RichBlock fields #2

### DIFF
--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -22,7 +22,10 @@
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use frame_support::{decl_module, decl_storage, decl_error, decl_event, ensure, weights::Weight, traits::Get};
+use frame_support::{
+	decl_module, decl_storage, decl_error, decl_event, ensure,
+	weights::Weight, traits::Get, traits::FindAuthor
+};
 use sp_std::prelude::*;
 use frame_system::{self as system, ensure_none};
 use ethereum_types::{H160, H64, H256, U256, Bloom};
@@ -54,6 +57,7 @@ pub trait Trait: frame_system::Trait<Hash=H256> + pallet_balances::Trait + palle
 	/// The overarching event type.
 	type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
 	type ChainId: Get<u64>;
+	type FindAuthor: FindAuthor<H160>;
 }
 
 decl_storage! {
@@ -181,7 +185,7 @@ decl_module! {
 				ommers_hash: H256::from_slice(
 					Keccak256::digest(&rlp::encode_list(&ommers)[..]).as_slice(),
 				), // TODO: check ommers hash.
-				beneficiary: H160::default(),
+				beneficiary: <Module<T>>::find_author(),
 				state_root: H256::default(), // TODO: figure out if there's better way to get a sort-of-valid state root.
 				transactions_root: H256::from_slice(
 					Keccak256::digest(&rlp::encode_list(&transactions)[..]).as_slice(),
@@ -256,6 +260,16 @@ impl<T: Trait> frame_support::unsigned::ValidateUnsigned for Module<T> {
 // functions that do not write to storage and operation functions that do.
 // - Private functions. These are your usual private utilities unavailable to other pallets.
 impl<T: Trait> Module<T> {
+	pub fn find_author() -> H160 {
+		let digest = <frame_system::Module<T>>::digest();
+		let pre_runtime_digests = digest.logs.iter().filter_map(|d| d.as_pre_runtime());
+		if let Some(authority_id) = T::FindAuthor::find_author(pre_runtime_digests) {
+			authority_id
+		} else {
+			H160::default()
+		}
+	}
+	
 	pub fn transaction_status(hash: H256) -> Option<TransactionStatus> {
 		TransactionStatuses::get(hash)
 	}

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -269,7 +269,7 @@ impl<T: Trait> Module<T> {
 			H160::default()
 		}
 	}
-	
+
 	pub fn transaction_status(hash: H256) -> Option<TransactionStatus> {
 		TransactionStatuses::get(hash)
 	}

--- a/frame/ethereum/src/mock.rs
+++ b/frame/ethereum/src/mock.rs
@@ -19,7 +19,9 @@
 use super::*;
 use crate::{Module, Trait};
 use ethereum::{TransactionAction, TransactionSignature};
-use frame_support::{impl_outer_origin, parameter_types, weights::Weight};
+use frame_support::{
+	impl_outer_origin, parameter_types, weights::Weight, ConsensusEngineId
+};
 use pallet_evm::{FeeCalculator, HashTruncateConvertAccountId};
 use rlp::*;
 use sp_core::{H160, H256, U256};
@@ -100,6 +102,15 @@ impl FeeCalculator for FixedGasPrice {
 	}
 }
 
+pub struct EthereumFindAuthor;
+impl FindAuthor<H160> for EthereumFindAuthor {
+	fn find_author<'a, I>(_digests: I) -> Option<H160> where
+		I: 'a + IntoIterator<Item=(ConsensusEngineId, &'a [u8])>
+	{
+		Some(address_build(0).1)
+	}
+}
+
 parameter_types! {
 	pub const TransactionByteFee: u64 = 1;
 	pub const ChainId: u64 = 42;
@@ -118,6 +129,7 @@ impl pallet_evm::Trait for Test {
 impl Trait for Test {
 	type Event = ();
 	type ChainId = ChainId;
+	type FindAuthor = EthereumFindAuthor;
 }
 
 pub type System = frame_system::Module<Test>;
@@ -130,6 +142,16 @@ pub struct AccountInfo {
 	pub private_key: H256,
 }
 
+fn address_build(seed: u8) -> (H256,H160) {
+	let private_key = H256::from_slice(&[(seed + 1) as u8; 32]); //H256::from_low_u64_be((i + 1) as u64);
+	let secret_key = secp256k1::SecretKey::parse_slice(&private_key[..]).unwrap();
+	let public_key = secp256k1::PublicKey::from_secret_key(&secret_key);
+	let address = H160::from(H256::from_slice(
+		&Keccak256::digest(&public_key.serialize()[1..])[..],
+	));
+	(private_key, address)
+}
+
 // This function basically just builds a genesis storage key/value store according to
 // our desired mockup.
 pub fn new_test_ext(accounts_len: usize) -> (Vec<AccountInfo>, sp_io::TestExternalities) {
@@ -140,12 +162,7 @@ pub fn new_test_ext(accounts_len: usize) -> (Vec<AccountInfo>, sp_io::TestExtern
 
 	let pairs = (0..accounts_len)
 		.map(|i| {
-			let private_key = H256::from_slice(&[(i + 1) as u8; 32]); //H256::from_low_u64_be((i + 1) as u64);
-			let secret_key = secp256k1::SecretKey::parse_slice(&private_key[..]).unwrap();
-			let public_key = secp256k1::PublicKey::from_secret_key(&secret_key);
-			let address = H160::from(H256::from_slice(
-				&Keccak256::digest(&public_key.serialize()[1..])[..],
-			));
+			let (private_key, address) = address_build(i as u8);
 			AccountInfo {
 				private_key: private_key,
 				address: address,

--- a/frame/ethereum/src/mock.rs
+++ b/frame/ethereum/src/mock.rs
@@ -142,7 +142,7 @@ pub struct AccountInfo {
 	pub private_key: H256,
 }
 
-fn address_build(seed: u8) -> (H256,H160) {
+fn address_build(seed: u8) -> (H256, H160) {
 	let private_key = H256::from_slice(&[(seed + 1) as u8; 32]); //H256::from_low_u64_be((i + 1) as u64);
 	let secret_key = secp256k1::SecretKey::parse_slice(&private_key[..]).unwrap();
 	let public_key = secp256k1::PublicKey::from_secret_key(&secret_key);

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -80,8 +80,8 @@ fn rich_block_build(
 			})),
 			parent_hash: block.header.parent_hash,
 			uncles_hash: H256::zero(),
-			author: H160::default(), // TODO
-			miner: H160::default(), // TODO
+			author: block.header.beneficiary,
+			miner: block.header.beneficiary,
 			state_root: block.header.state_root,
 			transactions_root: block.header.transactions_root,
 			receipts_root: block.header.receipts_root,

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -108,7 +108,7 @@ fn rich_block_build(
 					transaction_build(transaction.clone(), block.clone(), status.unwrap())
 				}).collect()
 			),
-			size: None // TODO
+			size: Some(U256::from(rlp::encode(&block).len() as u32))
 		},
 		extra_info: BTreeMap::new()
 	}

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -79,7 +79,7 @@ fn rich_block_build(
 				)
 			})),
 			parent_hash: block.header.parent_hash,
-			uncles_hash: H256::zero(), // TODO
+			uncles_hash: H256::zero(),
 			author: H160::default(), // TODO
 			miner: H160::default(), // TODO
 			state_root: block.header.state_root,
@@ -92,20 +92,19 @@ fn rich_block_build(
 			logs_bloom: Some(block.header.logs_bloom),
 			timestamp: U256::from(block.header.timestamp),
 			difficulty: block.header.difficulty,
-			total_difficulty: None, // TODO
+			total_difficulty: None,
 			seal_fields: vec![
 				Bytes(block.header.mix_hash.as_bytes().to_vec()),
 				Bytes(block.header.nonce.as_bytes().to_vec())
 			],
-			uncles: vec![], // TODO
+			uncles: vec![],
 			transactions: BlockTransactions::Full(
 				block.transactions.iter().enumerate().map(|(index, transaction)|{
-					let mut status = statuses[index].clone();
-					// A fallback to default check
-					if status.is_none() {
-						status = Some(TransactionStatus::default());
-					}
-					transaction_build(transaction.clone(), block.clone(), status.unwrap())
+					transaction_build(
+						transaction.clone(),
+						block.clone(),
+						statuses[index].clone().unwrap_or_default()
+					)
 				}).collect()
 			),
 			size: Some(U256::from(rlp::encode(&block).len() as u32))


### PR DESCRIPTION
rel #7 `block_by_hash` and `block_by_number`.

- Adds support for RichBlock field `author` and `miner`.
- Adds support for RichBlock field `size`.
- Cleanup.