### PR TITLE
Small clean-up of RPC methods

### DIFF
--- a/rpc/core/src/eth.rs
+++ b/rpc/core/src/eth.rs
@@ -71,10 +71,6 @@ pub trait EthApi {
 	#[rpc(name = "eth_getBalance")]
 	fn balance(&self, _: H160, _: Option<BlockNumber>) -> Result<U256>;
 
-	/// Returns the account- and storage-values of the specified account including the Merkle-proof
-	#[rpc(name = "eth_getProof")]
-	fn proof(&self, _: H160, _: Vec<H256>, _: Option<BlockNumber>) -> BoxFuture<EthAccount>;
-
 	/// Returns content of the storage at given address.
 	#[rpc(name = "eth_getStorageAt")]
 	fn storage_at(&self, _: H160, _: U256, _: Option<BlockNumber>) -> Result<H256>;
@@ -114,10 +110,6 @@ pub trait EthApi {
 	/// Sends signed transaction, returning its hash.
 	#[rpc(name = "eth_sendRawTransaction")]
 	fn send_raw_transaction(&self, _: Bytes) -> BoxFuture<H256>;
-
-	/// @alias of `eth_sendRawTransaction`.
-	#[rpc(name = "eth_submitTransaction")]
-	fn submit_transaction(&self, _: Bytes) -> Result<H256>;
 
 	/// Call contract, returning the output data.
 	#[rpc(name = "eth_call")]
@@ -163,26 +155,6 @@ pub trait EthApi {
 		_: Index,
 	) -> Result<Option<RichBlock>>;
 
-	/// Returns available compilers.
-	/// @deprecated
-	#[rpc(name = "eth_getCompilers")]
-	fn compilers(&self) -> Result<Vec<String>>;
-
-	/// Compiles lll code.
-	/// @deprecated
-	#[rpc(name = "eth_compileLLL")]
-	fn compile_lll(&self, _: String) -> Result<Bytes>;
-
-	/// Compiles solidity.
-	/// @deprecated
-	#[rpc(name = "eth_compileSolidity")]
-	fn compile_solidity(&self, _: String) -> Result<Bytes>;
-
-	/// Compiles serpent.
-	/// @deprecated
-	#[rpc(name = "eth_compileSerpent")]
-	fn compile_serpent(&self, _: String) -> Result<Bytes>;
-
 	/// Returns logs matching given filter object.
 	#[rpc(name = "eth_getLogs")]
 	fn logs(&self, _: Filter) -> Result<Vec<Log>>;
@@ -198,16 +170,9 @@ pub trait EthApi {
 	/// Used for submitting mining hashrate.
 	#[rpc(name = "eth_submitHashrate")]
 	fn submit_hashrate(&self, _: U256, _: H256) -> Result<bool>;
-
-	// TODO: Once development is more stable, remove the net_ functions which are already defined net.rs
-	#[rpc(name = "net_listening")]
-	fn is_listening(&self) -> Result<bool>;
-	#[rpc(name = "net_version")]
-	fn version(&self) -> Result<String>;
 }
 
 /// Eth filters rpc api (polling).
-// TODO: do filters api properly
 #[rpc(server)]
 pub trait EthFilterApi {
 	/// Returns id of new filter.

--- a/rpc/core/src/lib.rs
+++ b/rpc/core/src/lib.rs
@@ -25,5 +25,5 @@ mod web3;
 pub use eth::{EthApi, EthApiServer, EthFilterApi};
 pub use eth_pubsub::EthPubSubApi;
 pub use eth_signing::EthSigningApi;
-pub use net::NetApi;
+pub use net::{NetApi, NetApiServer};
 pub use web3::Web3Api;

--- a/rpc/core/src/net.rs
+++ b/rpc/core/src/net.rs
@@ -18,6 +18,8 @@
 use jsonrpc_core::Result;
 use jsonrpc_derive::rpc;
 
+pub use rpc_impl_NetApi::gen_server::NetApi as NetApiServer;
+
 /// Net rpc interface.
 #[rpc(server)]
 pub trait NetApi {

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -28,14 +28,14 @@ use sp_transaction_pool::TransactionPool;
 use sc_client_api::backend::{StorageProvider, Backend, StateBackend, AuxStore};
 use sha3::{Keccak256, Digest};
 use sp_runtime::traits::BlakeTwo256;
-use frontier_rpc_core::EthApi as EthApiT;
+use frontier_rpc_core::{EthApi as EthApiT, NetApi as NetApiT};
 use frontier_rpc_core::types::{
 	BlockNumber, Bytes, CallRequest, EthAccount, Filter, Index, Log, Receipt, RichBlock,
 	SyncStatus, SyncInfo, Transaction, Work, Rich, Block, BlockTransactions, VariadicValue
 };
 use frontier_rpc_primitives::{EthereumRuntimeRPCApi, ConvertTransaction, TransactionStatus};
 
-pub use frontier_rpc_core::EthApiServer;
+pub use frontier_rpc_core::{EthApiServer, NetApiServer};
 
 fn internal_err(message: &str) -> Error {
 	Error {
@@ -308,10 +308,6 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 		Ok(U256::zero())
 	}
 
-	fn proof(&self, _: H160, _: Vec<H256>, _: Option<BlockNumber>) -> BoxFuture<EthAccount> {
-		unimplemented!("proof");
-	}
-
 	fn storage_at(&self, address: H160, index: U256, number: Option<BlockNumber>) -> Result<H256> {
 		if let Ok(Some(id)) = self.native_block_id(number) {
 			return Ok(
@@ -480,10 +476,6 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 				.map(move |_| transaction_hash)
 				.map_err(|_| internal_err("submit transaction to pool failed"))
 		)
-	}
-
-	fn submit_transaction(&self, _: Bytes) -> Result<H256> {
-		unimplemented!("submit_transaction");
 	}
 
 	fn call(&self, request: CallRequest, _: Option<BlockNumber>) -> Result<Bytes> {
@@ -735,22 +727,6 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 		Ok(None)
 	}
 
-	fn compilers(&self) -> Result<Vec<String>> {
-		Err(not_supported_err("Method eth_getCompilers not supported."))
-	}
-
-	fn compile_lll(&self, _: String) -> Result<Bytes> {
-		Err(not_supported_err("Method eth_compileLLL not supported."))
-	}
-
-	fn compile_solidity(&self, _: String) -> Result<Bytes> {
-		Err(not_supported_err("Method eth_compileSolidity not supported."))
-	}
-
-	fn compile_serpent(&self, _: String) -> Result<Bytes> {
-		Err(not_supported_err("Method eth_compileSerpent not supported."))
-	}
-
 	fn logs(&self, filter: Filter) -> Result<Vec<Log>> {
 		let mut blocks_and_receipts = Vec::new();
 		let mut ret = Vec::new();
@@ -883,12 +859,20 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 	fn submit_hashrate(&self, _: U256, _: H256) -> Result<bool> {
 		Ok(false)
 	}
+}
 
+pub struct NetApi;
+
+impl NetApiT for NetApi {
 	fn is_listening(&self) -> Result<bool> {
 		Ok(true)
 	}
 
+	fn peer_count(&self) -> Result<String> {
+		Ok("0".to_string())
+	}
+
 	fn version(&self) -> Result<String> {
-		Ok(self.chain_id().unwrap().unwrap().to_string())
+		Ok("Frontier/v0.1.0".to_string())
 	}
 }

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -78,7 +78,7 @@ pub fn create_full<C, P, M, SC, BE>(
 {
 	use substrate_frame_rpc_system::{FullSystem, SystemApi};
 	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApi};
-	use frontier_rpc::{EthApi, EthApiServer};
+	use frontier_rpc::{EthApi, EthApiServer, NetApi, NetApiServer};
 
 	let mut io = jsonrpc_core::IoHandler::default();
 	let FullDeps {
@@ -104,6 +104,9 @@ pub fn create_full<C, P, M, SC, BE>(
 			frontier_template_runtime::TransactionConverter,
 			is_authority,
 		))
+	);
+	io.extend_with(
+		NetApiServer::to_delegate(NetApi)
 	);
 
 	match command_sink {

--- a/ts-tests/tests/test-deprecated.ts
+++ b/ts-tests/tests/test-deprecated.ts
@@ -16,7 +16,7 @@ describeWithFrontier("Frontier RPC (Deprecated)", `simple-specs.json`, (context)
 			expect(await customRequest(context.web3, method, params)).to.deep.equal({
 				id: 1,
 				jsonrpc: "2.0",
-				error: { message: `Method ${method} not supported.`, code: -32600 },
+				error: { message: `Method not found`, code: -32601 },
 			});
 		});
 	});


### PR DESCRIPTION
* Remove non-standard JSON-RPC method definitions.
* Move `net_` APIs to proper `NetApi` trait.