### PR TITLE
Add test for retrieving block by hash

### DIFF
--- a/ts-tests/tests/test-block.ts
+++ b/ts-tests/tests/test-block.ts
@@ -113,4 +113,45 @@ describeWithFrontier("Frontier RPC (Block)", `simple-specs.json`, (context) => {
 		expect(block.hash).to.not.equal(previousBlock.hash);
 		expect(block.parentHash).to.equal(previousBlock.hash);
 	});
+
+	step("retrieve block information by hash", async function () {
+		expect(firstBlockCreated).to.be.true;
+
+		const block_pre = await context.web3.eth.getBlock("latest");
+		const hash = block_pre.hash;
+		const block = await context.web3.eth.getBlock(hash);
+		expect(block).to.include({
+			author: "0x0000000000000000000000000000000000000000",
+			difficulty: "0",
+			extraData: "0x0000000000000000000000000000000000000000000000000000000000000000",
+			gasLimit: 0,
+			gasUsed: 0,
+			//hash: "0x14fe6f7c93597f79b901f8b5d7a84277a90915b8d355959b587e18de34f1dc17",
+			logsBloom:
+				"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+			miner: "0x0000000000000000000000000000000000000000",
+			number: 1,
+			//parentHash: "0x04540257811b46d103d9896e7807040e7de5080e285841c5430d1a81588a0ce4",
+			receiptsRoot: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+			sha3Uncles: "0x0000000000000000000000000000000000000000000000000000000000000000",
+			size: 539,
+			stateRoot: "0x0000000000000000000000000000000000000000000000000000000000000000",
+			//timestamp: 1595012243836,
+			totalDifficulty: null,
+			//transactions: [],
+			transactionsRoot: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+			//uncles: []
+		});
+		previousBlock = block;
+
+		expect(block.transactions).to.be.a("array").empty;
+		expect(block.uncles).to.be.a("array").empty;
+		expect((block as any).sealFields).to.eql([
+			"0x0000000000000000000000000000000000000000000000000000000000000000",
+			"0x0000000000000000",
+		]);
+		expect(block.hash).to.be.a("string").lengthOf(66);
+		expect(block.parentHash).to.be.a("string").lengthOf(66);
+		expect(block.timestamp).to.be.a("number");
+	});
 });


### PR DESCRIPTION
With recent changes calling `eth_getBlockByHash` or using `web3.eth.getBlock` (using a hash) is returning `null` instead of the block's body.

This PR adds the assertion to the typescript tests.

P.S. the PR fails obviously on functional tests -> `AssertionError: Target cannot be null or undefined.`