### PR TITLE
Frontier-specific block import consensus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3465,6 +3465,7 @@ dependencies = [
  "ethereum-types",
  "frame-support",
  "frame-system",
+ "frontier-consensus-primitives",
  "frontier-rpc-primitives",
  "libsecp256k1",
  "pallet-balances",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,9 +1353,7 @@ dependencies = [
 name = "frontier-consensus-primitives"
 version = "0.1.0"
 dependencies = [
- "ethereum",
  "parity-scale-codec",
- "sp-api",
  "sp-core",
  "sp-runtime",
  "sp-std",
@@ -4694,6 +4692,7 @@ name = "sc-chain-spec"
 version = "2.0.0-rc6"
 dependencies = [
  "impl-trait-for-tuples",
+ "parity-scale-codec",
  "sc-chain-spec-derive",
  "sc-network",
  "sc-telemetry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1332,6 +1332,7 @@ name = "frontier-consensus"
 version = "0.1.0"
 dependencies = [
  "derive_more",
+ "ethereum",
  "frontier-consensus-primitives",
  "futures 0.3.5",
  "log",
@@ -1352,6 +1353,7 @@ dependencies = [
 name = "frontier-consensus-primitives"
 version = "0.1.0"
 dependencies = [
+ "ethereum",
  "parity-scale-codec",
  "sp-api",
  "sp-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,6 +1328,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "frontier-consensus-primitives"
+version = "0.1.0"
+dependencies = [
+ "parity-scale-codec",
+ "sp-api",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "frontier-rpc"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,6 +1328,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "frontier-consensus"
+version = "0.1.0"
+dependencies = [
+ "derive_more",
+ "frontier-consensus-primitives",
+ "futures 0.3.5",
+ "log",
+ "parity-scale-codec",
+ "sc-client-api",
+ "sp-api",
+ "sp-block-builder",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-timestamp",
+ "substrate-prometheus-endpoint",
+]
+
+[[package]]
 name = "frontier-consensus-primitives"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,6 +1365,7 @@ version = "0.1.0"
 dependencies = [
  "ethereum",
  "ethereum-types",
+ "frontier-consensus",
  "frontier-rpc-core",
  "frontier-rpc-primitives",
  "futures 0.3.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,6 +1416,7 @@ dependencies = [
 name = "frontier-template-node"
 version = "2.0.0-dev"
 dependencies = [
+ "frontier-consensus",
  "frontier-rpc",
  "frontier-rpc-primitives",
  "frontier-template-runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
 	"rpc",
 	"rpc/core",
 	"rpc/primitives",
+	"consensus",
 	"consensus/primitives",
 	"template/node",
 	"template/runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
 	"rpc",
 	"rpc/core",
 	"rpc/primitives",
+	"consensus/primitives",
 	"template/node",
 	"template/runtime",
 	"template/test-utils/client",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -23,3 +23,4 @@ futures = { version = "0.3.1", features = ["compat"] }
 sp-timestamp = { version = "2.0.0-rc6", path = "../vendor/substrate/primitives/timestamp" }
 derive_more = "0.99.2"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../vendor/substrate/utils/prometheus", version = "0.8.0-rc6"}
+ethereum = { version = "0.2", features = ["codec"], path = "../vendor/ethereum/" }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "frontier-consensus"
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+description = "Frontier consensus for substrate"
+edition = "2018"
+license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+repository = "https://github.com/paritytech/frontier/"
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "1.3.4", features = ["derive"] }
+sp-core = { version = "2.0.0-rc6", path = "../vendor/substrate/primitives/core" }
+sp-blockchain = { version = "2.0.0-rc6", path = "../vendor/substrate/primitives/blockchain" }
+sp-runtime = { version = "2.0.0-rc6", path = "../vendor/substrate/primitives/runtime" }
+sp-api = { version = "2.0.0-rc6", path = "../vendor/substrate/primitives/api" }
+sc-client-api = { version = "2.0.0-rc6", path = "../vendor/substrate/client/api" }
+sp-block-builder = { version = "2.0.0-rc6", path = "../vendor/substrate/primitives/block-builder" }
+sp-inherents = { version = "2.0.0-rc6", path = "../vendor/substrate/primitives/inherents" }
+frontier-consensus-primitives = { version = "0.1.0", path = "primitives" }
+sp-consensus = { version = "0.8.0-rc6", path = "../vendor/substrate/primitives/consensus/common" }
+log = "0.4.8"
+futures = { version = "0.3.1", features = ["compat"] }
+sp-timestamp = { version = "2.0.0-rc6", path = "../vendor/substrate/primitives/timestamp" }
+derive_more = "0.99.2"
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../vendor/substrate/utils/prometheus", version = "0.8.0-rc6"}

--- a/consensus/primitives/Cargo.toml
+++ b/consensus/primitives/Cargo.toml
@@ -9,20 +9,16 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 
 [dependencies]
-sp-api = { version = "2.0.0-rc6", default-features = false, path = "../../vendor/substrate/primitives/api" }
 sp-std = { version = "2.0.0-rc6", default-features = false, path = "../../vendor/substrate/primitives/std" }
 sp-runtime = { version = "2.0.0-rc6", default-features = false, path = "../../vendor/substrate/primitives/runtime" }
 sp-core = { version = "2.0.0-rc6", default-features = false, path = "../../vendor/substrate/primitives/core" }
 codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false, features = ["derive"] }
-ethereum = { version = "0.2", default-features = false, features = ["codec"], path = "../../vendor/ethereum/" }
 
 [features]
 default = ["std"]
 std = [
 	"sp-std/std",
-	"sp-api/std",
 	"sp-runtime/std",
 	"sp-core/std",
 	"codec/std",
-	"ethereum/std",
 ]

--- a/consensus/primitives/Cargo.toml
+++ b/consensus/primitives/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "frontier-consensus-primitives"
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+description = "Primitives for Frontier consensus"
+edition = "2018"
+license = "Apache-2.0"
+homepage = "https://substrate.dev"
+repository = "https://github.com/paritytech/substrate/"
+
+[dependencies]
+sp-api = { version = "2.0.0-rc6", default-features = false, path = "../../vendor/substrate/primitives/api" }
+sp-std = { version = "2.0.0-rc6", default-features = false, path = "../../vendor/substrate/primitives/std" }
+sp-runtime = { version = "2.0.0-rc6", default-features = false, path = "../../vendor/substrate/primitives/runtime" }
+sp-core = { version = "2.0.0-rc6", default-features = false, path = "../../vendor/substrate/primitives/core" }
+codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false, features = ["derive"] }
+
+[features]
+default = ["std"]
+std = [
+	"sp-std/std",
+	"sp-api/std",
+	"sp-runtime/std",
+	"sp-core/std",
+	"codec/std",
+]

--- a/consensus/primitives/Cargo.toml
+++ b/consensus/primitives/Cargo.toml
@@ -14,6 +14,7 @@ sp-std = { version = "2.0.0-rc6", default-features = false, path = "../../vendor
 sp-runtime = { version = "2.0.0-rc6", default-features = false, path = "../../vendor/substrate/primitives/runtime" }
 sp-core = { version = "2.0.0-rc6", default-features = false, path = "../../vendor/substrate/primitives/core" }
 codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false, features = ["derive"] }
+ethereum = { version = "0.2", default-features = false, features = ["codec"], path = "../../vendor/ethereum/" }
 
 [features]
 default = ["std"]
@@ -23,4 +24,5 @@ std = [
 	"sp-runtime/std",
 	"sp-core/std",
 	"codec/std",
+	"ethereum/std",
 ]

--- a/consensus/primitives/src/lib.rs
+++ b/consensus/primitives/src/lib.rs
@@ -15,6 +15,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use codec::{Encode, Decode};
 use sp_runtime::ConsensusEngineId;
 
 pub const FRONTIER_ENGINE_ID: ConsensusEngineId = [b'f', b'r', b'o', b'n'];
+
+#[derive(Decode, Encode, Clone, PartialEq, Eq)]
+pub enum ConsensusLog {
+	#[codec(index = "1")]
+	Block(ethereum::Block),
+}

--- a/consensus/primitives/src/lib.rs
+++ b/consensus/primitives/src/lib.rs
@@ -16,6 +16,7 @@
 // limitations under the License.
 
 use codec::{Encode, Decode};
+use sp_core::H256;
 use sp_runtime::ConsensusEngineId;
 
 pub const FRONTIER_ENGINE_ID: ConsensusEngineId = [b'f', b'r', b'o', b'n'];
@@ -23,5 +24,10 @@ pub const FRONTIER_ENGINE_ID: ConsensusEngineId = [b'f', b'r', b'o', b'n'];
 #[derive(Decode, Encode, Clone, PartialEq, Eq)]
 pub enum ConsensusLog {
 	#[codec(index = "1")]
-	Block(ethereum::Block),
+	EndBlock {
+		/// Ethereum block hash.
+		block_hash: H256,
+		/// Transaction hashes of the Ethereum block.
+		transaction_hashes: Vec<H256>,
+	},
 }

--- a/consensus/primitives/src/lib.rs
+++ b/consensus/primitives/src/lib.rs
@@ -15,7 +15,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
 use codec::{Encode, Decode};
+use sp_std::vec::Vec;
 use sp_core::H256;
 use sp_runtime::ConsensusEngineId;
 

--- a/consensus/primitives/src/lib.rs
+++ b/consensus/primitives/src/lib.rs
@@ -1,0 +1,20 @@
+// This file is part of Frontier.
+
+// Copyright (C) 2017-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use sp_runtime::ConsensusEngineId;
+
+pub const FRONTIER_ENGINE_ID: ConsensusEngineId = [b'f', b'r', b'o', b'n'];

--- a/consensus/src/aux_schema.rs
+++ b/consensus/src/aux_schema.rs
@@ -1,0 +1,89 @@
+// This file is part of Frontier.
+
+// Copyright (C) 2017-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use codec::{Encode, Decode};
+use sp_core::H256;
+use sp_runtime::traits::Block as BlockT;
+use sc_client_api::backend::AuxStore;
+use sp_blockchain::{Result as ClientResult, Error as ClientError};
+
+fn load_decode<B: AuxStore, T: Decode>(backend: &B, key: &[u8]) -> ClientResult<Option<T>> {
+	let corrupt = |e: codec::Error| {
+		ClientError::Backend(format!("Frontier DB is corrupted. Decode error: {}", e.what()))
+	};
+	match backend.get_aux(key)? {
+		None => Ok(None),
+		Some(t) => T::decode(&mut &t[..]).map(Some).map_err(corrupt)
+	}
+}
+
+/// Map an Ethereum block hash into a Substrate block hash.
+pub fn block_hash_key(ethereum_block_hash: H256) -> Vec<u8> {
+	let mut ret = b"ethereum_block_hash:".to_vec();
+	ret.append(&mut ethereum_block_hash.as_ref().to_vec());
+	ret
+}
+
+/// Given an Ethereum block hash, get the corresponding Substrate block hash from AuxStore.
+pub fn load_block_hash<Block: BlockT, B: AuxStore>(
+	backend: &B,
+	hash: H256,
+) -> ClientResult<Option<Block::Hash>> {
+	let key = block_hash_key(hash);
+	load_decode(backend, &key)
+}
+
+/// Update Aux block hash.
+pub fn write_block_hash<Hash: Encode, B: AuxStore, F, R>(
+	ethereum_hash: H256,
+	block_hash: Hash,
+	write_aux: F,
+) -> R where
+	F: FnOnce(&[(&[u8], &[u8])]) -> R,
+{
+	let key = block_hash_key(ethereum_hash);
+	write_aux(&[(&key, &block_hash.encode()[..])])
+}
+
+/// Map an Ethereum transaction hash into its corresponding Ethereum block hash and index.
+pub fn transaction_metadata_key(ethereum_transaction_hash: H256) -> Vec<u8> {
+	let mut ret = b"ethereum_transaction_hash:".to_vec();
+	ret.append(&mut ethereum_transaction_hash.as_ref().to_vec());
+	ret
+}
+
+/// Given an Ethereum transaction hash, get the corresponding Ethereum block hash and index.
+pub fn load_transaction_metadata<B: AuxStore>(
+	backend: &B,
+	hash: H256,
+) -> ClientResult<Option<(H256, u32)>> {
+	let key = transaction_metadata_key(hash);
+	load_decode(backend, &key)
+}
+
+/// Update Aux transaction metadata.
+pub fn write_transaction_metadata<B: AuxStore, F, R>(
+	hash: H256,
+	metadata: (H256, u32),
+	write_aux: F,
+) -> R where
+	F: FnOnce(&[(&[u8], &[u8])]) -> R,
+{
+	let key = transaction_metadata_key(hash);
+	write_aux(&[(&key, &metadata.encode())])
+}

--- a/consensus/src/aux_schema.rs
+++ b/consensus/src/aux_schema.rs
@@ -49,7 +49,7 @@ pub fn load_block_hash<Block: BlockT, B: AuxStore>(
 }
 
 /// Update Aux block hash.
-pub fn write_block_hash<Hash: Encode, B: AuxStore, F, R>(
+pub fn write_block_hash<Hash: Encode, F, R>(
 	ethereum_hash: H256,
 	block_hash: Hash,
 	write_aux: F,
@@ -77,7 +77,7 @@ pub fn load_transaction_metadata<B: AuxStore>(
 }
 
 /// Update Aux transaction metadata.
-pub fn write_transaction_metadata<B: AuxStore, F, R>(
+pub fn write_transaction_metadata<F, R>(
 	hash: H256,
 	metadata: (H256, u32),
 	write_aux: F,

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -15,3 +15,68 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+use std::collections::HashMap;
+use std::marker::PhantomData;
+use sc_client_api::{BlockOf, backend::AuxStore};
+use sp_blockchain::{HeaderBackend, ProvideCache, well_known_cache_keys::Id as CacheKeyId};
+use sp_block_builder::BlockBuilder as BlockBuilderApi;
+use sp_runtime::traits::Block as BlockT;
+use sp_api::ProvideRuntimeApi;
+use sp_consensus::{
+	BlockImportParams, Error as ConsensusError, BlockImport,
+	BlockCheckParams, ImportResult,
+};
+use sc_client_api;
+
+pub struct FrontierBlockImport<B: BlockT, I, C> {
+	inner: I,
+	client: Arc<C>,
+	_marker: PhantomData<B>,
+}
+
+impl<B, I, C> FrontierBlockImport<B, I, C> where
+	B: BlockT,
+	I: BlockImport<B, Transaction = sp_api::TransactionFor<C, B>> + Send + Sync,
+	I::Error: Into<ConsensusError>,
+	C: ProvideRuntimeApi<B> + Send + Sync + HeaderBackend<B> + AuxStore + ProvideCache<B> + BlockOf,
+	C::Api: BlockBuilderApi<B, Error = sp_blockchain::Error>,
+{
+	pub fn new(
+		inner: I,
+		client: Arc<C>,
+	) -> Self {
+		Self {
+			inner,
+			client,
+			_marker: PhantomData,
+		}
+	}
+}
+
+impl<B, I, C> BlockImport<B> for FrontierBlockImport<B, I, C> where
+	B: BlockT,
+	I: BlockImport<B, Transaction = sp_api::TransactionFor<C, B>> + Send + Sync,
+	I::Error: Into<ConsensusError>,
+	C: ProvideRuntimeApi<B> + Send + Sync + HeaderBackend<B> + AuxStore + ProvideCache<B> + BlockOf,
+	C::Api: BlockBuilderApi<B, Error = sp_blockchain::Error>,
+{
+	type Error = ConsensusError;
+	type Transaction = sp_api::TransactionFor<C, B>;
+
+	fn check_block(
+		&mut self,
+		block: BlockCheckParams<B>,
+	) -> Result<ImportResult, Self::Error> {
+		self.inner.check_block(block).map_err(Into::into)
+	}
+
+	fn import_block(
+		&mut self,
+		block: BlockImportParams<B, Self::Transaction>,
+		new_cache: HashMap<CacheKeyId, Vec<u8>>,
+	) -> Result<ImportResult, Self::Error> {
+		self.inner.import_block(block, new_cache).map_err(Into::into)
+	}
+}

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -1,0 +1,17 @@
+// This file is part of Frontier.
+
+// Copyright (C) 2017-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -18,6 +18,8 @@
 
 mod aux_schema;
 
+pub use crate::aux_schema::{load_block_hash, load_transaction_metadata};
+
 use std::sync::Arc;
 use std::collections::HashMap;
 use std::marker::PhantomData;

--- a/frame/ethereum/Cargo.toml
+++ b/frame/ethereum/Cargo.toml
@@ -23,6 +23,7 @@ ethereum-types = { version = "0.9", default-features = false }
 rlp = { version = "0.4", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 libsecp256k1 = { version = "0.3", default-features = false }
+frontier-consensus-primitives = { path = "../../consensus/primitives", default-features = false }
 frontier-rpc-primitives = { path = "../../rpc/primitives", default-features = false }
 
 [dev-dependencies]
@@ -47,5 +48,6 @@ std = [
 	"rlp/std",
 	"sha3/std",
 	"libsecp256k1/std",
+	"frontier-consensus-primitives/std",
 	"frontier-rpc-primitives/std",
 ]

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -61,25 +61,19 @@ pub trait Trait: frame_system::Trait<Hash=H256> + pallet_balances::Trait + palle
 
 decl_storage! {
 	trait Store for Module<T: Trait> as Example {
+		/// Current building block's transactions and receipts.
+		Pending: Vec<(ethereum::Transaction, TransactionStatus, ethereum::Receipt)>;
+
 		/// The current Ethereum block.
 		CurrentBlock: Option<ethereum::Block>;
 		/// The current Ethereum receipts.
 		CurrentReceipts: Option<Vec<ethereum::Receipt>>;
-		/// Block hash to block body and block receipt map.
-		BlocksAndReceipts: map hasher(blake2_128_concat)
-			H256 => Option<(ethereum::Block, Vec<ethereum::Receipt>)>;
-		/// Block number to block hash map.
-		BlockNumbers: map hasher(blake2_128_concat) T::BlockNumber => H256;
-		/// Current building block's transactions and receipts.
-		PendingTransactionsAndReceipts: Vec<(ethereum::Transaction, ethereum::Receipt)>;
-		/// Transaction hash to transaction status map.
-		TransactionStatuses: map hasher(blake2_128_concat) H256 => Option<TransactionStatus>;
-		/// Transaction hash to transaction map.
-		Transactions: map hasher(blake2_128_concat) H256 => Option<(H256, u32)>;
+		/// The current transaction statuses.
+		CurrentTransactionStatuses: Option<Vec<TransactionStatus>>;
 	}
 	add_extra_genesis {
 		build(|_config: &GenesisConfig| {
-			<Module<T>>::store_block(T::BlockNumber::from(0));
+			<Module<T>>::store_block();
 		});
 	}
 }
@@ -128,7 +122,7 @@ decl_module! {
 		}
 
 		fn on_finalize(n: T::BlockNumber) {
-			<Module<T>>::store_block(n);
+			<Module<T>>::store_block();
 		}
 	}
 }
@@ -144,12 +138,19 @@ impl<T: Trait> frame_support::unsigned::ValidateUnsigned for Module<T> {
 }
 
 impl<T: Trait> Module<T> {
-	fn store_block(n: T::BlockNumber) {
-		let transactions_and_receipts = PendingTransactionsAndReceipts::take();
-		let (transactions, receipts): (Vec<_>, Vec<_>) =
-			transactions_and_receipts.into_iter().unzip();
-		let ommers = Vec::<ethereum::Header>::new();
+	fn store_block() {
+		let pending = Pending::take();
 
+		let mut transactions = Vec::new();
+		let mut statuses = Vec::new();
+		let mut receipts = Vec::new();
+		for (transaction, status, receipt) in pending {
+			transactions.push(transaction);
+			statuses.push(status);
+			receipts.push(receipt);
+		}
+
+		let ommers = Vec::<ethereum::Header>::new();
 		let header = ethereum::Header {
 			parent_hash: frame_system::Module::<T>::parent_hash(),
 			ommers_hash: H256::from_slice(
@@ -193,20 +194,12 @@ impl<T: Trait> Module<T> {
 			let transaction_hash = H256::from_slice(
 				Keccak256::digest(&rlp::encode(t)).as_slice()
 			);
-			if let Some(status) = TransactionStatuses::get(transaction_hash) {
-				transaction_hashes.push(transaction_hash);
-				Transactions::insert(
-					transaction_hash,
-					(hash, status.transaction_index)
-				);
-			}
+			transaction_hashes.push(transaction_hash);
 		}
 
 		CurrentBlock::put(block.clone());
 		CurrentReceipts::put(receipts.clone());
-
-		BlocksAndReceipts::insert(hash, (block.clone(), receipts));
-		BlockNumbers::<T>::insert(n, hash);
+		CurrentTransactionStatuses::put(statuses.clone());
 
 		let digest = DigestItem::<T::Hash>::Consensus(
 			FRONTIER_ENGINE_ID,
@@ -226,200 +219,19 @@ impl<T: Trait> Module<T> {
 		T::FindAuthor::find_author(pre_runtime_digests).unwrap_or_default()
 	}
 
-	/// Get the transaction status with given transaction hash.
-	pub fn transaction_status(hash: H256) -> Option<TransactionStatus> {
-		TransactionStatuses::get(hash)
-	}
-
-	/// Get the transaction with given transaction hash.
-	pub fn transaction_by_hash(hash: H256) -> Option<(
-		ethereum::Transaction,
-		ethereum::Block,
-		TransactionStatus,
-		Vec<ethereum::Receipt>
-	)> {
-		let (block_hash, transaction_index) = Transactions::get(hash)?;
-		let transaction_status = TransactionStatuses::get(hash)?;
-		let (block, receipts) = BlocksAndReceipts::get(block_hash)?;
-		let transaction = &block.transactions[transaction_index as usize];
-		Some((transaction.clone(), block, transaction_status, receipts))
-	}
-
-	/// Get transaction by block hash and index.
-	pub fn transaction_by_block_hash_and_index(
-		hash: H256,
-		index: u32
-	) -> Option<(
-		ethereum::Transaction,
-		ethereum::Block,
-		TransactionStatus
-	)> {
-		let (block,_receipt) = BlocksAndReceipts::get(hash)?;
-		if index < block.transactions.len() as u32 {
-			let transaction = &block.transactions[index as usize];
-			let transaction_hash = H256::from_slice(
-				Keccak256::digest(&rlp::encode(transaction)).as_slice()
-			);
-			let transaction_status = TransactionStatuses::get(transaction_hash)?;
-			Some((transaction.clone(), block, transaction_status))
-		} else {
-			None
-		}
-	}
-
-	/// Get transaction by block number and index.
-	pub fn transaction_by_block_number_and_index(
-		number: T::BlockNumber,
-		index: u32
-	) -> Option<(
-		ethereum::Transaction,
-		ethereum::Block,
-		TransactionStatus
-	)> {
-		if <BlockNumbers<T>>::contains_key(number) {
-			let hash = <BlockNumbers<T>>::get(number);
-			return <Module<T>>::transaction_by_block_hash_and_index(hash, index);
-		}
-		None
+	/// Get the transaction status with given index.
+	pub fn current_transaction_status(index: u32) -> Option<TransactionStatus> {
+		CurrentTransactionStatuses::get().unwrap_or_default().get(index as usize).cloned()
 	}
 
 	/// Get block by number.
-	pub fn block_by_number(number: T::BlockNumber) -> Option<ethereum::Block> {
-		if <BlockNumbers<T>>::contains_key(number) {
-			let hash = <BlockNumbers<T>>::get(number);
-			if let Some((block, _receipt)) = BlocksAndReceipts::get(hash) {
-				return Some(block)
-			}
-		}
-		None
+	pub fn current_block() -> Option<ethereum::Block> {
+		CurrentBlock::get()
 	}
 
-	/// Get block by hash.
-	pub fn block_by_hash(hash: H256) -> Option<ethereum::Block> {
-		if let Some((block, _receipt)) = BlocksAndReceipts::get(hash) {
-			return Some(block)
-		}
-		None
-	}
-
-	/// Get block transaction status of the given block.
-	pub fn block_transaction_statuses(
-		block: &Block
-	) -> Vec<Option<TransactionStatus>> {
-		block.transactions.iter().map(|transaction|{
-			let transaction_hash = H256::from_slice(
-				Keccak256::digest(&rlp::encode(transaction)).as_slice()
-			);
-			<Module<T>>::transaction_status(transaction_hash)
-		}).collect()
-	}
-
-	fn block_logs(
-		block_hash: H256,
-		address: Option<H160>,
-		topic: Option<Vec<H256>>
-	) -> Option<Vec<(
-		H160, // address
-		Vec<H256>, // topics
-		Vec<u8>, // data
-		Option<H256>, // block_hash
-		Option<U256>, // block_number
-		Option<H256>, // transaction_hash
-		Option<U256>, // transaction_index
-		Option<U256>, // log index in block
-		Option<U256>, // log index in transaction
-	)>> {
-		let mut output = vec![];
-		let (block, receipts) = BlocksAndReceipts::get(block_hash)?;
-		let mut block_log_index: u32 = 0;
-		for (index, receipt) in receipts.iter().enumerate() {
-			let logs = receipt.logs.clone();
-			let mut transaction_log_index: u32 = 0;
-			let transaction = &block.transactions[index as usize];
-			let transaction_hash = H256::from_slice(
-				Keccak256::digest(&rlp::encode(transaction)).as_slice()
-			);
-			for log in logs {
-				let mut add: bool = false;
-				if let (Some(address), Some(topics)) = (address.clone(), topic.clone()) {
-					if address == log.address && log.topics.starts_with(&topics) {
-						add = true;
-					}
-				} else if let Some(address) = address {
-					if address == log.address {
-						add = true;
-					}
-				} else if let Some(topics) = &topic {
-					if log.topics.starts_with(&topics) {
-						add = true;
-					}
-				}
-				if add {
-					output.push((
-						log.address.clone(),
-						log.topics.clone(),
-						log.data.clone(),
-						Some(H256::from_slice(
-							Keccak256::digest(&rlp::encode(&block.header)).as_slice()
-						)),
-						Some(block.header.number.clone()),
-						Some(transaction_hash),
-						Some(U256::from(index)),
-						Some(U256::from(block_log_index)),
-						Some(U256::from(transaction_log_index))
-					));
-				}
-				transaction_log_index += 1;
-				block_log_index += 1;
-			}
-		}
-		Some(output)
-	}
-
-	pub fn filtered_logs(
-		from_block: Option<u32>,
-		to_block: Option<u32>,
-		block_hash: Option<H256>,
-		address: Option<H160>,
-		topic: Option<Vec<H256>>,
-	) -> Option<Vec<(
-		H160, // address
-		Vec<H256>, // topics
-		Vec<u8>, // data
-		Option<H256>, // block_hash
-		Option<U256>, // block_number
-		Option<H256>, // transaction_hash
-		Option<U256>, // transaction_index
-		Option<U256>, // log index in block
-		Option<U256>, // log index in transaction
-	)>> {
-		if let Some(block_hash) = block_hash {
-			<Module<T>>::block_logs(
-				block_hash,
-				address,
-				topic
-			)
-		} else if let (Some(from_block), Some(to_block)) = (from_block, to_block) {
-			let mut output = vec![];
-			if from_block >= to_block {
-				for number in from_block..to_block {
-					let block_number = T::BlockNumber::from(number);
-					if <BlockNumbers<T>>::contains_key(block_number) {
-						let hash = <BlockNumbers<T>>::get(block_number);
-						output.extend(<Module<T>>::block_logs(
-							hash,
-							address.clone(),
-							topic.clone()
-						).unwrap())
-					}
-				}
-				Some(output)
-			} else {
-				None
-			}
-		} else {
-			None
-		}
+	/// Get receipts by number.
+	pub fn current_receipt(index: u32) -> Option<ethereum::Receipt> {
+		CurrentReceipts::get().unwrap_or_default().get(index as usize).cloned()
 	}
 
 	/// Execute an Ethereum transaction, ignoring transaction signatures.
@@ -427,7 +239,7 @@ impl<T: Trait> Module<T> {
 		let transaction_hash = H256::from_slice(
 			Keccak256::digest(&rlp::encode(&transaction)).as_slice()
 		);
-		let transaction_index = PendingTransactionsAndReceipts::get().len() as u32;
+		let transaction_index = Pending::get().len() as u32;
 
 		let status = match transaction.action {
 			ethereum::TransactionAction::Call(target) => {
@@ -475,8 +287,6 @@ impl<T: Trait> Module<T> {
 			},
 		};
 
-		TransactionStatuses::insert(transaction_hash, status);
-
 		let receipt = ethereum::Receipt {
 			state_root: H256::default(), // TODO: should be okay / error status.
 			used_gas: U256::default(), // TODO: set this.
@@ -484,6 +294,6 @@ impl<T: Trait> Module<T> {
 			logs: Vec::new(), // TODO: set this.
 		};
 
-		PendingTransactionsAndReceipts::append((transaction, receipt));
+		Pending::append((transaction, status, receipt));
 	}
 }

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -61,6 +61,10 @@ pub trait Trait: frame_system::Trait<Hash=H256> + pallet_balances::Trait + palle
 
 decl_storage! {
 	trait Store for Module<T: Trait> as Example {
+		/// The current Ethereum block.
+		CurrentBlock: Option<ethereum::Block>;
+		/// The current Ethereum receipts.
+		CurrentReceipts: Option<Vec<ethereum::Receipt>>;
 		/// Block hash to block body and block receipt map.
 		BlocksAndReceipts: map hasher(blake2_128_concat)
 			H256 => Option<(ethereum::Block, Vec<ethereum::Receipt>)>;
@@ -197,6 +201,9 @@ impl<T: Trait> Module<T> {
 				);
 			}
 		}
+
+		CurrentBlock::put(block.clone());
+		CurrentReceipts::put(receipts.clone());
 
 		BlocksAndReceipts::insert(hash, (block.clone(), receipts));
 		BlockNumbers::<T>::insert(n, hash);

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -220,8 +220,8 @@ impl<T: Trait> Module<T> {
 	}
 
 	/// Get the transaction status with given index.
-	pub fn current_transaction_status(index: u32) -> Option<TransactionStatus> {
-		CurrentTransactionStatuses::get().unwrap_or_default().get(index as usize).cloned()
+	pub fn current_transaction_statuses() -> Option<Vec<TransactionStatus>> {
+		CurrentTransactionStatuses::get()
 	}
 
 	/// Get block by number.
@@ -230,8 +230,8 @@ impl<T: Trait> Module<T> {
 	}
 
 	/// Get receipts by number.
-	pub fn current_receipt(index: u32) -> Option<ethereum::Receipt> {
-		CurrentReceipts::get().unwrap_or_default().get(index as usize).cloned()
+	pub fn current_receipts() -> Option<Vec<ethereum::Receipt>> {
+		CurrentReceipts::get()
 	}
 
 	/// Execute an Ethereum transaction, ignoring transaction signatures.

--- a/frame/ethereum/src/tests.rs
+++ b/frame/ethereum/src/tests.rs
@@ -69,8 +69,8 @@ fn transaction_should_be_added_to_pending() {
 			alice.address,
 			transaction.clone(),
 		);
-		assert_eq!(PendingTransactionsAndReceipts::get().len(), 1);
-		assert_eq!(PendingTransactionsAndReceipts::get()[0].0.input, transaction.input);
+		assert_eq!(Pending::get().len(), 1);
+		assert_eq!(Pending::get()[0].0.input, transaction.input);
 	});
 }
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -11,6 +11,7 @@ jsonrpc-core = "14.0.3"
 jsonrpc-derive = "14.0.3"
 jsonrpc-core-client = "14.0.3"
 ethereum-types = "0.9.0"
+frontier-consensus = { path = "../consensus" }
 frontier-rpc-core = { path = "core" }
 frontier-rpc-primitives = { path = "primitives" }
 sp-runtime = { path = "../vendor/substrate/primitives/runtime" }

--- a/rpc/primitives/src/lib.rs
+++ b/rpc/primitives/src/lib.rs
@@ -78,9 +78,9 @@ sp_api::decl_runtime_apis! {
 		/// Return the current block.
 		fn current_block() -> Option<EthereumBlock>;
 		/// Return the current receipt.
-		fn current_receipt(index: u32) -> Option<ethereum::Receipt>;
+		fn current_receipts() -> Option<Vec<ethereum::Receipt>>;
 		/// Return the current transaction status.
-		fn current_transaction_status(index: u32) -> Option<TransactionStatus>;
+		fn current_transaction_statuses() -> Option<Vec<TransactionStatus>>;
 	}
 }
 

--- a/rpc/primitives/src/lib.rs
+++ b/rpc/primitives/src/lib.rs
@@ -52,7 +52,7 @@ impl Default for TransactionStatus {
 
 sp_api::decl_runtime_apis! {
 	/// API necessary for Ethereum-compatibility layer.
-	pub trait EthereumRuntimeApi {
+	pub trait EthereumRuntimeRPCApi {
 		/// Returns runtime defined pallet_evm::ChainId.
 		fn chain_id() -> u64;
 		/// Returns pallet_evm::Accounts by address.
@@ -75,71 +75,12 @@ sp_api::decl_runtime_apis! {
 			nonce: Option<U256>,
 			action: TransactionAction
 		) -> Option<(Vec<u8>, U256)>;
-		/// For a given block number, returns an ethereum::Block and all its TransactionStatus.
-		fn block_by_number(number: u32) -> (Option<EthereumBlock>, Vec<Option<TransactionStatus>>);
-		/// For a given block number, returns the number of transactions.
-		fn block_transaction_count_by_number(number: u32) -> Option<U256>;
-		/// For a given block hash, returns an ethereum::Block.
-		fn block_by_hash(hash: H256) -> Option<EthereumBlock>;
-		/// For a given block hash, returns an ethereum::Block and all its TransactionStatus.
-		fn block_by_hash_with_statuses(hash: H256) -> (Option<EthereumBlock>, Vec<Option<TransactionStatus>>);
-		/// For a given block hash, returns the number of transactions in a given block hash.
-		fn block_transaction_count_by_hash(hash: H256) -> Option<U256>;
-		/// For a given transaction hash, returns data necessary to build an Transaction rpc type response.
-		/// - EthereumTransaction: transaction as stored in pallet-ethereum.
-		/// - EthereumBlock: block as stored in pallet-ethereum .
-		/// - TransactionStatus: transaction execution metadata.
-		/// - EthereumReceipt: transaction receipt.
-		fn transaction_by_hash(hash: H256) -> Option<(
-			EthereumTransaction,
-			EthereumBlock,
-			TransactionStatus,
-			Vec<EthereumReceipt>
-		)>;
-		/// For a given block hash and transaction index, returns data necessary to build an Transaction rpc
-		/// type response.
-		/// - EthereumTransaction: transaction as stored in pallet-ethereum.
-		/// - EthereumBlock: block as stored in pallet-ethereum .
-		/// - TransactionStatus: transaction execution metadata.
-		fn transaction_by_block_hash_and_index(
-			hash: H256,
-			index: u32
-		) -> Option<(
-			EthereumTransaction,
-			EthereumBlock,
-			TransactionStatus
-		)>;
-		/// For a given block number and transaction index, returns data necessary to build an Transaction rpc
-		/// type response.
-		/// - EthereumTransaction: transaction as stored in pallet-ethereum.
-		/// - EthereumBlock: block as stored in pallet-ethereum .
-		/// - TransactionStatus: transaction execution metadata.
-		fn transaction_by_block_number_and_index(
-			number: u32,
-			index: u32
-		) -> Option<(
-			EthereumTransaction,
-			EthereumBlock,
-			TransactionStatus
-		)>;
-		/// For given filter arguments, return data necessary to build Logs
-		fn logs(
-			from_block: Option<u32>,
-			to_block: Option<u32>,
-			block_hash: Option<H256>,
-			address: Option<H160>,
-			topic: Option<Vec<H256>>
-		) -> Vec<(
-			H160, // address
-			Vec<H256>, // topics
-			Vec<u8>, // data
-			Option<H256>, // block_hash
-			Option<U256>, // block_number
-			Option<H256>, // transaction_hash
-			Option<U256>, // transaction_index
-			Option<U256>, // log index in block
-			Option<U256>, // log index in transaction
-		)>;
+		/// Return the current block.
+		fn current_block() -> Option<EthereumBlock>;
+		/// Return the current receipt.
+		fn current_receipt(index: u32) -> Option<ethereum::Receipt>;
+		/// Return the current transaction status.
+		fn current_transaction_status(index: u32) -> Option<TransactionStatus>;
 	}
 }
 

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -416,20 +416,19 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 	}
 
 	fn block_transaction_count_by_number(&self, number: BlockNumber) -> Result<Option<U256>> {
-		unimplemented!()
+		let id = match self.native_block_id(Some(number))? {
+			Some(id) => id,
+			None => return Ok(None),
+		};
 
-		// let header = self.select_chain.best_chain()
-		// 	.map_err(|_| internal_err("fetch header failed"))?;
+		let block = self.client.runtime_api()
+			.current_block(&id)
+			.map_err(|_| internal_err("fetch runtime account basic failed"))?;
 
-		// let mut result = None;
-		// if let Ok(Some(native_number)) = self.native_block_id(Some(number)) {
-		// 	result = match self.client.runtime_api()
-		// 		.block_transaction_count_by_number(&BlockId::Hash(header.hash()), native_number) {
-		// 		Ok(result) => result,
-		// 		Err(_) => None
-		// 	};
-		// }
-		// Ok(result)
+		match block {
+			Some(block) => Ok(Some(U256::from(block.transactions.len()))),
+			None => Ok(None),
+		}
 	}
 
 	fn block_uncles_count_by_hash(&self, _: H256) -> Result<U256> {

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -20,12 +20,12 @@ use ethereum::{Block as EthereumBlock, Transaction as EthereumTransaction};
 use ethereum_types::{H160, H256, H64, U256, U64};
 use jsonrpc_core::{BoxFuture, Result, ErrorCode, Error, futures::future::{self, Future}};
 use futures::future::TryFutureExt;
-use sp_runtime::traits::{Block as BlockT, Header as _, UniqueSaturatedInto};
+use sp_runtime::traits::{Block as BlockT, Header as _, UniqueSaturatedInto, Zero};
 use sp_runtime::transaction_validity::TransactionSource;
 use sp_api::{ProvideRuntimeApi, BlockId};
 use sp_consensus::SelectChain;
 use sp_transaction_pool::TransactionPool;
-use sc_client_api::backend::{StorageProvider, Backend, StateBackend};
+use sc_client_api::backend::{StorageProvider, Backend, StateBackend, AuxStore};
 use sha3::{Keccak256, Digest};
 use sp_runtime::traits::BlakeTwo256;
 use frontier_rpc_core::EthApi as EthApiT;
@@ -33,7 +33,7 @@ use frontier_rpc_core::types::{
 	BlockNumber, Bytes, CallRequest, EthAccount, Filter, Index, Log, Receipt, RichBlock,
 	SyncStatus, SyncInfo, Transaction, Work, Rich, Block, BlockTransactions, VariadicValue
 };
-use frontier_rpc_primitives::{EthereumRuntimeApi, ConvertTransaction, TransactionStatus};
+use frontier_rpc_primitives::{EthereumRuntimeRPCApi, ConvertTransaction, TransactionStatus};
 
 pub use frontier_rpc_core::EthApiServer;
 
@@ -58,7 +58,7 @@ pub struct EthApi<B: BlockT, C, SC, P, CT, BE> {
 	select_chain: SC,
 	convert_transaction: CT,
 	is_authority: bool,
-	_marker: PhantomData<(B,BE)>,
+	_marker: PhantomData<(B, BE)>,
 }
 
 impl<B: BlockT, C, SC, P, CT, BE> EthApi<B, C, SC, P, CT, BE> {
@@ -171,8 +171,8 @@ fn transaction_build(
 }
 
 impl<B, C, SC, P, CT, BE> EthApi<B, C, SC, P, CT, BE> where
-	C: ProvideRuntimeApi<B> + StorageProvider<B,BE>,
-	C::Api: EthereumRuntimeApi<B>,
+	C: ProvideRuntimeApi<B> + StorageProvider<B, BE> + AuxStore,
+	C::Api: EthereumRuntimeRPCApi<B>,
 	BE: Backend<B> + 'static,
 	BE::State: StateBackend<BlakeTwo256>,
 	B: BlockT<Hash=H256> + Send + Sync + 'static,
@@ -181,53 +181,37 @@ impl<B, C, SC, P, CT, BE> EthApi<B, C, SC, P, CT, BE> where
 	P: TransactionPool<Block=B> + Send + Sync + 'static,
 	CT: ConvertTransaction<<B as BlockT>::Extrinsic> + Send + Sync + 'static,
 {
-	fn native_block_number(&self, number: Option<BlockNumber>) -> Result<Option<u32>> {
-		let header = self
-			.select_chain
-			.best_chain()
-			.map_err(|_| internal_err("fetch header failed"))?;
+	fn native_block_id(&self, number: Option<BlockNumber>) -> Result<Option<BlockId<B>>> {
+		Ok(match number.unwrap_or(BlockNumber::Latest) {
+			BlockNumber::Hash { hash, .. } => {
+				let hash = frontier_consensus::load_block_hash::<B, _>(self.client.as_ref(), hash)
+					.map_err(|_| internal_err("fetch aux store failed"))?;
 
-		let mut native_number: Option<u32> = None;
-
-		if let Some(number) = number {
-			match number {
-				BlockNumber::Hash { hash, .. } => {
-					if let Ok(Some(block)) = self.client.runtime_api().block_by_hash(
-						&BlockId::Hash(header.hash()),
-						hash
-					) {
-						native_number = Some(block.header.number.as_u32());
-					}
-				},
-				BlockNumber::Num(_) => {
-					if let Some(number) = number.to_min_block_num() {
-						native_number = Some(number.unique_saturated_into());
-					}
-				},
-				BlockNumber::Latest => {
-					native_number = Some(
-						header.number().clone().unique_saturated_into() as u32
-					);
-				},
-				BlockNumber::Earliest => {
-					native_number = Some(0);
-				},
-				BlockNumber::Pending => {
-					native_number = None;
-				}
-			};
-		} else {
-			native_number = Some(
-				header.number().clone().unique_saturated_into() as u32
-			);
-		}
-		Ok(native_number)
+				hash.map(|h| BlockId::Hash(h))
+			},
+			BlockNumber::Num(number) => {
+				Some(BlockId::Number(number.unique_saturated_into()))
+			},
+			BlockNumber::Latest => {
+				Some(BlockId::Hash(
+					self.select_chain.best_chain()
+						.map_err(|_| internal_err("fetch header failed"))?
+						.hash()
+				))
+			},
+			BlockNumber::Earliest => {
+				Some(BlockId::Number(Zero::zero()))
+			},
+			BlockNumber::Pending => {
+				None
+			}
+		})
 	}
 }
 
 impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
-	C: ProvideRuntimeApi<B> + StorageProvider<B,BE>,
-	C::Api: EthereumRuntimeApi<B>,
+	C: ProvideRuntimeApi<B> + StorageProvider<B, BE> + AuxStore,
+	C::Api: EthereumRuntimeRPCApi<B>,
 	BE: Backend<B> + 'static,
 	BE::State: StateBackend<BlakeTwo256>,
 	B: BlockT<Hash=H256> + Send + Sync + 'static,
@@ -312,11 +296,11 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 	}
 
 	fn balance(&self, address: H160, number: Option<BlockNumber>) -> Result<U256> {
-		if let Ok(Some(native_number)) = self.native_block_number(number) {
+		if let Ok(Some(id)) = self.native_block_id(number) {
 			return Ok(
 				self.client
 					.runtime_api()
-					.account_basic(&BlockId::Number(native_number.into()), address)
+					.account_basic(&id, address)
 					.map_err(|_| internal_err("fetch runtime chain id failed"))?
 					.balance.into(),
 			);
@@ -329,11 +313,11 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 	}
 
 	fn storage_at(&self, address: H160, index: U256, number: Option<BlockNumber>) -> Result<H256> {
-		if let Ok(Some(native_number)) = self.native_block_number(number) {
+		if let Ok(Some(id)) = self.native_block_id(number) {
 			return Ok(
 				self.client
 					.runtime_api()
-					.storage_at(&BlockId::Number(native_number.into()), address, index)
+					.storage_at(&id, address, index)
 					.map_err(|_| internal_err("fetch runtime chain id failed"))?
 					.into(),
 			);
@@ -342,71 +326,81 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 	}
 
 	fn block_by_hash(&self, hash: H256, full: bool) -> Result<Option<RichBlock>> {
-		let header = self.select_chain.best_chain()
-			.map_err(|_| internal_err("fetch header failed"))?;
+		unimplemented!()
 
-		if let Ok((Some(block), statuses)) = self.client.runtime_api().block_by_hash_with_statuses(
-			&BlockId::Hash(header.hash()),
-			hash
-		) {
-			Ok(Some(rich_block_build(block, statuses, Some(hash), full)))
-		} else {
-			Ok(None)
-		}
+		// let header = self.select_chain.best_chain()
+		// 	.map_err(|_| internal_err("fetch header failed"))?;
+
+		// if let Ok((Some(block), statuses)) = self.client.runtime_api().block_by_hash_with_statuses(
+		// 	&BlockId::Hash(header.hash()),
+		// 	hash
+		// ) {
+		// 	Ok(Some(rich_block_build(block, statuses, Some(hash), full)))
+		// } else {
+		// 	Ok(None)
+		// }
 	}
 
 	fn block_by_number(&self, number: BlockNumber, full: bool) -> Result<Option<RichBlock>> {
-		let header = self.select_chain.best_chain()
-			.map_err(|_| internal_err("fetch header failed"))?;
-		if let Ok(Some(native_number)) = self.native_block_number(Some(number)) {
-			if let Ok((Some(block), statuses)) = self.client.runtime_api().block_by_number(
-				&BlockId::Hash(header.hash()),
-				native_number
-			) {
-				return Ok(Some(rich_block_build(block, statuses, None, full)));
-			}
-		}
-		Ok(None)
+		unimplemented!()
+
+		// let header = self.select_chain.best_chain()
+		// 	.map_err(|_| internal_err("fetch header failed"))?;
+		// if let Ok(Some(native_number)) = self.native_block_id(Some(number)) {
+		// 	if let Ok((Some(block), statuses)) = self.client.runtime_api().block_by_number(
+		// 		&BlockId::Hash(header.hash()),
+		// 		native_number
+		// 	) {
+		// 		return Ok(Some(rich_block_build(block, statuses, None, full)));
+		// 	}
+		// }
+		// Ok(None)
 	}
 
 	fn transaction_count(&self, address: H160, number: Option<BlockNumber>) -> Result<U256> {
-		if let Ok(Some(native_number)) = self.native_block_number(number) {
-			return Ok(
-				self.client
-					.runtime_api()
-					.account_basic(&BlockId::Number(native_number.into()), address)
-					.map_err(|_| internal_err("fetch runtime account basic failed"))?
-					.nonce.into()
-			);
-		}
-		Ok(U256::zero())
+		unimplemented!()
+
+		// if let Ok(Some(native_number)) = self.native_block_id(number) {
+		// 	return Ok(
+		// 		self.client
+		// 			.runtime_api()
+		// 			.account_basic(&BlockId::Number(native_number.into()), address)
+		// 			.map_err(|_| internal_err("fetch runtime account basic failed"))?
+		// 			.nonce.into()
+		// 	);
+		// }
+		// Ok(U256::zero())
 	}
 
 	fn block_transaction_count_by_hash(&self, hash: H256) -> Result<Option<U256>> {
-		let header = self.select_chain.best_chain()
-			.map_err(|_| internal_err("fetch header failed"))?;
+		unimplemented!()
 
-		let result = match self.client.runtime_api()
-			.block_transaction_count_by_hash(&BlockId::Hash(header.hash()), hash) {
-			Ok(result) => result,
-			Err(_) => return Ok(None)
-		};
-		Ok(result)
+		// let header = self.select_chain.best_chain()
+		// 	.map_err(|_| internal_err("fetch header failed"))?;
+
+		// let result = match self.client.runtime_api()
+		// 	.block_transaction_count_by_hash(&BlockId::Hash(header.hash()), hash) {
+		// 	Ok(result) => result,
+		// 	Err(_) => return Ok(None)
+		// };
+		// Ok(result)
 	}
 
 	fn block_transaction_count_by_number(&self, number: BlockNumber) -> Result<Option<U256>> {
-		let header = self.select_chain.best_chain()
-			.map_err(|_| internal_err("fetch header failed"))?;
+		unimplemented!()
 
-		let mut result = None;
-		if let Ok(Some(native_number)) = self.native_block_number(Some(number)) {
-			result = match self.client.runtime_api()
-				.block_transaction_count_by_number(&BlockId::Hash(header.hash()), native_number) {
-				Ok(result) => result,
-				Err(_) => None
-			};
-		}
-		Ok(result)
+		// let header = self.select_chain.best_chain()
+		// 	.map_err(|_| internal_err("fetch header failed"))?;
+
+		// let mut result = None;
+		// if let Ok(Some(native_number)) = self.native_block_id(Some(number)) {
+		// 	result = match self.client.runtime_api()
+		// 		.block_transaction_count_by_number(&BlockId::Hash(header.hash()), native_number) {
+		// 		Ok(result) => result,
+		// 		Err(_) => None
+		// 	};
+		// }
+		// Ok(result)
 	}
 
 	fn block_uncles_count_by_hash(&self, _: H256) -> Result<U256> {
@@ -418,11 +412,11 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 	}
 
 	fn code_at(&self, address: H160, number: Option<BlockNumber>) -> Result<Bytes> {
-		if let Ok(Some(native_number)) = self.native_block_number(number) {
+		if let Ok(Some(id)) = self.native_block_id(number) {
 			return Ok(
 				self.client
 					.runtime_api()
-					.account_code_at(&BlockId::Number(native_number.into()), address)
+					.account_code_at(&id, address)
 					.map_err(|_| internal_err("fetch runtime chain id failed"))?
 					.into(),
 			);
@@ -529,20 +523,22 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 	}
 
 	fn transaction_by_hash(&self, hash: H256) -> Result<Option<Transaction>> {
-		let header = self
-			.select_chain
-			.best_chain()
-			.map_err(|_| internal_err("fetch header failed"))?;
+		unimplemented!()
 
-		if let Ok(Some((transaction, block, status, _receipt))) = self.client.runtime_api()
-			.transaction_by_hash(&BlockId::Hash(header.hash()), hash) {
-			return Ok(Some(transaction_build(
-				transaction,
-				block,
-				status
-			)));
-		}
-		Ok(None)
+		// let header = self
+		// 	.select_chain
+		// 	.best_chain()
+		// 	.map_err(|_| internal_err("fetch header failed"))?;
+
+		// if let Ok(Some((transaction, block, status, _receipt))) = self.client.runtime_api()
+		// 	.transaction_by_hash(&BlockId::Hash(header.hash()), hash) {
+		// 	return Ok(Some(transaction_build(
+		// 		transaction,
+		// 		block,
+		// 		status
+		// 	)));
+		// }
+		// Ok(None)
 	}
 
 	fn transaction_by_block_hash_and_index(
@@ -550,22 +546,24 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 		hash: H256,
 		index: Index,
 	) -> Result<Option<Transaction>> {
-		let header = self
-			.select_chain
-			.best_chain()
-			.map_err(|_| internal_err("fetch header failed"))?;
+		unimplemented!()
 
-		let index_param = index.value() as u32;
+		// let header = self
+		// 	.select_chain
+		// 	.best_chain()
+		// 	.map_err(|_| internal_err("fetch header failed"))?;
 
-		if let Ok(Some((transaction, block, status))) = self.client.runtime_api()
-			.transaction_by_block_hash_and_index(&BlockId::Hash(header.hash()), hash, index_param) {
-			return Ok(Some(transaction_build(
-				transaction,
-				block,
-				status
-			)));
-		}
-		Ok(None)
+		// let index_param = index.value() as u32;
+
+		// if let Ok(Some((transaction, block, status))) = self.client.runtime_api()
+		// 	.transaction_by_block_hash_and_index(&BlockId::Hash(header.hash()), hash, index_param) {
+		// 	return Ok(Some(transaction_build(
+		// 		transaction,
+		// 		block,
+		// 		status
+		// 	)));
+		// }
+		// Ok(None)
 	}
 
 	fn transaction_by_block_number_and_index(
@@ -573,88 +571,92 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 		number: BlockNumber,
 		index: Index,
 	) -> Result<Option<Transaction>> {
-		let header = self
-			.select_chain
-			.best_chain()
-			.map_err(|_| internal_err("fetch header failed"))?;
+		unimplemented!()
 
-		let index_param = index.value() as u32;
+		// let header = self
+		// 	.select_chain
+		// 	.best_chain()
+		// 	.map_err(|_| internal_err("fetch header failed"))?;
 
-		if let Ok(Some(native_number)) = self.native_block_number(Some(number)) {
-			if let Ok(Some((transaction, block, status))) = self.client.runtime_api()
-				.transaction_by_block_number_and_index(
-					&BlockId::Hash(header.hash()),
-					native_number,
-					index_param) {
-				return Ok(Some(transaction_build(
-					transaction,
-					block,
-					status
-				)));
-			}
-		}
-		Ok(None)
+		// let index_param = index.value() as u32;
+
+		// if let Ok(Some(native_number)) = self.native_block_id(Some(number)) {
+		// 	if let Ok(Some((transaction, block, status))) = self.client.runtime_api()
+		// 		.transaction_by_block_number_and_index(
+		// 			&BlockId::Hash(header.hash()),
+		// 			native_number,
+		// 			index_param) {
+		// 		return Ok(Some(transaction_build(
+		// 			transaction,
+		// 			block,
+		// 			status
+		// 		)));
+		// 	}
+		// }
+		// Ok(None)
 	}
 
 	fn transaction_receipt(&self, hash: H256) -> Result<Option<Receipt>> {
-		let header = self.select_chain.best_chain()
-			.map_err(|_| internal_err("fetch header failed"))?;
-		if let Ok(Some((_transaction, block, status, receipts))) = self.client.runtime_api()
-			.transaction_by_hash(&BlockId::Hash(header.hash()), hash) {
+		unimplemented!()
 
-			let block_hash = H256::from_slice(
-				Keccak256::digest(&rlp::encode(&block.header)).as_slice()
-			);
-			let receipt = receipts[status.transaction_index as usize].clone();
-			let mut cumulative_receipts = receipts.clone();
-			cumulative_receipts.truncate((status.transaction_index + 1) as usize);
+		// let header = self.select_chain.best_chain()
+		// 	.map_err(|_| internal_err("fetch header failed"))?;
+		// if let Ok(Some((_transaction, block, status, receipts))) = self.client.runtime_api()
+		// 	.transaction_by_hash(&BlockId::Hash(header.hash()), hash) {
 
-			return Ok(Some(Receipt {
-				transaction_hash: Some(status.transaction_hash),
-				transaction_index: Some(status.transaction_index.into()),
-				block_hash: Some(block_hash),
-				from: Some(status.from),
-				to: status.to,
-				block_number: Some(block.header.number),
-				cumulative_gas_used: {
-					let cumulative_gas: u32 = cumulative_receipts.iter().map(|r| {
-						r.used_gas.as_u32()
-					}).sum();
-					U256::from(cumulative_gas)
-				},
-				gas_used: Some(receipt.used_gas),
-				contract_address: status.contract_address,
-				logs: {
-					let mut pre_receipts_log_index = None;
-					if cumulative_receipts.len() > 0 {
-						cumulative_receipts.truncate(cumulative_receipts.len() - 1);
-						pre_receipts_log_index = Some(cumulative_receipts.iter().map(|r| {
-							r.logs.len() as u32
-						}).sum::<u32>());
-					}
-					receipt.logs.iter().enumerate().map(|(i, log)| {
-						Log {
-							address: log.address,
-							topics: log.topics.clone(),
-							data: Bytes(log.data.clone()),
-							block_hash: Some(block_hash),
-							block_number: Some(block.header.number),
-							transaction_hash: Some(hash),
-							transaction_index: Some(status.transaction_index.into()),
-							log_index: Some(U256::from(
-								(pre_receipts_log_index.unwrap_or(0)) + i as u32
-							)),
-							transaction_log_index: Some(U256::from(i)),
-							removed: false,
-						}
-					}).collect()
-				},
-				state_root: Some(receipt.state_root),
-				logs_bloom: receipt.logs_bloom,
-				status_code: None,
-			}))
-		}
-		Ok(None)
+		// 	let block_hash = H256::from_slice(
+		// 		Keccak256::digest(&rlp::encode(&block.header)).as_slice()
+		// 	);
+		// 	let receipt = receipts[status.transaction_index as usize].clone();
+		// 	let mut cumulative_receipts = receipts.clone();
+		// 	cumulative_receipts.truncate((status.transaction_index + 1) as usize);
+
+		// 	return Ok(Some(Receipt {
+		// 		transaction_hash: Some(status.transaction_hash),
+		// 		transaction_index: Some(status.transaction_index.into()),
+		// 		block_hash: Some(block_hash),
+		// 		from: Some(status.from),
+		// 		to: status.to,
+		// 		block_number: Some(block.header.number),
+		// 		cumulative_gas_used: {
+		// 			let cumulative_gas: u32 = cumulative_receipts.iter().map(|r| {
+		// 				r.used_gas.as_u32()
+		// 			}).sum();
+		// 			U256::from(cumulative_gas)
+		// 		},
+		// 		gas_used: Some(receipt.used_gas),
+		// 		contract_address: status.contract_address,
+		// 		logs: {
+		// 			let mut pre_receipts_log_index = None;
+		// 			if cumulative_receipts.len() > 0 {
+		// 				cumulative_receipts.truncate(cumulative_receipts.len() - 1);
+		// 				pre_receipts_log_index = Some(cumulative_receipts.iter().map(|r| {
+		// 					r.logs.len() as u32
+		// 				}).sum::<u32>());
+		// 			}
+		// 			receipt.logs.iter().enumerate().map(|(i, log)| {
+		// 				Log {
+		// 					address: log.address,
+		// 					topics: log.topics.clone(),
+		// 					data: Bytes(log.data.clone()),
+		// 					block_hash: Some(block_hash),
+		// 					block_number: Some(block.header.number),
+		// 					transaction_hash: Some(hash),
+		// 					transaction_index: Some(status.transaction_index.into()),
+		// 					log_index: Some(U256::from(
+		// 						(pre_receipts_log_index.unwrap_or(0)) + i as u32
+		// 					)),
+		// 					transaction_log_index: Some(U256::from(i)),
+		// 					removed: false,
+		// 				}
+		// 			}).collect()
+		// 		},
+		// 		state_root: Some(receipt.state_root),
+		// 		logs_bloom: receipt.logs_bloom,
+		// 		status_code: None,
+		// 	}))
+		// }
+		// Ok(None)
 	}
 
 	fn uncle_by_block_hash_and_index(&self, _: H256, _: Index) -> Result<Option<RichBlock>> {
@@ -686,75 +688,7 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 	}
 
 	fn logs(&self, filter: Filter) -> Result<Vec<Log>> {
-		let header = self.select_chain.best_chain()
-			.map_err(|_| internal_err("fetch header failed"))?;
-
-		let mut from_block = None;
-		if let Some(from_block_input) = filter.from_block {
-			if let Ok(Some(block_number)) = self.native_block_number(Some(from_block_input)) {
-				from_block = Some(block_number);
-			}
-		}
-
-		let mut to_block = None;
-		if let Some(to_block_input) = filter.to_block {
-			if let Ok(Some(block_number)) = self.native_block_number(Some(to_block_input)) {
-				to_block = Some(block_number);
-			}
-		}
-
-		let mut address = None;
-		if let Some(address_input) = filter.address {
-			match address_input {
-				VariadicValue::Single(x) => { address = Some(x); },
-				_ => { address = None; }
-			}
-		}
-
-		let mut topics = None;
-		if let Some(topics_input) = filter.topics {
-			match topics_input {
-				VariadicValue::Multiple(x) => { topics = Some(x); },
-				_ => { topics = None; }
-			}
-		}
-
-		if let Ok(logs) = self.client.runtime_api()
-			.logs(
-				&BlockId::Hash(header.hash()),
-				from_block,
-				to_block,
-				filter.block_hash,
-				address,
-				topics
-		) {
-			let mut output = vec![];
-			for log in logs {
-				let address = log.0;
-				let topics = log.1;
-				let data = log.2;
-				let block_hash = log.3;
-				let block_number = log.4;
-				let transaction_hash = log.5;
-				let transaction_index = log.6;
-				let log_index = log.7;
-				let transaction_log_index = log.8;
-				output.push(Log {
-					address,
-					topics,
-					data: Bytes(data),
-					block_hash,
-					block_number,
-					transaction_hash,
-					transaction_index,
-					log_index,
-					transaction_log_index,
-					removed: false
-				});
-			}
-			return Ok(output);
-		}
-		Ok(vec![])
+		unimplemented!()
 	}
 
 	fn work(&self) -> Result<Work> {
@@ -777,6 +711,7 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 	fn is_listening(&self) -> Result<bool> {
 		Ok(true)
 	}
+
 	fn version(&self) -> Result<String> {
 		Ok(self.chain_id().unwrap().unwrap().to_string())
 	}

--- a/template/node/Cargo.toml
+++ b/template/node/Cargo.toml
@@ -47,6 +47,7 @@ sp-runtime = { version = "2.0.0-dev", path = "../../vendor/substrate/primitives/
 sc-basic-authorship = { path = "../../vendor/substrate/client/basic-authorship" }
 sp-block-builder = { path = "../../vendor/substrate/primitives/block-builder" }
 
+frontier-consensus = { version = "0.1.0", path = "../../consensus" }
 frontier-template-runtime = { version = "2.0.0-dev", path = "../runtime" }
 frontier-rpc = { version = "0.1.0", path = "../../rpc" }
 frontier-rpc-primitives = { version = "0.1.0", path = "../../rpc/primitives" }

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -26,7 +26,7 @@ use sp_transaction_pool::TransactionPool;
 use sp_blockchain::{Error as BlockChainError, HeaderMetadata, HeaderBackend};
 use sp_consensus::SelectChain;
 use sc_rpc_api::DenyUnsafe;
-use sc_client_api::backend::{StorageProvider, Backend, StateBackend};
+use sc_client_api::backend::{StorageProvider, Backend, StateBackend, AuxStore};
 use sp_runtime::traits::BlakeTwo256;
 use sp_block_builder::BlockBuilder;
 
@@ -64,13 +64,13 @@ pub fn create_full<C, P, M, SC, BE>(
 ) -> jsonrpc_core::IoHandler<M> where
 	BE: Backend<Block> + 'static,
 	BE::State: StateBackend<BlakeTwo256>,
-	C: ProvideRuntimeApi<Block> + StorageProvider<Block, BE>,
+	C: ProvideRuntimeApi<Block> + StorageProvider<Block, BE> + AuxStore,
 	C: HeaderBackend<Block> + HeaderMetadata<Block, Error=BlockChainError> + 'static,
 	C: Send + Sync + 'static,
 	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
 	C::Api: BlockBuilder<Block>,
 	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
-	C::Api: frontier_rpc_primitives::EthereumRuntimeApi<Block>,
+	C::Api: frontier_rpc_primitives::EthereumRuntimeRPCApi<Block>,
 	<C::Api as sp_api::ApiErrorExt>::Error: fmt::Debug,
 	P: TransactionPool<Block=Block> + 'static,
 	M: jsonrpc_core::Metadata + Default,

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -467,7 +467,7 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl frontier_rpc_primitives::EthereumRuntimeApi<Block> for Runtime {
+	impl frontier_rpc_primitives::EthereumRuntimeRPCApi<Block> for Runtime {
 		fn chain_id() -> u64 {
 			ChainId::get()
 		}
@@ -528,103 +528,16 @@ impl_runtime_apis! {
 			}
 		}
 
-		fn block_by_number(number: u32) -> (
-			Option<EthereumBlock>, Vec<Option<frame_ethereum::TransactionStatus>>
-		) {
-			if let Some(block) = <frame_ethereum::Module<Runtime>>::block_by_number(number) {
-				let statuses = <frame_ethereum::Module<Runtime>>::block_transaction_statuses(&block);
-				return (
-					Some(block),
-					statuses
-				);
-			}
-			(None,vec![])
+		fn current_transaction_status(index: u32) -> Option<TransactionStatus> {
+			Ethereum::current_transaction_status(index)
 		}
 
-		fn block_transaction_count_by_number(number: u32) -> Option<U256> {
-			if let Some(block) = <frame_ethereum::Module<Runtime>>::block_by_number(number) {
-				return Some(U256::from(block.transactions.len()))
-			}
-			None
+		fn current_block() -> Option<frame_ethereum::Block> {
+			Ethereum::current_block()
 		}
 
-		fn block_transaction_count_by_hash(hash: H256) -> Option<U256> {
-			if let Some(block) = <frame_ethereum::Module<Runtime>>::block_by_hash(hash) {
-				return Some(U256::from(block.transactions.len()))
-			}
-			None
-		}
-
-		fn block_by_hash(hash: H256) -> Option<EthereumBlock> {
-			<frame_ethereum::Module<Runtime>>::block_by_hash(hash)
-		}
-
-		fn block_by_hash_with_statuses(hash: H256) -> (
-			Option<EthereumBlock>, Vec<Option<frame_ethereum::TransactionStatus>>
-		) {
-			if let Some(block) = <frame_ethereum::Module<Runtime>>::block_by_hash(hash) {
-				let statuses = <frame_ethereum::Module<Runtime>>::block_transaction_statuses(&block);
-				return (
-					Some(block),
-					statuses
-				);
-			}
-			(None, vec![])
-		}
-
-		fn transaction_by_hash(hash: H256) -> Option<(
-			EthereumTransaction,
-			EthereumBlock,
-			TransactionStatus,
-			Vec<EthereumReceipt>)> {
-			<frame_ethereum::Module<Runtime>>::transaction_by_hash(hash)
-		}
-
-		fn transaction_by_block_hash_and_index(hash: H256, index: u32) -> Option<(
-			EthereumTransaction,
-			EthereumBlock,
-			TransactionStatus)> {
-			<frame_ethereum::Module<Runtime>>::transaction_by_block_hash_and_index(hash, index)
-		}
-
-		fn transaction_by_block_number_and_index(number: u32, index: u32) -> Option<(
-			EthereumTransaction,
-			EthereumBlock,
-			TransactionStatus)> {
-			<frame_ethereum::Module<Runtime>>::transaction_by_block_number_and_index(
-				number,
-				index
-			)
-		}
-
-		fn logs(
-			from_block: Option<u32>,
-			to_block: Option<u32>,
-			block_hash: Option<H256>,
-			address: Option<H160>,
-			topic: Option<Vec<H256>>
-		) -> Vec<(
-			H160, // address
-			Vec<H256>, // topics
-			Vec<u8>, // data
-			Option<H256>, // block_hash
-			Option<U256>, // block_number
-			Option<H256>, // transaction_hash
-			Option<U256>, // transaction_index
-			Option<U256>, // log index in block
-			Option<U256>, // log index in transaction
-		)> {
-			let output = <frame_ethereum::Module<Runtime>>::filtered_logs(
-				from_block,
-				to_block,
-				block_hash,
-				address,
-				topic
-			);
-			if let Some(output) = output {
-				return output;
-			}
-			return vec![];
+		fn current_receipt(index: u32) -> Option<frame_ethereum::Receipt> {
+			Ethereum::current_receipt(index)
 		}
 	}
 

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -528,16 +528,16 @@ impl_runtime_apis! {
 			}
 		}
 
-		fn current_transaction_status(index: u32) -> Option<TransactionStatus> {
-			Ethereum::current_transaction_status(index)
+		fn current_transaction_statuses() -> Option<Vec<TransactionStatus>> {
+			Ethereum::current_transaction_statuses()
 		}
 
 		fn current_block() -> Option<frame_ethereum::Block> {
 			Ethereum::current_block()
 		}
 
-		fn current_receipt(index: u32) -> Option<frame_ethereum::Receipt> {
-			Ethereum::current_receipt(index)
+		fn current_receipts() -> Option<Vec<frame_ethereum::Receipt>> {
+			Ethereum::current_receipts()
 		}
 	}
 


### PR DESCRIPTION
Currently, we store all the mappings of block hashes and transaction hashes directly in state storage. This is not optimal, as those hashes are repeated for every block. In addition, retrieval of those hashes from the runtime results in a large number of runtime API methods, which complicates implementations.

This PR attempts to fix those issues by moving the mapping from runtime state storage into the consensus auxiliary storage, by defining a custom block import struct. The import struct will read a post-runtime digest produced by runtime. The digest contains information about the block and transaction hash mappings, which are then moved to auxiliary store.

Substrate allows block imports to be stacked, so this frontier block import can wrap any other block imports in Substrate's consensus and work with them.