### PR TITLE
Improve `eth_getLogs` runtime access

### DIFF
--- a/rpc/primitives/src/lib.rs
+++ b/rpc/primitives/src/lib.rs
@@ -80,6 +80,12 @@ sp_api::decl_runtime_apis! {
 		fn current_receipts() -> Option<Vec<ethereum::Receipt>>;
 		/// Return the current transaction status.
 		fn current_transaction_statuses() -> Option<Vec<TransactionStatus>>;
+		/// Return all the current data for a block in a single runtime call.
+		fn current_all() -> (
+			Option<EthereumBlock>,
+			Option<Vec<ethereum::Receipt>>,
+			Option<Vec<TransactionStatus>>
+		);
 	}
 }
 

--- a/rpc/src/eth.rs
+++ b/rpc/src/eth.rs
@@ -751,7 +751,6 @@ impl<B, C, P, CT, BE> EthApiT for EthApi<B, C, P, CT, BE> where
 				.unwrap_or(
 					self.client.info().best_number
 				);
-			
 			while current_number >= from_number {
 				let id = BlockId::Number(current_number);
 

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -553,6 +553,18 @@ impl_runtime_apis! {
 		fn current_receipts() -> Option<Vec<frame_ethereum::Receipt>> {
 			Ethereum::current_receipts()
 		}
+
+		fn current_all() -> (
+			Option<frame_ethereum::Block>,
+			Option<Vec<frame_ethereum::Receipt>>,
+			Option<Vec<TransactionStatus>>
+		 ) {
+			(
+				Ethereum::current_block(),
+				Ethereum::current_receipts(),
+				Ethereum::current_transaction_statuses()
+			)
+		}
 	}
 
 	impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -558,7 +558,7 @@ impl_runtime_apis! {
 			Option<frame_ethereum::Block>,
 			Option<Vec<frame_ethereum::Receipt>>,
 			Option<Vec<TransactionStatus>>
-		 ) {
+		) {
 			(
 				Ethereum::current_block(),
 				Ethereum::current_receipts(),


### PR DESCRIPTION
Currently in `eth_getLogs` there are 2 runtime api calls per block + an additional keccak calculation per transaction hash within each block. This is - i.e. for web3's logs subscriptions with an initial past events payload - very expensive.

This PR mitigates that cost by adding `EthereumRuntimeRPCApi.current_all`, that returns all block information - Block, Receipt and Status - in a single runtime call.