### PR TITLE
Return correct response in `eth_syncing`

### DIFF
--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -106,6 +106,7 @@ pub fn create_full<C, P, BE>(
 			client.clone(),
 			pool.clone(),
 			frontier_template_runtime::TransactionConverter,
+			network.clone(),
 			is_authority,
 		))
 	);


### PR DESCRIPTION
`eth_syncing` was returning a `SyncStatus::Info` no matter what the actual network syncing status was. That is not the way this method works https://eth.wiki/json-rpc/API#eth_syncing. 

 This PR fixes it to return SyncStatus::Info when the network `is_major_syncing`, and false (SyncStatus::None) otherwise.

**Additional note**

I couldn't find a built-in way of pulling the `best_seen_block` from the `NetworkService`, so while this PR fixes the expected response type, the response object still returns incomplete data. https://github.com/paritytech/substrate/issues/7311