### PR TITLE
Add support for BlockTransactions variants

### DIFF
--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -112,7 +112,7 @@ fn rich_block_build(
 					)
 				} else {
 					BlockTransactions::Hashes(
-						block.transactions.iter().enumerate().map(|(_, transaction)|{
+						block.transactions.iter().map(|transaction|{
 							H256::from_slice(
 								Keccak256::digest(&rlp::encode(&transaction.clone())).as_slice()
 							)

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -69,7 +69,8 @@ impl<B: BlockT, C, SC, P, CT, BE> EthApi<B, C, SC, P, CT, BE> {
 fn rich_block_build(
 	block: ethereum::Block,
 	statuses: Vec<Option<TransactionStatus>>,
-	hash: Option<H256>
+	hash: Option<H256>,
+	full_transactions: bool
 ) -> RichBlock {
 	Rich {
 		inner: Block {
@@ -98,16 +99,27 @@ fn rich_block_build(
 				Bytes(block.header.nonce.as_bytes().to_vec())
 			],
 			uncles: vec![], // TODO
-			transactions: BlockTransactions::Full(
-				block.transactions.iter().enumerate().map(|(index, transaction)|{
-					let mut status = statuses[index].clone();
-					// A fallback to default check
-					if status.is_none() {
-						status = Some(TransactionStatus::default());
-					}
-					transaction_build(transaction.clone(), block.clone(), status.unwrap())
-				}).collect()
-			),
+			transactions: {
+				if full_transactions {
+					BlockTransactions::Full(
+						block.transactions.iter().enumerate().map(|(index, transaction)|{
+							transaction_build(
+								transaction.clone(),
+								block.clone(),
+								statuses[index].clone().unwrap_or_default()
+							)
+						}).collect()
+					)
+				} else {
+					BlockTransactions::Hashes(
+						block.transactions.iter().enumerate().map(|(_, transaction)|{
+							H256::from_slice(
+								Keccak256::digest(&rlp::encode(&transaction.clone())).as_slice()
+							)
+						}).collect()
+					)
+				}
+			},
 			size: None // TODO
 		},
 		extra_info: BTreeMap::new()
@@ -310,7 +322,7 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 		Ok(H256::default())
 	}
 
-	fn block_by_hash(&self, hash: H256, _: bool) -> Result<Option<RichBlock>> {
+	fn block_by_hash(&self, hash: H256, full: bool) -> Result<Option<RichBlock>> {
 		let header = self.select_chain.best_chain()
 			.map_err(|_| internal_err("fetch header failed"))?;
 
@@ -318,13 +330,13 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 			&BlockId::Hash(header.hash()),
 			hash
 		) {
-			Ok(Some(rich_block_build(block, statuses, Some(hash))))
+			Ok(Some(rich_block_build(block, statuses, Some(hash), full)))
 		} else {
 			Ok(None)
 		}
 	}
 
-	fn block_by_number(&self, number: BlockNumber, _: bool) -> Result<Option<RichBlock>> {
+	fn block_by_number(&self, number: BlockNumber, full: bool) -> Result<Option<RichBlock>> {
 		let header = self.select_chain.best_chain()
 			.map_err(|_| internal_err("fetch header failed"))?;
 		if let Ok(Some(native_number)) = self.native_block_number(Some(number)) {
@@ -332,7 +344,7 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 				&BlockId::Hash(header.hash()),
 				native_number
 			) {
-				return Ok(Some(rich_block_build(block, statuses, None)));
+				return Ok(Some(rich_block_build(block, statuses, None, full)));
 			}
 		}
 		Ok(None)


### PR DESCRIPTION
Rel #64 

This PR adds support for the boolean arg in `eth_getBlockByHash` and `eth_getBlockByNumber`.

- If `true`, it will return `BlockTransactions::Full(Vec<Transaction>)`
- If `false`, it will return `BlockTransactions::Hashes(Vec<H256>)`