### PR TITLE
Decouple Runtime API impls from specific structs

### DIFF
--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -487,7 +487,7 @@ impl_runtime_apis! {
 		}
 
 		fn gas_price() -> U256 {
-			FixedGasPrice::min_gas_price()
+			<Runtime as frame_evm::Trait>::FeeCalculator::min_gas_price()
 		}
 
 		fn account_code_at(address: H160) -> Vec<u8> {

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -479,7 +479,7 @@ impl_runtime_apis! {
 
 	impl frontier_rpc_primitives::EthereumRuntimeRPCApi<Block> for Runtime {
 		fn chain_id() -> u64 {
-			ChainId::get()
+			<Runtime as frame_evm::Trait>::ChainId::get()
 		}
 
 		fn account_basic(address: H160) -> EVMAccount {


### PR DESCRIPTION
This PR changes the implementation of `fn gas_price` to use the `pallet_evm`'s associated type, `FeeCalculator`, rather than the `FixedGasPrice` struct directly. This code is more reuseable because it will not need to change when other `FeeCalculator` implementations are used.

And makes an analogous change to the chainId api.