### PR TITLE
Fix eth_estimateGas and eth_call to match with Ethereum impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,6 +1465,7 @@ dependencies = [
  "pallet-ethereum 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec",
  "rlp",
+ "rustc-hex",
  "sc-client-api",
  "sc-network",
  "sc-rpc",

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -24,7 +24,7 @@
 
 use frame_support::{
 	decl_module, decl_storage, decl_error, decl_event,
-	traits::Get, traits::FindAuthor
+	traits::Get, traits::FindAuthor,
 };
 use sp_std::prelude::*;
 use frame_system::ensure_none;
@@ -48,6 +48,12 @@ mod tests;
 
 #[cfg(all(feature = "std", test))]
 mod mock;
+
+#[derive(Eq, PartialEq, Clone, sp_runtime::RuntimeDebug)]
+pub enum ReturnValue {
+	Bytes(Vec<u8>),
+	Hash(H160),
+}
 
 /// A type alias for the balance type from this pallet's point of view.
 pub type BalanceOf<T> = <T as pallet_balances::Trait>::Balance;
@@ -172,7 +178,7 @@ decl_module! {
 
 #[repr(u8)]
 enum TransactionValidationError {
-	#[allow (dead_code)]
+	#[allow(dead_code)]
 	UnknownError,
 	InvalidChainId,
 	InvalidSignature,
@@ -219,7 +225,6 @@ impl<T: Trait> frame_support::unsigned::ValidateUnsigned for Module<T> {
 }
 
 impl<T: Trait> Module<T> {
-
 	fn recover_signer(transaction: &ethereum::Transaction) -> Option<H160> {
 		let mut sig = [0u8; 65];
 		let mut msg = [0u8; 32];
@@ -321,78 +326,52 @@ impl<T: Trait> Module<T> {
 	}
 
 	/// Execute an Ethereum transaction, ignoring transaction signatures.
-	pub fn execute(source: H160, transaction: ethereum::Transaction) -> DispatchResult {
+	pub fn execute(from: H160, transaction: ethereum::Transaction) -> DispatchResult {
 		let transaction_hash = H256::from_slice(
 			Keccak256::digest(&rlp::encode(&transaction)).as_slice()
 		);
 		let transaction_index = Pending::get().len() as u32;
 
-		let (status, gas_used) = match transaction.action {
-			ethereum::TransactionAction::Call(target) => {
-				let (_, _, gas_used, logs) = Self::handle_exec(
-					pallet_evm::Module::<T>::execute_call(
-						source,
-						target,
-						transaction.input.clone(),
-						transaction.value,
-						transaction.gas_limit.low_u32(),
-						transaction.gas_price,
-						Some(transaction.nonce),
-						true,
-					)?
-				)?;
+		let (exit_reason, returned_value, gas_used, logs) = Self::execute_evm(
+			from,
+			transaction.input.clone(),
+			transaction.value,
+			transaction.gas_limit.low_u32(),
+			transaction.gas_price,
+			Some(transaction.nonce),
+			transaction.action,
+			true,
+		)?;
 
-				(TransactionStatus {
-					transaction_hash,
-					transaction_index,
-					from: source,
-					to: Some(target),
-					contract_address: None,
-					logs: {
-						logs.into_iter()
-						.map(|log| {
-							Log {
-								address: log.address,
-								topics: log.topics,
-								data: log.data
-							}
-						}).collect()
-					},
-					logs_bloom: Bloom::default(), // TODO: feed in bloom.
-				}, gas_used)
-			},
-			ethereum::TransactionAction::Create => {
-				let (_, contract_address, gas_used, logs) = Self::handle_exec(
-					pallet_evm::Module::<T>::execute_create(
-						source,
-						transaction.input.clone(),
-						transaction.value,
-						transaction.gas_limit.low_u32(),
-						transaction.gas_price,
-						Some(transaction.nonce),
-						true,
-					)?
-				)?;
+		Self::handle_exit_reason(exit_reason)?;
 
-				(TransactionStatus {
-					transaction_hash,
-					transaction_index,
-					from: source,
-					to: None,
-					contract_address: Some(contract_address),
-					logs: {
-						logs.into_iter()
-						.map(|log| {
-							Log {
-								address: log.address,
-								topics: log.topics,
-								data: log.data
-							}
-						}).collect()
-					},
-					logs_bloom: Bloom::default(), // TODO: feed in bloom.
-				}, gas_used)
+		let to = match transaction.action {
+			TransactionAction::Create => None,
+			TransactionAction::Call(to) => Some(to)
+		};
+
+		let contract_address = match returned_value {
+			ReturnValue::Bytes(_) => None,
+			ReturnValue::Hash(addr) => Some(addr)
+		};
+
+		let status = TransactionStatus {
+			transaction_hash,
+			transaction_index,
+			from,
+			to,
+			contract_address,
+			logs: {
+				logs.into_iter()
+					.map(|log| {
+						Log {
+							address: log.address,
+							topics: log.topics,
+							data: log.data,
+						}
+					}).collect()
 			},
+			logs_bloom: Bloom::default(), // TODO: feed in bloom.
 		};
 
 		let receipt = ethereum::Receipt {
@@ -407,56 +386,86 @@ impl<T: Trait> Module<T> {
 		Ok(())
 	}
 
+	/// Execute an EVM call or create
 	pub fn call(
-		from: H160,
+		source: H160,
 		data: Vec<u8>,
 		value: U256,
 		gas_limit: u32,
 		gas_price: U256,
 		nonce: Option<U256>,
-		action: TransactionAction
+		action: TransactionAction,
 	) -> Result<(Vec<u8>, U256), (sp_runtime::DispatchError, Vec<u8>)> {
-		let result = match action {
-			TransactionAction::Call(to) => pallet_evm::Module::<T>::execute_call(
-				from,
-				to,
+		let (exit_reason, returned_value, gas_used, _) = Self::execute_evm(
+			source,
+			data,
+			value,
+			gas_limit,
+			gas_price,
+			nonce,
+			action,
+			false,
+		).map_err(|err| (err.into(), Vec::new()))?;
+
+		let returned_value = match returned_value.clone() {
+			ReturnValue::Bytes(data) => data,
+			ReturnValue::Hash(_) => Vec::new()
+		};
+
+		Self::handle_exit_reason(exit_reason)
+			.map_err(|err| (err.into(), returned_value.clone()))?;
+
+		Ok((returned_value, gas_used))
+	}
+}
+
+impl<T: Trait> Module<T> {
+	fn execute_evm(
+		source: H160,
+		data: Vec<u8>,
+		value: U256,
+		gas_limit: u32,
+		gas_price: U256,
+		nonce: Option<U256>,
+		action: TransactionAction,
+		apply_state: bool,
+	) -> Result<(ExitReason, ReturnValue, U256, Vec<pallet_evm::Log>), pallet_evm::Error<T>> {
+		match action {
+			TransactionAction::Call(target) => pallet_evm::Module::<T>::execute_call(
+				source,
+				target,
 				data,
 				value,
 				gas_limit,
 				gas_price,
 				nonce,
-				false
-			),
+				apply_state,
+			).map(|(exit_reason, returned_value, gas_used, logs)| {
+				(exit_reason, ReturnValue::Bytes(returned_value), gas_used, logs)
+			}),
 			TransactionAction::Create => pallet_evm::Module::<T>::execute_create(
-				from,
+				source,
 				data,
 				value,
 				gas_limit,
 				gas_price,
 				nonce,
-				false
-			).map(|(reason, _, gas_used, logs)| (reason, Vec::new(), gas_used, logs)),
-		}.map_err(|err| (err.into(), Vec::new()))?;
-
-		let returned_value = result.1.clone();
-
-		Self::handle_exec(result)
-			.map(|(_, returned_value, gas_used, _)| (returned_value, gas_used))
-			.map_err(|err| {
-				(err.into(), returned_value)
+				apply_state,
+			).map(|(exit_reason, returned_value, gas_used, logs)| {
+				(exit_reason, ReturnValue::Hash(returned_value), gas_used, logs)
 			})
+		}
 	}
 
-	fn handle_exec<R>(res: (ExitReason, R, U256, Vec<pallet_evm::Log>))
-		-> Result<(ExitReason, R, U256, Vec<pallet_evm::Log>), Error<T>> {
-		match res.0 {
-			ExitReason::Succeed(_s) => Ok(res),
+	fn handle_exit_reason(exit_reason: ExitReason) -> Result<(), Error<T>> {
+		match exit_reason {
+			ExitReason::Succeed(_s) => Ok(()),
 			ExitReason::Error(e) => Err(Self::parse_exit_error(e)),
 			ExitReason::Revert(e) => {
 				match e {
 					ExitRevert::Reverted => Err(Error::<T>::Reverted),
 				}
-			},
+			}
 			ExitReason::Fatal(e) => {
 				match e {
 					ExitFatal::NotSupported => Err(Error::<T>::NotSupported),
@@ -464,26 +473,26 @@ impl<T: Trait> Module<T> {
 					ExitFatal::CallErrorAsFatal(e_error) => Err(Self::parse_exit_error(e_error)),
 					ExitFatal::Other(_s) => Err(Error::<T>::ExitFatalOther),
 				}
-			},
+			}
 		}
 	}
 
 	fn parse_exit_error(exit_error: ExitError) -> Error<T> {
 		match exit_error {
-			ExitError::StackUnderflow => return Error::<T>::StackUnderflow,
-			ExitError::StackOverflow => return Error::<T>::StackOverflow,
-			ExitError::InvalidJump => return Error::<T>::InvalidJump,
-			ExitError::InvalidRange => return Error::<T>::InvalidRange,
-			ExitError::DesignatedInvalid => return Error::<T>::DesignatedInvalid,
-			ExitError::CallTooDeep => return Error::<T>::CallTooDeep,
-			ExitError::CreateCollision => return Error::<T>::CreateCollision,
-			ExitError::CreateContractLimit => return Error::<T>::CreateContractLimit,
-			ExitError::OutOfOffset => return Error::<T>::OutOfOffset,
-			ExitError::OutOfGas => return Error::<T>::OutOfGas,
-			ExitError::OutOfFund => return Error::<T>::OutOfFund,
-			ExitError::PCUnderflow => return Error::<T>::PCUnderflow,
-			ExitError::CreateEmpty => return Error::<T>::CreateEmpty,
-			ExitError::Other(_s) => return Error::<T>::ExitErrorOther,
+			ExitError::StackUnderflow => Error::<T>::StackUnderflow,
+			ExitError::StackOverflow => Error::<T>::StackOverflow,
+			ExitError::InvalidJump => Error::<T>::InvalidJump,
+			ExitError::InvalidRange => Error::<T>::InvalidRange,
+			ExitError::DesignatedInvalid => Error::<T>::DesignatedInvalid,
+			ExitError::CallTooDeep => Error::<T>::CallTooDeep,
+			ExitError::CreateCollision => Error::<T>::CreateCollision,
+			ExitError::CreateContractLimit => Error::<T>::CreateContractLimit,
+			ExitError::OutOfOffset => Error::<T>::OutOfOffset,
+			ExitError::OutOfGas => Error::<T>::OutOfGas,
+			ExitError::OutOfFund => Error::<T>::OutOfFund,
+			ExitError::PCUnderflow => Error::<T>::PCUnderflow,
+			ExitError::CreateEmpty => Error::<T>::CreateEmpty,
+			ExitError::Other(_s) => Error::<T>::ExitErrorOther,
 		}
 	}
 }

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -416,14 +416,21 @@ impl<T: Trait> Module<T> {
 		gas_price: U256,
 		nonce: Option<U256>,
 	) -> Result<(Vec<u8>, U256), (sp_runtime::DispatchError, Vec<u8>)> {
-		let result = pallet_evm::Module::<T>::execute_call(from, to, data, value, gas_limit, gas_price, nonce, false)
-			.map(|(reason, retv, gas, logs)| (reason, retv, gas, logs))
-			.map_err(|err| (err.into(), Vec::new()))?;
+		let result = pallet_evm::Module::<T>::execute_call(
+			from,
+			to,
+			data,
+			value,
+			gas_limit,
+			gas_price,
+			nonce,
+			false
+		).map_err(|err| (err.into(), Vec::new()))?;
 
 		let returned_value = result.1.clone();
 
 		Self::handle_exec::<Vec<u8>>(result)
-			.map(|(_, retv, gas_used, _)| (retv, gas_used))
+			.map(|(_, returned_value, gas_used, _)| (returned_value, gas_used))
 			.map_err(|err| {
 				(err.into(), returned_value)
 			})

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -407,26 +407,26 @@ impl<T: Trait> Module<T> {
 		Ok(())
 	}
 
-	/// Estimate gas needed to execute Ethereum transaction.
-	pub fn estimate_gas(
-		source: H160,
+	pub fn call(
+		from: H160,
+		to: H160,
 		data: Vec<u8>,
 		value: U256,
 		gas_limit: u32,
 		gas_price: U256,
 		nonce: Option<U256>,
-		action: ethereum::TransactionAction
-	) -> Result<U256, (sp_runtime::DispatchError, Vec<u8>)> {
-		let result = match action {
-			ethereum::TransactionAction::Call(target) => pallet_evm::Module::<T>::execute_call(source, target, data, value, gas_limit, gas_price, nonce, false),
-			ethereum::TransactionAction::Create => pallet_evm::Module::<T>::execute_create(source, data, value, gas_limit, gas_price, nonce, false).map(|(reason, _, gas, logs)| (reason, Vec::new(), gas, logs))
-		}.map_err(|err| (err.into(), Vec::new()))?;
+	) -> Result<(Vec<u8>, U256), (sp_runtime::DispatchError, Vec<u8>)> {
+		let result = pallet_evm::Module::<T>::execute_call(from, to, data, value, gas_limit, gas_price, nonce, false)
+			.map(|(reason, retv, gas, logs)| (reason, retv, gas, logs))
+			.map_err(|err| (err.into(), Vec::new()))?;
 
 		let returned_value = result.1.clone();
 
 		Self::handle_exec::<Vec<u8>>(result)
-			.map(|(_, _, gas, _)| gas)
-			.map_err(|err| (err.into(), returned_value))
+			.map(|(_, retv, gas_used, _)| (retv, gas_used))
+			.map_err(|err| {
+				(err.into(), returned_value)
+			})
 	}
 
 	fn handle_exec<R>(res: (ExitReason, R, U256, Vec<pallet_evm::Log>))

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -32,3 +32,4 @@ rlp = "0.4"
 pallet-ethereum = "0.1"
 futures = { version = "0.3.1", features = ["compat"] }
 sha3 = "0.8"
+rustc-hex = { version = "2.1.0", default-features = false }

--- a/rpc/core/src/types/call_request.rs
+++ b/rpc/core/src/types/call_request.rs
@@ -26,7 +26,7 @@ pub struct CallRequest {
 	/// From
 	pub from: Option<H160>,
 	/// To
-	pub to: H160,
+	pub to: Option<H160>,
 	/// Gas Price
 	pub gas_price: Option<U256>,
 	/// Gas

--- a/rpc/core/src/types/call_request.rs
+++ b/rpc/core/src/types/call_request.rs
@@ -26,7 +26,7 @@ pub struct CallRequest {
 	/// From
 	pub from: Option<H160>,
 	/// To
-	pub to: Option<H160>,
+	pub to: H160,
 	/// Gas Price
 	pub gas_price: Option<U256>,
 	/// Gas

--- a/rpc/primitives/src/lib.rs
+++ b/rpc/primitives/src/lib.rs
@@ -18,7 +18,7 @@
 
 use sp_core::{H160, H256, U256};
 use ethereum::{
-	Log, Block as EthereumBlock
+	Log, Block as EthereumBlock, TransactionAction
 };
 use ethereum_types::Bloom;
 use codec::{Encode, Decode};
@@ -64,15 +64,15 @@ sp_api::decl_runtime_apis! {
 		fn author() -> H160;
 		/// For a given account address and index, returns pallet_evm::AccountStorages.
 		fn storage_at(address: H160, index: U256) -> H256;
-		/// Returns a frame_ethereum::call response be use by eth_call and eth_estimateGas
+		/// Returns a frame_ethereum::call response to be use by eth_call and eth_estimateGas
 		fn call(
 			from: H160,
-			to: H160,
 			data: Vec<u8>,
 			value: U256,
 			gas_limit: U256,
 			gas_price: Option<U256>,
-			nonce: Option<U256>
+			nonce: Option<U256>,
+			action: TransactionAction
 		) -> Result<(Vec<u8>, U256), (sp_runtime::DispatchError, Vec<u8>)>;
 		/// Return the current block.
 		fn current_block() -> Option<EthereumBlock>;

--- a/rpc/primitives/src/lib.rs
+++ b/rpc/primitives/src/lib.rs
@@ -18,7 +18,7 @@
 
 use sp_core::{H160, H256, U256};
 use ethereum::{
-	Log, Block as EthereumBlock, TransactionAction
+	Log, Block as EthereumBlock, TransactionAction,
 };
 use ethereum_types::Bloom;
 use codec::{Encode, Decode};
@@ -64,7 +64,7 @@ sp_api::decl_runtime_apis! {
 		fn author() -> H160;
 		/// For a given account address and index, returns pallet_evm::AccountStorages.
 		fn storage_at(address: H160, index: U256) -> H256;
-		/// Returns a frame_ethereum::call response to be use by eth_call and eth_estimateGas
+		/// Returns a frame_ethereum::call response.
 		fn call(
 			from: H160,
 			data: Vec<u8>,

--- a/rpc/primitives/src/lib.rs
+++ b/rpc/primitives/src/lib.rs
@@ -64,6 +64,16 @@ sp_api::decl_runtime_apis! {
 		fn author() -> H160;
 		/// For a given account address and index, returns pallet_evm::AccountStorages.
 		fn storage_at(address: H160, index: U256) -> H256;
+		/// Returns gas needed to execute transaction.
+		fn estimate_gas(
+			from: H160,
+			data: Vec<u8>,
+			value: U256,
+			gas_limit: U256,
+			gas_price: Option<U256>,
+			nonce: Option<U256>,
+			action: TransactionAction
+		) -> Result<U256, (sp_runtime::DispatchError, Vec<u8>)>;
 		/// Returns a pallet_evm::execute_call response.
 		fn call(
 			from: H160,

--- a/rpc/primitives/src/lib.rs
+++ b/rpc/primitives/src/lib.rs
@@ -18,7 +18,7 @@
 
 use sp_core::{H160, H256, U256};
 use ethereum::{
-	Log, Block as EthereumBlock, TransactionAction
+	Log, Block as EthereumBlock
 };
 use ethereum_types::Bloom;
 use codec::{Encode, Decode};
@@ -64,26 +64,16 @@ sp_api::decl_runtime_apis! {
 		fn author() -> H160;
 		/// For a given account address and index, returns pallet_evm::AccountStorages.
 		fn storage_at(address: H160, index: U256) -> H256;
-		/// Returns gas needed to execute transaction.
-		fn estimate_gas(
-			from: H160,
-			data: Vec<u8>,
-			value: U256,
-			gas_limit: U256,
-			gas_price: Option<U256>,
-			nonce: Option<U256>,
-			action: TransactionAction
-		) -> Result<U256, (sp_runtime::DispatchError, Vec<u8>)>;
-		/// Returns a pallet_evm::execute_call response.
+		/// Returns a frame_ethereum::call response be use by eth_call and eth_estimateGas
 		fn call(
 			from: H160,
+			to: H160,
 			data: Vec<u8>,
 			value: U256,
 			gas_limit: U256,
 			gas_price: Option<U256>,
-			nonce: Option<U256>,
-			action: TransactionAction
-		) -> Result<(Vec<u8>, U256), sp_runtime::DispatchError>;
+			nonce: Option<U256>
+		) -> Result<(Vec<u8>, U256), (sp_runtime::DispatchError, Vec<u8>)>;
 		/// Return the current block.
 		fn current_block() -> Option<EthereumBlock>;
 		/// Return the current receipt.

--- a/rpc/src/eth.rs
+++ b/rpc/src/eth.rs
@@ -491,16 +491,21 @@ impl<B, C, P, CT, BE> EthApiT for EthApi<B, C, P, CT, BE> where
 		let gas_limit = gas.unwrap_or(U256::max_value());
 		let data = data.map(|d| d.0).unwrap_or_default();
 
+		let action = match to {
+			Some(to) => ethereum::TransactionAction::Call(to),
+			_ => ethereum::TransactionAction::Create,
+		};
+
 		let (ret, _) = self.client.runtime_api()
 			.call(
 				&BlockId::Hash(hash),
 				from.unwrap_or_default(),
-				to,
 				data,
 				value.unwrap_or_default(),
 				gas_limit,
 				gas_price,
-				nonce
+				nonce,
+				action
 			)
 			.map_err(|err| internal_err(format!("internal error: {:?}", err)))?
 			.map_err(handle_call_error)?;
@@ -524,16 +529,21 @@ impl<B, C, P, CT, BE> EthApiT for EthApi<B, C, P, CT, BE> where
 		let gas_limit = gas.unwrap_or(U256::max_value());
 		let data = data.map(|d| d.0).unwrap_or_default();
 
+		let action = match to {
+			Some(to) => ethereum::TransactionAction::Call(to),
+			_ => ethereum::TransactionAction::Create,
+		};
+
 		let (_, used_gas) = self.client.runtime_api()
 			.call(
 				&BlockId::Hash(hash),
 				from.unwrap_or_default(),
-				to,
 				data,
 				value.unwrap_or_default(),
 				gas_limit,
 				gas_price,
-				nonce
+				nonce,
+				action
 			)
 			.map_err(|err| internal_err(format!("internal error: {:?}", err)))?
 			.map_err(handle_call_error)?;

--- a/rpc/src/eth.rs
+++ b/rpc/src/eth.rs
@@ -488,7 +488,7 @@ impl<B, C, P, CT, BE> EthApiT for EthApi<B, C, P, CT, BE> where
 			nonce
 		} = request;
 
-		let gas_limit = gas.unwrap_or(U256::max_value());
+		let gas_limit = gas.unwrap_or(U256::max_value()); // TODO: set a limit
 		let data = data.map(|d| d.0).unwrap_or_default();
 
 		let action = match to {
@@ -526,7 +526,7 @@ impl<B, C, P, CT, BE> EthApiT for EthApi<B, C, P, CT, BE> where
 			nonce
 		} = request;
 
-		let gas_limit = gas.unwrap_or(U256::max_value());
+		let gas_limit = gas.unwrap_or(U256::max_value()); // TODO: set a limit
 		let data = data.map(|d| d.0).unwrap_or_default();
 
 		let action = match to {

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -20,12 +20,20 @@ mod eth_pubsub;
 pub use eth::{EthApi, EthApiServer, NetApi, NetApiServer};
 pub use eth_pubsub::{EthPubSubApi, EthPubSubApiServer};
 
-use jsonrpc_core::{ErrorCode, Error};
+use jsonrpc_core::{ErrorCode, Error, Value};
 
 pub fn internal_err<T: ToString>(message: T) -> Error {
 	Error {
 		code: ErrorCode::InternalError,
 		message: message.to_string(),
 		data: None
+	}
+}
+
+pub fn execution_err<T: ToString>(message: T, data: Option<Value>) -> Error {
+	Error {
+		code: ErrorCode::InternalError,
+		message: message.to_string(),
+		data,
 	}
 }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -21,7 +21,7 @@ pub use eth::{EthApi, EthApiServer, NetApi, NetApiServer};
 pub use eth_pubsub::{EthPubSubApi, EthPubSubApiServer};
 
 use jsonrpc_core::{ErrorCode, Error, Value};
-use sp_runtime::{DispatchError, app_crypto::sp_core::bytes::to_hex};
+use rustc_hex::ToHex;
 
 pub fn internal_err<T: ToString>(message: T) -> Error {
 	Error {
@@ -31,14 +31,13 @@ pub fn internal_err<T: ToString>(message: T) -> Error {
 	}
 }
 
-pub fn handle_call_error((err, data): (DispatchError, Vec<u8>)) -> Error {
+pub fn handle_call_error((err, data): (sp_runtime::DispatchError, Vec<u8>)) -> Error {
 	let error: &'static str = err.into();
 	// TODO: trim error message
 	let msg = String::from_utf8_lossy(&data);
-	let data = to_hex(&data, true);
 	Error {
 		code: ErrorCode::InternalError,
 		message: format!("{}: {}", error.to_lowercase(), msg),
-		data: Some(Value::String(data))
+		data: Some(Value::String(data.to_hex()))
 	}
 }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -21,6 +21,7 @@ pub use eth::{EthApi, EthApiServer, NetApi, NetApiServer};
 pub use eth_pubsub::{EthPubSubApi, EthPubSubApiServer};
 
 use jsonrpc_core::{ErrorCode, Error, Value};
+use sp_runtime::{DispatchError, app_crypto::sp_core::bytes::to_hex};
 
 pub fn internal_err<T: ToString>(message: T) -> Error {
 	Error {
@@ -30,10 +31,14 @@ pub fn internal_err<T: ToString>(message: T) -> Error {
 	}
 }
 
-pub fn execution_err<T: ToString>(message: T, data: Option<Value>) -> Error {
+pub fn handle_call_error((err, data): (DispatchError, Vec<u8>)) -> Error {
+	let error: &'static str = err.into();
+	// TODO: trim error message
+	let msg = String::from_utf8_lossy(&data);
+	let data = to_hex(&data, true);
 	Error {
 		code: ErrorCode::InternalError,
-		message: message.to_string(),
-		data,
+		message: format!("{}: {}", error.to_lowercase(), msg),
+		data: Some(Value::String(data))
 	}
 }

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -504,54 +504,16 @@ impl_runtime_apis! {
 			EVM::account_storages(address, H256::from_slice(&tmp[..]))
 		}
 
-		fn estimate_gas(
-			from: H160,
-			data: Vec<u8>,
-			value: U256,
-			gas_limit: U256,
-			gas_price: Option<U256>,
-			nonce: Option<U256>,
-			action: frame_ethereum::TransactionAction
-		) -> Result<U256, (sp_runtime::DispatchError, Vec<u8>)> {
-			<frame_ethereum::Module<Runtime>>::estimate_gas(from, data, value, gas_limit.low_u32(), gas_price.unwrap_or_default(), nonce, action)
-		}
-
 		fn call(
 			from: H160,
+			to: H160,
 			data: Vec<u8>,
 			value: U256,
 			gas_limit: U256,
 			gas_price: Option<U256>,
-			nonce: Option<U256>,
-			action: frame_ethereum::TransactionAction,
-		) -> Result<(Vec<u8>, U256), sp_runtime::DispatchError> {
-			match action {
-				frame_ethereum::TransactionAction::Call(to) =>
-					EVM::execute_call(
-						from,
-						to,
-						data,
-						value,
-						gas_limit.low_u32(),
-						gas_price.unwrap_or_default(),
-						nonce,
-						false,
-					)
-					.map(|(_, ret, gas, _)| (ret, gas))
-					.map_err(|err| err.into()),
-				frame_ethereum::TransactionAction::Create =>
-					EVM::execute_create(
-						from,
-						data,
-						value,
-						gas_limit.low_u32(),
-						gas_price.unwrap_or_default(),
-						nonce,
-						false,
-					)
-					.map(|(_, _, gas, _)| (vec![], gas))
-					.map_err(|err| err.into()),
-			}
+			nonce: Option<U256>
+		) -> Result<(Vec<u8>, U256), (sp_runtime::DispatchError, Vec<u8>)> {
+			<frame_ethereum::Module<Runtime>>::call(from, to, data, value, gas_limit.low_u32(), gas_price.unwrap_or_default(), nonce)
 		}
 
 		fn current_transaction_statuses() -> Option<Vec<TransactionStatus>> {

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -504,6 +504,18 @@ impl_runtime_apis! {
 			EVM::account_storages(address, H256::from_slice(&tmp[..]))
 		}
 
+		fn estimate_gas(
+			from: H160,
+			data: Vec<u8>,
+			value: U256,
+			gas_limit: U256,
+			gas_price: Option<U256>,
+			nonce: Option<U256>,
+			action: frame_ethereum::TransactionAction
+		) -> Result<U256, (sp_runtime::DispatchError, Vec<u8>)> {
+			<frame_ethereum::Module<Runtime>>::estimate_gas(from, data, value, gas_limit.low_u32(), gas_price.unwrap_or_default(), nonce, action)
+		}
+
 		fn call(
 			from: H160,
 			data: Vec<u8>,

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -506,14 +506,14 @@ impl_runtime_apis! {
 
 		fn call(
 			from: H160,
-			to: H160,
 			data: Vec<u8>,
 			value: U256,
 			gas_limit: U256,
 			gas_price: Option<U256>,
-			nonce: Option<U256>
+			nonce: Option<U256>,
+			action: frame_ethereum::TransactionAction
 		) -> Result<(Vec<u8>, U256), (sp_runtime::DispatchError, Vec<u8>)> {
-			<frame_ethereum::Module<Runtime>>::call(from, to, data, value, gas_limit.low_u32(), gas_price.unwrap_or_default(), nonce)
+			<frame_ethereum::Module<Runtime>>::call(from, data, value, gas_limit.low_u32(), gas_price.unwrap_or_default(), nonce, action)
 		}
 
 		fn current_transaction_statuses() -> Option<Vec<TransactionStatus>> {


### PR DESCRIPTION
This PR fixes RPC call `eth_estimateGas` and `eth_call` to handle exit reason and returned value. Error message will include the returned value like Ethereum. I also did some refactoring.