### PR TITLE
Attempt to provide default implementation

### DIFF
--- a/rpc/primitives/src/lib.rs
+++ b/rpc/primitives/src/lib.rs
@@ -85,7 +85,13 @@ sp_api::decl_runtime_apis! {
 			Option<EthereumBlock>,
 			Option<Vec<ethereum::Receipt>>,
 			Option<Vec<TransactionStatus>>
-		);
+		) {
+			(
+				Self::current_block(),
+				Self::current_receipts(),
+				Self::current_transaction_statuses(),
+			)
+		}
 	}
 }
 

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -527,18 +527,6 @@ impl_runtime_apis! {
 		fn current_receipts() -> Option<Vec<frame_ethereum::Receipt>> {
 			Ethereum::current_receipts()
 		}
-
-		fn current_all() -> (
-			Option<frame_ethereum::Block>,
-			Option<Vec<frame_ethereum::Receipt>>,
-			Option<Vec<TransactionStatus>>
-		) {
-			(
-				Ethereum::current_block(),
-				Ethereum::current_receipts(),
-				Ethereum::current_transaction_statuses()
-			)
-		}
 	}
 
 	impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<


### PR DESCRIPTION
This PR attempts to provide a [default implementation](https://doc.rust-lang.org/stable/book/ch10-02-traits.html#default-implementations) of the function `frontier_rpc_primitives::EthereumRuntimeRPCApi::current_all`.

The trait definition compiles fine, but the runtime that implements it does not.

```
error[E0046]: not all trait items implemented, missing: `EthereumRuntimeRPCApi_current_all_runtime_api_impl`
   --> template/runtime/src/lib.rs:480:2
    |
480 |     impl frontier_rpc_primitives::EthereumRuntimeRPCApi<Block> for Runtime {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `EthereumRuntimeRPCApi_current_all_runtime_api_impl` in implementation
    |
    = help: implement the missing item: `fn EthereumRuntimeRPCApi_current_all_runtime_api_impl(&self, _: &sp_api::BlockId<Block>, _: ExecutionContext, _: std::option::Option<()>, _: std::vec::Vec<u8>) -> std::result::Result<NativeOrEncoded<(std::option::Option<pallet_ethereum::Block>, std::option::Option<std::vec::Vec<Receipt>>, std::option::Option<std::vec::Vec<frontier_rpc_primitives::TransactionStatus>>)>, <Self as ApiErrorExt>::Error> { todo!() }`

error: aborting due to previous error
```

@thiolliere Do `impl_runtime_apis!` and `decl_runtime_apis!` support methods with default implementations? Or can they?