### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,5 @@
+# A codeowner just oversees some part of the codebase. If an owned file is changed then the
+# corresponding codeowner receives a review request. An approval of the codeowner is
+# not required for merging a PR.
+
 * @sorpaas

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sorpaas


### PR DESCRIPTION
As the same in Substrate repo -- this does not mean "code owners", but just makes my workflow easier as I'll receive email notifications for every new PRs in this repo.