### PR TITLE
Add support and Runtime API implementation for eth_getLogs

### DIFF
--- a/rpc/core/src/eth.rs
+++ b/rpc/core/src/eth.rs
@@ -185,7 +185,7 @@ pub trait EthApi {
 
 	/// Returns logs matching given filter object.
 	#[rpc(name = "eth_getLogs")]
-	fn logs(&self, _: Filter) -> BoxFuture<Vec<Log>>;
+	fn logs(&self, _: Filter) -> Result<Vec<Log>>;
 
 	/// Returns the hash of the current block, the seedHash, and the boundary condition to be met.
 	#[rpc(name = "eth_getWork")]

--- a/rpc/core/src/types/filter.rs
+++ b/rpc/core/src/types/filter.rs
@@ -66,9 +66,7 @@ pub struct Filter {
 	/// Address
 	pub address: Option<FilterAddress>,
 	/// Topics
-	pub topics: Option<Vec<Topic>>,
-	/// Limit
-	pub limit: Option<usize>,
+	pub topics: Option<Topic>,
 }
 
 /// Results of the filter_changes RPC.

--- a/rpc/core/src/types/mod.rs
+++ b/rpc/core/src/types/mod.rs
@@ -38,7 +38,7 @@ pub use self::bytes::Bytes;
 pub use self::block::{RichBlock, Block, BlockTransactions, Header, RichHeader, Rich};
 pub use self::block_number::BlockNumber;
 pub use self::call_request::CallRequest;
-pub use self::filter::{Filter, FilterChanges};
+pub use self::filter::{Filter, FilterChanges, VariadicValue};
 pub use self::index::Index;
 pub use self::log::Log;
 pub use self::receipt::Receipt;

--- a/rpc/primitives/src/lib.rs
+++ b/rpc/primitives/src/lib.rs
@@ -106,7 +106,11 @@ sp_api::decl_runtime_apis! {
 			Vec<H256>, // topics
 			Vec<u8>, // data
 			Option<H256>, // block_hash
-			Option<U256> // block_number
+			Option<U256>, // block_number
+			Option<H256>, // transaction_hash
+			Option<U256>, // transaction_index
+			Option<U256>, // log index in block
+			Option<U256>, // log index in transaction
 		)>;
 	}
 }

--- a/rpc/primitives/src/lib.rs
+++ b/rpc/primitives/src/lib.rs
@@ -95,6 +95,19 @@ sp_api::decl_runtime_apis! {
 			EthereumBlock,
 			TransactionStatus
 		)>;
+		fn logs(
+			from_block: Option<u32>,
+			to_block: Option<u32>,
+			block_hash: Option<H256>,
+			address: Option<H160>,
+			topic: Option<Vec<H256>>
+		) -> Vec<(
+			H160, // address
+			Vec<H256>, // topics
+			Vec<u8>, // data
+			Option<H256>, // block_hash
+			Option<U256> // block_number
+		)>;
 	}
 }
 

--- a/rpc/primitives/src/lib.rs
+++ b/rpc/primitives/src/lib.rs
@@ -95,6 +95,7 @@ sp_api::decl_runtime_apis! {
 			EthereumBlock,
 			TransactionStatus
 		)>;
+		/// For given filter arguments, return data necessary to build Logs
 		fn logs(
 			from_block: Option<u32>,
 			to_block: Option<u32>,

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -714,18 +714,21 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 				let data = log.2;
 				let block_hash = log.3;
 				let block_number = log.4;
-
+				let transaction_hash = log.5;
+				let transaction_index = log.6;
+				let log_index = log.7;
+				let transaction_log_index = log.8;
 				output.push(Log {
 					address,
 					topics,
 					data: Bytes(data),
 					block_hash,
 					block_number,
-					transaction_hash: None, // TODO
-					transaction_index: None, // TODO
-					log_index: None, // TODO
-					transaction_log_index: None, // TODO
-					removed: false // TODO
+					transaction_hash,
+					transaction_index,
+					log_index,
+					transaction_log_index,
+					removed: false
 				});
 			}
 			return Ok(output);

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -700,14 +700,14 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 
 		if let Ok(logs) = self.client.runtime_api()
 			.logs(
-				&BlockId::Hash(header.hash()), 
+				&BlockId::Hash(header.hash()),
 				from_block,
 				to_block,
 				filter.block_hash,
 				address,
 				topics
 		) {
-			let mut output = vec![]; 
+			let mut output = vec![];
 			for log in logs {
 				let address = log.0;
 				let topics = log.1;

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -668,44 +668,44 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 		let header = self.select_chain.best_chain()
 			.map_err(|_| internal_err("fetch header failed"))?;
 
-		let mut from_block_arg = None;
-		if let Some(from_block) = filter.from_block {
-			if let Ok(Some(block_number)) = self.native_block_number(Some(from_block)) {
-				from_block_arg = Some(block_number);
+		let mut from_block = None;
+		if let Some(from_block_input) = filter.from_block {
+			if let Ok(Some(block_number)) = self.native_block_number(Some(from_block_input)) {
+				from_block = Some(block_number);
 			}
 		}
 
-		let mut to_block_arg = None;
-		if let Some(to_block) = filter.to_block {
-			if let Ok(Some(block_number)) = self.native_block_number(Some(to_block)) {
-				to_block_arg = Some(block_number);
+		let mut to_block = None;
+		if let Some(to_block_input) = filter.to_block {
+			if let Ok(Some(block_number)) = self.native_block_number(Some(to_block_input)) {
+				to_block = Some(block_number);
 			}
 		}
 
-		let mut address_arg = None;
-		if let Some(address) = filter.address {
-			match address {
-				VariadicValue::Single(x) => { address_arg = Some(x); },
-				_ => { address_arg = None; }
+		let mut address = None;
+		if let Some(address_input) = filter.address {
+			match address_input {
+				VariadicValue::Single(x) => { address = Some(x); },
+				_ => { address = None; }
 			}
 		}
 
-		let mut topics_arg = None;
-		if let Some(topics) = filter.topics {
-			match topics {
-				VariadicValue::Multiple(x) => { topics_arg = Some(x); },
-				_ => { address_arg = None; }
+		let mut topics = None;
+		if let Some(topics_input) = filter.topics {
+			match topics_input {
+				VariadicValue::Multiple(x) => { topics = Some(x); },
+				_ => { topics = None; }
 			}
 		}
 
 		if let Ok(logs) = self.client.runtime_api()
 			.logs(
 				&BlockId::Hash(header.hash()), 
-				from_block_arg,
-				to_block_arg,
+				from_block,
+				to_block,
 				filter.block_hash,
-				address_arg,
-				topics_arg
+				address,
+				topics
 		) {
 			let mut output = vec![]; 
 			for log in logs {

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -595,7 +595,11 @@ impl_runtime_apis! {
 			Vec<H256>, // topics
 			Vec<u8>, // data
 			Option<H256>, // block_hash
-			Option<U256> // block_number
+			Option<U256>, // block_number
+			Option<H256>, // transaction_hash
+			Option<U256>, // transaction_index
+			Option<U256>, // log index in block
+			Option<U256>, // log index in transaction
 		)> {
 			let output = <ethereum::Module<Runtime>>::filtered_logs(
 				from_block,

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -583,6 +583,32 @@ impl_runtime_apis! {
 				index
 			)
 		}
+
+		fn logs(
+			from_block: Option<u32>,
+			to_block: Option<u32>,
+			block_hash: Option<H256>,
+			address: Option<H160>,
+			topic: Option<Vec<H256>>
+		) -> Vec<(
+			H160, // address
+			Vec<H256>, // topics
+			Vec<u8>, // data
+			Option<H256>, // block_hash
+			Option<U256> // block_number
+		)> {
+			let output = <ethereum::Module<Runtime>>::filtered_logs(
+				from_block,
+				to_block,
+				block_hash,
+				address,
+				topic
+			);
+			if let Some(output) = output {
+				return output;
+			}
+			return vec![];
+		}
 	}
 
 	impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<


### PR DESCRIPTION
Add support and Runtime API implementation for eth_getLogs

Rel #83 

This PR adds support for `etg_getLogs`.

- Iterative process in `pallet-ethereum` to filter stored receipt logs.
- Runtime API implementation.
- Removed `limit` field in `Filter` struct, as not specified in https://eth.wiki/json-rpc/API#eth_getlogs.