### PR TITLE
Insert `Ethereum::CurrentReceipts` in the AuxStore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,6 +1432,7 @@ dependencies = [
  "sp-consensus",
  "sp-core",
  "sp-inherents",
+ "sp-io",
  "sp-runtime",
  "sp-timestamp",
  "substrate-prometheus-endpoint",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -16,6 +16,7 @@ sp-api = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git
 sc-client-api = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-block-builder = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-inherents = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-io = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 frontier-consensus-primitives = { version = "0.1.0", path = "primitives" }
 sp-consensus = { version = "0.8.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 log = "0.4.8"

--- a/consensus/src/aux_schema.rs
+++ b/consensus/src/aux_schema.rs
@@ -96,3 +96,22 @@ pub fn write_transaction_metadata<F, R>(
 	let key = transaction_metadata_key(hash);
 	write_aux(&[(&key, &metadata.encode())])
 }
+
+/// Map a Ethereum block hash to the current runtime stored Ethereum receipts. 
+pub fn receipt_key(ethereum_block_hash: H256) -> Vec<u8> {
+	let mut ret = b"ethereum_receipts:".to_vec();
+	ret.append(&mut ethereum_block_hash.as_ref().to_vec());
+	ret
+}
+
+/// Update Aux block hash.
+pub fn write_receipts<F, R>(
+	ethereum_hash: H256,
+	data: Vec<u8>,
+	write_aux: F,
+) -> R where
+	F: FnOnce(&[(&[u8], &[u8])]) -> R,
+{
+	let key = receipt_key(ethereum_hash);
+	write_aux(&[(&key, &data[..])])
+}

--- a/consensus/src/aux_schema.rs
+++ b/consensus/src/aux_schema.rs
@@ -97,7 +97,7 @@ pub fn write_transaction_metadata<F, R>(
 	write_aux(&[(&key, &metadata.encode())])
 }
 
-/// Map a Ethereum block hash to the current runtime stored Ethereum receipts. 
+/// Map a Ethereum block hash to the current runtime stored Ethereum receipts.
 pub fn receipt_key(ethereum_block_hash: H256) -> Vec<u8> {
 	let mut ret = b"ethereum_receipts:".to_vec();
 	ret.append(&mut ethereum_block_hash.as_ref().to_vec());

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -83,7 +83,7 @@ impl<B, I, C, BE> FrontierBlockImport<B, I, C, BE> where
 	BE::State: StateBackend<BlakeTwo256>,
 	I: BlockImport<B, Transaction = sp_api::TransactionFor<C, B>> + Send + Sync,
 	I::Error: Into<ConsensusError>,
-	C: ProvideRuntimeApi<B> + Send + Sync + HeaderBackend<B> + AuxStore + ProvideCache<B> + BlockOf + StorageProvider<B,BE>, 
+	C: ProvideRuntimeApi<B> + Send + Sync + HeaderBackend<B> + AuxStore + ProvideCache<B> + BlockOf + StorageProvider<B,BE>,
 	C::Api: BlockBuilderApi<B, Error = sp_blockchain::Error>,
 {
 	pub fn new(
@@ -106,7 +106,7 @@ impl<B, I, C, BE> BlockImport<B> for FrontierBlockImport<B, I, C, BE> where
 	BE::State: StateBackend<BlakeTwo256>,
 	I: BlockImport<B, Transaction = sp_api::TransactionFor<C, B>> + Send + Sync,
 	I::Error: Into<ConsensusError>,
-	C: ProvideRuntimeApi<B> + Send + Sync + HeaderBackend<B> + AuxStore + ProvideCache<B> + BlockOf + StorageProvider<B,BE>, 
+	C: ProvideRuntimeApi<B> + Send + Sync + HeaderBackend<B> + AuxStore + ProvideCache<B> + BlockOf + StorageProvider<B,BE>,
 	C::Api: BlockBuilderApi<B, Error = sp_blockchain::Error>,
 {
 	type Error = ConsensusError;

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -24,12 +24,14 @@ use std::sync::Arc;
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use frontier_consensus_primitives::{FRONTIER_ENGINE_ID, ConsensusLog};
-use sc_client_api::{BlockOf, backend::AuxStore};
+use sc_client_api::{BlockOf, backend::AuxStore, StorageProvider, Backend, StateBackend};
 use sp_blockchain::{HeaderBackend, ProvideCache, well_known_cache_keys::Id as CacheKeyId};
 use sp_block_builder::BlockBuilder as BlockBuilderApi;
-use sp_runtime::generic::OpaqueDigestItemId;
-use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
+use sp_runtime::generic::{OpaqueDigestItemId, BlockId};
+use sp_runtime::traits::{Block as BlockT, Header as HeaderT, BlakeTwo256};
 use sp_api::ProvideRuntimeApi;
+use sp_core::storage::StorageKey;
+use sp_io::hashing::twox_128;
 use sp_consensus::{
 	BlockImportParams, Error as ConsensusError, BlockImport,
 	BlockCheckParams, ImportResult,
@@ -57,14 +59,14 @@ impl std::convert::From<Error> for ConsensusError {
 	}
 }
 
-pub struct FrontierBlockImport<B: BlockT, I, C> {
+pub struct FrontierBlockImport<B: BlockT, I, C, BE> {
 	inner: I,
 	client: Arc<C>,
 	enabled: bool,
-	_marker: PhantomData<B>,
+	_marker: PhantomData<(B, BE)>,
 }
 
-impl<Block: BlockT, I: Clone + BlockImport<Block>, C> Clone for FrontierBlockImport<Block, I, C> {
+impl<Block: BlockT, I: Clone + BlockImport<Block>, C, BE> Clone for FrontierBlockImport<Block, I, C, BE> {
 	fn clone(&self) -> Self {
 		FrontierBlockImport {
 			inner: self.inner.clone(),
@@ -75,11 +77,13 @@ impl<Block: BlockT, I: Clone + BlockImport<Block>, C> Clone for FrontierBlockImp
 	}
 }
 
-impl<B, I, C> FrontierBlockImport<B, I, C> where
+impl<B, I, C, BE> FrontierBlockImport<B, I, C, BE> where
 	B: BlockT,
+	BE: Backend<B>,
+	BE::State: StateBackend<BlakeTwo256>,
 	I: BlockImport<B, Transaction = sp_api::TransactionFor<C, B>> + Send + Sync,
 	I::Error: Into<ConsensusError>,
-	C: ProvideRuntimeApi<B> + Send + Sync + HeaderBackend<B> + AuxStore + ProvideCache<B> + BlockOf,
+	C: ProvideRuntimeApi<B> + Send + Sync + HeaderBackend<B> + AuxStore + ProvideCache<B> + BlockOf + StorageProvider<B,BE>, 
 	C::Api: BlockBuilderApi<B, Error = sp_blockchain::Error>,
 {
 	pub fn new(
@@ -96,11 +100,13 @@ impl<B, I, C> FrontierBlockImport<B, I, C> where
 	}
 }
 
-impl<B, I, C> BlockImport<B> for FrontierBlockImport<B, I, C> where
+impl<B, I, C, BE> BlockImport<B> for FrontierBlockImport<B, I, C, BE> where
 	B: BlockT,
+	BE: Backend<B>,
+	BE::State: StateBackend<BlakeTwo256>,
 	I: BlockImport<B, Transaction = sp_api::TransactionFor<C, B>> + Send + Sync,
 	I::Error: Into<ConsensusError>,
-	C: ProvideRuntimeApi<B> + Send + Sync + HeaderBackend<B> + AuxStore + ProvideCache<B> + BlockOf,
+	C: ProvideRuntimeApi<B> + Send + Sync + HeaderBackend<B> + AuxStore + ProvideCache<B> + BlockOf + StorageProvider<B,BE>, 
 	C::Api: BlockBuilderApi<B, Error = sp_blockchain::Error>,
 {
 	type Error = ConsensusError;
@@ -145,12 +151,25 @@ impl<B, I, C> BlockImport<B> for FrontierBlockImport<B, I, C> where
 							insert_closure!(),
 						);
 					}
+
+					if let Ok(Some(data)) = self.client.storage(
+						&BlockId::Hash(block.header.hash()),
+						&StorageKey(
+							storage_prefix_build(b"Ethereum", b"CurrentReceipts")
+						)
+					) {
+						aux_schema::write_receipts(block_hash, data.0, insert_closure!());
+					}
 				},
 			}
 		}
 
 		self.inner.import_block(block, new_cache).map_err(Into::into)
 	}
+}
+
+fn storage_prefix_build(module: &[u8], storage: &[u8]) -> Vec<u8> {
+	[twox_128(module), twox_128(storage)].concat().to_vec()
 }
 
 fn find_frontier_log<B: BlockT>(

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -34,13 +34,14 @@ pub enum ConsensusResult {
 			FrontierBlockImport<
 				Block,
 				sc_finality_grandpa::GrandpaBlockImport<FullBackend, Block, FullClient, FullSelectChain>,
-				FullClient
+				FullClient,
+				FullBackend,
 			>,
 			AuraPair
 		>,
 		sc_finality_grandpa::LinkHalf<Block, FullClient, FullSelectChain>
 	),
-	ManualSeal(FrontierBlockImport<Block, Arc<FullClient>, FullClient>)
+	ManualSeal(FrontierBlockImport<Block, Arc<FullClient>, FullClient, FullBackend>)
 }
 
 pub fn new_partial(config: &Configuration, manual_seal: bool) -> Result<


### PR DESCRIPTION
- Bound `StorageProvider` trait to `FrontierBlockImport`.
- On `FrontierBlockImport.import_block`, read `CurrentReceipts` from `pallet-ethereum` and append it to the current block auxiliary storage.