### PR TITLE
Frontier consensus one-to-many mapping

### DIFF
--- a/consensus/src/aux_schema.rs
+++ b/consensus/src/aux_schema.rs
@@ -43,21 +43,30 @@ pub fn block_hash_key(ethereum_block_hash: H256) -> Vec<u8> {
 pub fn load_block_hash<Block: BlockT, B: AuxStore>(
 	backend: &B,
 	hash: H256,
-) -> ClientResult<Option<Block::Hash>> {
+) -> ClientResult<Option<Vec<Block::Hash>>> {
 	let key = block_hash_key(hash);
 	load_decode(backend, &key)
 }
 
 /// Update Aux block hash.
-pub fn write_block_hash<Hash: Encode, F, R>(
+pub fn write_block_hash<Hash: Encode + Decode, F, R, Backend: AuxStore>(
+	client: &Backend,
 	ethereum_hash: H256,
 	block_hash: Hash,
 	write_aux: F,
 ) -> R where
-	F: FnOnce(&[(&[u8], &[u8])]) -> R,
+	F: FnOnce(&[(&[u8], &[u8])]) -> R, Hash: std::fmt::Debug,
 {
 	let key = block_hash_key(ethereum_hash);
-	write_aux(&[(&key, &block_hash.encode()[..])])
+
+	let mut data: Vec<Hash> = match load_decode(client, &key)
+	{
+		Ok(Some(hashes)) => hashes,
+		_ => Vec::new(),
+	};
+	data.push(block_hash);
+
+	write_aux(&[(&key, &data.encode()[..])])
 }
 
 /// Map an Ethereum transaction hash into its corresponding Ethereum block hash and index.

--- a/consensus/src/aux_schema.rs
+++ b/consensus/src/aux_schema.rs
@@ -55,7 +55,7 @@ pub fn write_block_hash<Hash: Encode + Decode, F, R, Backend: AuxStore>(
 	block_hash: Hash,
 	write_aux: F,
 ) -> R where
-	F: FnOnce(&[(&[u8], &[u8])]) -> R, Hash: std::fmt::Debug,
+	F: FnOnce(&[(&[u8], &[u8])]) -> R,
 {
 	let key = block_hash_key(ethereum_hash);
 

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -126,6 +126,8 @@ impl<B, I, C> BlockImport<B> for FrontierBlockImport<B, I, C> where
 			)
 		}
 
+		let client = self.client.clone();
+
 		if self.enabled {
 			let log = find_frontier_log::<B>(&block.header)?;
 			let hash = block.post_hash();
@@ -134,7 +136,7 @@ impl<B, I, C> BlockImport<B> for FrontierBlockImport<B, I, C> where
 				ConsensusLog::EndBlock {
 					block_hash, transaction_hashes,
 				} => {
-					aux_schema::write_block_hash(block_hash, hash, insert_closure!());
+					aux_schema::write_block_hash(client.as_ref(), block_hash, hash, insert_closure!());
 
 					for (index, transaction_hash) in transaction_hashes.into_iter().enumerate() {
 						aux_schema::write_transaction_metadata(

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -16,6 +16,7 @@ frontier-rpc-core = { path = "core" }
 frontier-rpc-primitives = { path = "primitives" }
 sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-api = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-consensus = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-transaction-pool = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -28,6 +28,7 @@ use sp_transaction_pool::TransactionPool;
 use sc_client_api::backend::{StorageProvider, Backend, StateBackend, AuxStore};
 use sha3::{Keccak256, Digest};
 use sp_runtime::traits::BlakeTwo256;
+use sp_blockchain::{Error as BlockChainError, HeaderMetadata, HeaderBackend};
 use frontier_rpc_core::{EthApi as EthApiT, NetApi as NetApiT};
 use frontier_rpc_core::types::{
 	BlockNumber, Bytes, CallRequest, EthAccount, Filter, Index, Log, Receipt, RichBlock,
@@ -186,6 +187,7 @@ fn transaction_build(
 
 impl<B, C, SC, P, CT, BE> EthApi<B, C, SC, P, CT, BE> where
 	C: ProvideRuntimeApi<B> + StorageProvider<B, BE> + AuxStore,
+	C: HeaderBackend<B> + HeaderMetadata<B, Error=BlockChainError> + 'static,
 	C::Api: EthereumRuntimeRPCApi<B>,
 	BE: Backend<B> + 'static,
 	BE::State: StateBackend<BlakeTwo256>,
@@ -198,10 +200,7 @@ impl<B, C, SC, P, CT, BE> EthApi<B, C, SC, P, CT, BE> where
 	fn native_block_id(&self, number: Option<BlockNumber>) -> Result<Option<BlockId<B>>> {
 		Ok(match number.unwrap_or(BlockNumber::Latest) {
 			BlockNumber::Hash { hash, .. } => {
-				let hash = frontier_consensus::load_block_hash::<B, _>(self.client.as_ref(), hash)
-					.map_err(|err| internal_err(format!("fetch aux store failed: {:?}", err)))?;
-
-				hash.map(|h| BlockId::Hash(h))
+				self.load_hash(hash).unwrap_or(None)
 			},
 			BlockNumber::Num(number) => {
 				Some(BlockId::Number(number.unique_saturated_into()))
@@ -221,10 +220,36 @@ impl<B, C, SC, P, CT, BE> EthApi<B, C, SC, P, CT, BE> where
 			}
 		})
 	}
+
+	// Asumes there is only one mapped canonical block in the AuxStore, otherwise something is wrong
+	fn load_hash(&self, hash: H256) -> Result<Option<BlockId<B>>> {
+		let hashes = match frontier_consensus::load_block_hash::<B, _>(self.client.as_ref(), hash)
+			.map_err(|err| internal_err(format!("fetch aux store failed: {:?}", err)))?
+		{
+			Some(hashes) => hashes,
+			None => return Ok(None),
+		};
+		let out: Vec<H256> = hashes.into_iter()
+			.filter_map(|h| {
+				if let Ok(Some(_)) = self.client.header(BlockId::Hash(h)) {
+					Some(h)
+				} else {
+					None
+				}
+			}).collect();
+		
+		if out.len() == 1 {
+			return Ok(Some(
+				BlockId::Hash(out[0])
+			));
+		}
+		Ok(None)
+	}
 }
 
 impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 	C: ProvideRuntimeApi<B> + StorageProvider<B, BE> + AuxStore,
+	C: HeaderBackend<B> + HeaderMetadata<B, Error=BlockChainError> + 'static,
 	C::Api: EthereumRuntimeRPCApi<B>,
 	BE: Backend<B> + 'static,
 	BE::State: StateBackend<BlakeTwo256>,
@@ -336,11 +361,11 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 	}
 
 	fn block_by_hash(&self, hash: H256, full: bool) -> Result<Option<RichBlock>> {
-		let id = match frontier_consensus::load_block_hash::<B, _>(self.client.as_ref(), hash)
-			.map_err(|err| internal_err(format!("fetch aux store failed: {:?}", err)))?
+		let id = match self.load_hash(hash)
+			.map_err(|err| internal_err(format!("{:?}", err)))?
 		{
-			Some(hash) => BlockId::Hash(hash),
-			None => return Ok(None),
+			Some(hash) => hash,
+			_ => return Ok(None),
 		};
 
 		let block = self.client.runtime_api().current_block(&id)
@@ -408,11 +433,11 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 	}
 
 	fn block_transaction_count_by_hash(&self, hash: H256) -> Result<Option<U256>> {
-		let id = match frontier_consensus::load_block_hash::<B, _>(self.client.as_ref(), hash)
-			.map_err(|err| internal_err(format!("fetch aux store failed: {:?}", err)))?
+		let id = match self.load_hash(hash)
+			.map_err(|err| internal_err(format!("{:?}", err)))?
 		{
-			Some(hash) => BlockId::Hash(hash),
-			None => return Ok(None),
+			Some(hash) => hash,
+			_ => return Ok(None),
 		};
 
 		let block = self.client.runtime_api()
@@ -565,11 +590,11 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 			None => return Ok(None),
 		};
 
-		let id = match frontier_consensus::load_block_hash::<B, _>(self.client.as_ref(), hash)
-			.map_err(|err| internal_err(format!("fetch aux store failed: {:?}", err)))?
+		let id = match self.load_hash(hash)
+			.map_err(|err| internal_err(format!("{:?}", err)))?
 		{
-			Some(hash) => BlockId::Hash(hash),
-			None => return Ok(None),
+			Some(hash) => hash,
+			_ => return Ok(None),
 		};
 
 		let block = self.client.runtime_api().current_block(&id)
@@ -594,11 +619,11 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 		hash: H256,
 		index: Index,
 	) -> Result<Option<Transaction>> {
-		let id = match frontier_consensus::load_block_hash::<B, _>(self.client.as_ref(), hash)
-			.map_err(|err| internal_err(format!("fetch aux store failed: {:?}", err)))?
+		let id = match self.load_hash(hash)
+			.map_err(|err| internal_err(format!("{:?}", err)))?
 		{
-			Some(hash) => BlockId::Hash(hash),
-			None => return Ok(None),
+			Some(hash) => hash,
+			_ => return Ok(None),
 		};
 		let index = index.value();
 
@@ -656,11 +681,11 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 			None => return Ok(None),
 		};
 
-		let id = match frontier_consensus::load_block_hash::<B, _>(self.client.as_ref(), hash)
-			.map_err(|err| internal_err(format!("fetch aux store failed: {:?}", err)))?
+		let id = match self.load_hash(hash)
+			.map_err(|err| internal_err(format!("{:?}", err)))?
 		{
-			Some(hash) => BlockId::Hash(hash),
-			None => return Ok(None),
+			Some(hash) => hash,
+			_ => return Ok(None),
 		};
 
 		let block = self.client.runtime_api().current_block(&id)
@@ -746,11 +771,11 @@ impl<B, C, SC, P, CT, BE> EthApiT for EthApi<B, C, SC, P, CT, BE> where
 		let mut ret = Vec::new();
 
 		if let Some(hash) = filter.block_hash {
-			let id = match frontier_consensus::load_block_hash::<B, _>(self.client.as_ref(), hash)
-				.map_err(|err| internal_err(format!("fetch aux store failed: {:?}", err)))?
+			let id = match self.load_hash(hash)
+				.map_err(|err| internal_err(format!("{:?}", err)))?
 			{
-				Some(hash) => BlockId::Hash(hash),
-				None => return Ok(ret),
+				Some(hash) => hash,
+				_ => return Ok(Vec::new()),
 			};
 
 			let block = self.client.runtime_api()

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -237,7 +237,7 @@ impl<B, C, SC, P, CT, BE> EthApi<B, C, SC, P, CT, BE> where
 					None
 				}
 			}).collect();
-		
+
 		if out.len() == 1 {
 			return Ok(Some(
 				BlockId::Hash(out[0])


### PR DESCRIPTION
As part of the block import pipeline, the Frontier consensus inserts Ethereum and Substrate Hash mapping in the auxiliary storage.

If a fork happens, the mapping is not rolled back and will point to a block Hash that is no longer part of the canonical chain.

Following @crystalin  suggestion, this PR implements a one-to-many relation between Ethereum and Substrate block hashes (a single Ethereum Hash will map to a Vector of Substrate hashes).

The PR implementation asumes that:

- `HeaderBackend::header(BlockId)` only returns `Some` when the `BlockId` is part of the canonical chain.
- Only one Substrate Hash candidate between all the mapped by Ethereum Hash is part of the canonical chain.