### PR TITLE
Replace vendor ethereum with published ethereum crate and fix warnings

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/ethereum"]
-	path = vendor/ethereum
-	url = https://github.com/rust-blockchain/ethereum

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,7 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "ethereum"
-version = "0.2.0"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f873613a1191fe9d63794b5d0b636712446153ef0df192e9381bf1f951d3b94"
 dependencies = [
  "ethereum-types",
  "parity-scale-codec",
@@ -1544,7 +1546,7 @@ dependencies = [
  "futures 0.3.5",
  "jsonrpc-core",
  "log",
- "pallet-ethereum 0.1.0",
+ "pallet-ethereum 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pallet-evm",
  "pallet-transaction-payment-rpc",
  "sc-basic-authorship",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,3 @@ members = [
 	"template/test-utils/client",
 ]
 exclude = ["vendor"]
-
-[patch.crates-io]
-ethereum = { path = "vendor/ethereum" }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -23,4 +23,4 @@ futures = { version = "0.3.1", features = ["compat"] }
 sp-timestamp = { version = "2.0.0-rc6", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 derive_more = "0.99.2"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/substrate.git", branch = "frontier"}
-ethereum = { version = "0.2", features = ["codec"], path = "../vendor/ethereum/" }
+ethereum = { version = "0.3", features = ["codec"] }

--- a/frame/ethereum/Cargo.toml
+++ b/frame/ethereum/Cargo.toml
@@ -19,7 +19,7 @@ sp-runtime = { version = "2.0.0-dev", default-features = false, git = "https://g
 sp-std = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 evm = { version = "0.17.0", default-features = false }
-ethereum = { version = "0.2", default-features = false, features = ["codec"], path = "../../vendor/ethereum/" }
+ethereum = { version = "0.3", default-features = false, features = ["codec"] }
 ethereum-types = { version = "0.9", default-features = false }
 rlp = { version = "0.4", default-features = false }
 sha3 = { version = "0.8", default-features = false }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -22,7 +22,7 @@ sp-transaction-pool = { git = "https://github.com/paritytech/substrate.git", bra
 sp-storage = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" } 
 sc-service = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sc-client-api = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-ethereum = { version = "0.2", features = ["codec"], path = "../vendor/ethereum/" }
+ethereum = { version = "0.3", features = ["codec"] }
 codec = { package = "parity-scale-codec", version = "1.0.0" }
 rlp = "0.4"
 pallet-ethereum = "0.1"

--- a/rpc/core/src/eth.rs
+++ b/rpc/core/src/eth.rs
@@ -21,7 +21,7 @@ use jsonrpc_core::{BoxFuture, Result};
 use jsonrpc_derive::rpc;
 
 use crate::types::{
-	BlockNumber, Bytes, CallRequest, EthAccount, Filter, FilterChanges, Index, Log, Receipt,
+	BlockNumber, Bytes, CallRequest, Filter, FilterChanges, Index, Log, Receipt,
 	RichBlock, SyncStatus, Transaction, Work,
 };
 pub use rpc_impl_EthApi::gen_server::EthApi as EthApiServer;

--- a/rpc/primitives/Cargo.toml
+++ b/rpc/primitives/Cargo.toml
@@ -10,7 +10,7 @@ license = "GPL-3.0"
 sp-core = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-api = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 pallet-evm = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-ethereum = { version = "0.2", default-features = false, features = ["codec"], path = "../../vendor/ethereum/" }
+ethereum = { version = "0.3", default-features = false, features = ["codec"] }
 ethereum-types = { version = "0.9", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
 sp-runtime = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }

--- a/rpc/primitives/src/lib.rs
+++ b/rpc/primitives/src/lib.rs
@@ -18,8 +18,7 @@
 
 use sp_core::{H160, H256, U256};
 use ethereum::{
-	Log, Block as EthereumBlock, Transaction as EthereumTransaction,
-	Receipt as EthereumReceipt, TransactionAction
+	Log, Block as EthereumBlock, TransactionAction
 };
 use ethereum_types::Bloom;
 use codec::{Encode, Decode};

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -30,7 +30,7 @@ use sha3::{Keccak256, Digest};
 use sp_runtime::traits::BlakeTwo256;
 use frontier_rpc_core::{EthApi as EthApiT, NetApi as NetApiT};
 use frontier_rpc_core::types::{
-	BlockNumber, Bytes, CallRequest, EthAccount, Filter, Index, Log, Receipt, RichBlock,
+	BlockNumber, Bytes, CallRequest, Filter, Index, Log, Receipt, RichBlock,
 	SyncStatus, SyncInfo, Transaction, Work, Rich, Block, BlockTransactions, VariadicValue
 };
 use frontier_rpc_primitives::{EthereumRuntimeRPCApi, ConvertTransaction, TransactionStatus};
@@ -40,13 +40,6 @@ pub use frontier_rpc_core::{EthApiServer, NetApiServer};
 fn internal_err<T: ToString>(message: T) -> Error {
 	Error {
 		code: ErrorCode::InternalError,
-		message: message.to_string(),
-		data: None
-	}
-}
-fn not_supported_err(message: &str) -> Error {
-	Error {
-		code: ErrorCode::InvalidRequest,
 		message: message.to_string(),
 		data: None
 	}

--- a/template/node/Cargo.toml
+++ b/template/node/Cargo.toml
@@ -39,7 +39,7 @@ sp-consensus = { version = "0.8.0-dev", git = "https://github.com/paritytech/sub
 sc-consensus = { version = "0.8.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-timestamp = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 evm = { version = "2.0.0-dev", package = "pallet-evm", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-ethereum = { version = "0.1.0", package = "pallet-ethereum", path = "../../frame/ethereum" }
+ethereum = { version = "0.1.0", package = "pallet-ethereum" }
 sc-finality-grandpa = { version = "0.8.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-finality-grandpa = { version = "2.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sc-client-api = { version = "2.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -21,7 +21,7 @@ use std::{sync::Arc, fmt};
 
 use sc_consensus_manual_seal::rpc::{ManualSeal, ManualSealApi};
 use frontier_template_runtime::{Hash, AccountId, Index, opaque::Block, Balance};
-use sp_api::{ProvideRuntimeApi, Core};
+use sp_api::ProvideRuntimeApi;
 use sp_transaction_pool::TransactionPool;
 use sp_blockchain::{Error as BlockChainError, HeaderMetadata, HeaderBackend};
 use sp_consensus::SelectChain;

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -59,7 +59,6 @@ pub use frame_support::{
 	},
 	ConsensusEngineId,
 };
-use frame_ethereum::{Block as EthereumBlock, Transaction as EthereumTransaction, Receipt as EthereumReceipt};
 use frame_evm::{Account as EVMAccount, FeeCalculator, HashedAddressMapping, EnsureAddressTruncated};
 use frontier_rpc_primitives::{TransactionStatus};
 pub type BlockNumber = u32;


### PR DESCRIPTION
This removes all vendor-ed dependencies. Fixes https://github.com/paritytech/parity-common/issues/428 (due to update to `ethereum 0.3.0`).