### PR TITLE
Allow disable FrontierBlockImport

### DIFF
--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -90,7 +90,8 @@ pub fn new_partial(config: &Configuration, manual_seal: bool) -> Result<
 
 	let frontier_block_import = FrontierBlockImport::new(
 		grandpa_block_import.clone(),
-		client.clone()
+		client.clone(),
+		true
 	);
 
 	let aura_block_import = sc_consensus_aura::AuraBlockImport::<_, _, _, AuraPair>::new(


### PR DESCRIPTION
Part of #120

So validator / non-rpc node does not need to index all the extra data.

In later version, there should be a way to detect if the flag was use inconsistently similar to pruning mode.