### PR TITLE
test-utils: test executor, backend and function to create test client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1342,6 +1342,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "frontier-template-test-client"
+version = "0.1.0"
+dependencies = [
+ "frontier-template-runtime",
+ "sc-executor",
+ "sc-light",
+ "sp-runtime",
+ "substrate-test-client",
+]
+
+[[package]]
 name = "fs-swap"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5133,9 +5144,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.53"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
+checksum = "3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3"
 dependencies = [
  "itoa",
  "ryu",
@@ -5978,6 +5989,31 @@ dependencies = [
  "log",
  "prometheus",
  "tokio 0.2.21",
+]
+
+[[package]]
+name = "substrate-test-client"
+version = "2.0.0-rc4"
+dependencies = [
+ "futures 0.1.29",
+ "futures 0.3.5",
+ "hash-db",
+ "hex",
+ "parity-scale-codec",
+ "sc-client-api",
+ "sc-client-db",
+ "sc-consensus",
+ "sc-executor",
+ "sc-light",
+ "sc-service",
+ "serde",
+ "serde_json",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-core",
+ "sp-keyring",
+ "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,8 +1346,12 @@ name = "frontier-template-test-client"
 version = "0.1.0"
 dependencies = [
  "frontier-template-runtime",
+ "parity-scale-codec",
+ "sc-client-api",
+ "sc-consensus",
  "sc-executor",
  "sc-light",
+ "sp-api",
  "sp-runtime",
  "substrate-test-client",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
 	"rpc/primitives",
 	"template/node",
 	"template/runtime",
+        "template/test-utils/client",
 ]
 exclude = ["vendor"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 	"rpc/primitives",
 	"template/node",
 	"template/runtime",
-        "template/test-utils/client",
+	"template/test-utils/client",
 ]
 exclude = ["vendor"]
 

--- a/template/test-utils/client/Cargo.toml
+++ b/template/test-utils/client/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "frontier-template-test-client"
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
+description = "Ethereum RPC (web3) compatibility layer for Substrate."
+license = "GPL-3.0"
+
+[dependencies]
+sp-runtime = { path = "../../../vendor/substrate/primitives/runtime" }
+sc-executor = { path = "../../../vendor/substrate/client/executor" }
+sc-light = { path = "../../../vendor/substrate/client/light" }
+substrate-test-client = { path = "../../../vendor/substrate/test-utils/client" }
+frontier-template-runtime = { path = "../../runtime" }

--- a/template/test-utils/client/Cargo.toml
+++ b/template/test-utils/client/Cargo.toml
@@ -7,8 +7,12 @@ description = "Ethereum RPC (web3) compatibility layer for Substrate."
 license = "GPL-3.0"
 
 [dependencies]
+codec = { package = "parity-scale-codec", version = "1.3.1" }
 sp-runtime = { path = "../../../vendor/substrate/primitives/runtime" }
+sp-api = { path = "../../../vendor/substrate/primitives/api" }
 sc-executor = { path = "../../../vendor/substrate/client/executor" }
 sc-light = { path = "../../../vendor/substrate/client/light" }
+sc-consensus = { path = "../../../vendor/substrate/client/consensus/common" }
+sc-client-api = { path = "../../../vendor/substrate/client/api" }
 substrate-test-client = { path = "../../../vendor/substrate/test-utils/client" }
 frontier-template-runtime = { path = "../../runtime" }

--- a/template/test-utils/client/src/lib.rs
+++ b/template/test-utils/client/src/lib.rs
@@ -1,0 +1,29 @@
+pub use substrate_test_client::*;
+pub use frontier_template_runtime as runtime;
+use sp_runtime::traits::HashFor;
+
+sc_executor::native_executor_instance! {
+	pub LocalExecutor,
+	runtime::api::dispatch,
+	runtime::native_version,
+}
+
+pub type Backend = substrate_test_client::Backend<runtime::Block>;
+
+pub type Executor = client::LocalCallExecutor<
+	Backend,
+	NativeExecutor<LocalExecutor>,
+>;
+
+pub type LightBackend = substrate_test_client::LightBackend<runtime::Block>;
+
+pub type LightExecutor = sc_light::GenesisCallExecutor<
+	LightBackend,
+	client::LocalCallExecutor<
+		sc_light::Backend<
+			sc_client_db::light::LightStorage<runtime::Block>,
+			HashFor<runtime::Block>
+		>,
+		NativeExecutor<LocalExecutor>
+	>
+>;

--- a/template/test-utils/client/src/lib.rs
+++ b/template/test-utils/client/src/lib.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 pub use substrate_test_client::*;
 pub use frontier_template_runtime as runtime;
 use sp_runtime::traits::HashFor;
@@ -8,22 +10,101 @@ sc_executor::native_executor_instance! {
 	runtime::native_version,
 }
 
-pub type Backend = substrate_test_client::Backend<runtime::Block>;
+pub type Backend = substrate_test_client::Backend<runtime::opaque::Block>;
 
 pub type Executor = client::LocalCallExecutor<
 	Backend,
 	NativeExecutor<LocalExecutor>,
 >;
 
-pub type LightBackend = substrate_test_client::LightBackend<runtime::Block>;
+pub type LightBackend = substrate_test_client::LightBackend<runtime::opaque::Block>;
 
 pub type LightExecutor = sc_light::GenesisCallExecutor<
 	LightBackend,
 	client::LocalCallExecutor<
 		sc_light::Backend<
-			sc_client_db::light::LightStorage<runtime::Block>,
-			HashFor<runtime::Block>
+			sc_client_db::light::LightStorage<runtime::opaque::Block>,
+			HashFor<runtime::opaque::Block>
 		>,
 		NativeExecutor<LocalExecutor>
 	>
 >;
+
+/// Parameters of test-client builder with test-runtime.
+#[derive(Default)]
+pub struct GenesisParameters;
+
+impl substrate_test_client::GenesisInit for GenesisParameters {
+	fn genesis_storage(&self) -> Storage {
+		Storage::default()
+	}
+}
+
+/// A `TestClient` with `test-runtime` builder.
+pub type TestClientBuilder<E, B> = substrate_test_client::TestClientBuilder<
+	runtime::opaque::Block,
+	E,
+	B,
+	GenesisParameters,
+>;
+
+/// Test client type with `LocalExecutor` and generic Backend.
+pub type Client<B> = client::Client<
+	B,
+	client::LocalCallExecutor<B, sc_executor::NativeExecutor<LocalExecutor>>,
+	runtime::opaque::Block,
+	runtime::RuntimeApi,
+>;
+
+/// A test client with default backend.
+pub type TestClient = Client<Backend>;
+
+/// A `TestClientBuilder` with default backend and executor.
+pub trait DefaultTestClientBuilderExt: Sized {
+	/// Create new `TestClientBuilder`
+	fn new() -> Self;
+}
+
+impl DefaultTestClientBuilderExt for TestClientBuilder<Executor, Backend> {
+	fn new() -> Self {
+		Self::with_default_backend()
+	}
+}
+
+/// A `test-runtime` extensions to `TestClientBuilder`.
+pub trait TestClientBuilderExt<B>: Sized {
+	/// Build the test client.
+	fn build(self) -> Client<B> {
+		self.build_with_longest_chain().0
+	}
+
+	/// Build the test client and longest chain selector.
+	fn build_with_longest_chain(self) -> (Client<B>, sc_consensus::LongestChain<B, runtime::opaque::Block>);
+
+	/// Build the test client and the backend.
+	fn build_with_backend(self) -> (Client<B>, Arc<B>);
+}
+
+impl<B> TestClientBuilderExt<B> for TestClientBuilder<
+	client::LocalCallExecutor<B, sc_executor::NativeExecutor<LocalExecutor>>,
+	B
+> where
+	B: sc_client_api::backend::Backend<runtime::opaque::Block> + 'static,
+	// Rust bug: https://github.com/rust-lang/rust/issues/24159
+	<B as sc_client_api::backend::Backend<runtime::opaque::Block>>::State:
+		sp_api::StateBackend<HashFor<runtime::opaque::Block>>,
+{
+	fn build_with_longest_chain(self) -> (Client<B>, sc_consensus::LongestChain<B, runtime::opaque::Block>) {
+		self.build_with_native_executor(None)
+	}
+
+	fn build_with_backend(self) -> (Client<B>, Arc<B>) {
+		let backend = self.backend();
+		(self.build_with_native_executor(None).0, backend)
+	}
+}
+
+/// Creates new client instance used for tests.
+pub fn new() -> Client<Backend> {
+	TestClientBuilder::new().build()
+}


### PR DESCRIPTION
Add basic executor and backend definitions, and implement functionality to create new test client. Genesis filling is not yet complete (it's now just `Default::default()`).