### PR TITLE
Support instant sealing

### DIFF
--- a/template/node/src/cli.rs
+++ b/template/node/src/cli.rs
@@ -15,7 +15,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use structopt::StructOpt;
+use structopt::{StructOpt, clap::arg_enum};
+
+arg_enum! {
+	/// Available Sealing methods.
+	#[allow(missing_docs)]
+	#[derive(Debug, Copy, Clone, StructOpt)]
+	pub enum Sealing {
+		// Seal using rpc method.
+		Manual,
+		// Seal when transaction is executed.
+		Instant,
+	}
+}
 
 #[allow(missing_docs)]
 #[derive(Debug, StructOpt)]
@@ -25,8 +37,8 @@ pub struct RunCmd {
 	pub base: sc_cli::RunCmd,
 
 	/// Force using Kusama native runtime.
-	#[structopt(long = "manual-seal")]
-	pub manual_seal: bool,
+	#[structopt(long = "sealing")]
+	pub sealing: Option<Sealing>,
 }
 
 #[derive(Debug, StructOpt)]

--- a/template/node/src/command.rs
+++ b/template/node/src/command.rs
@@ -75,7 +75,7 @@ pub fn run() -> sc_cli::Result<()> {
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {
 				let PartialComponents { client, task_manager, import_queue, ..}
-					= new_partial(&config, cli.run.manual_seal)?;
+					= new_partial(&config, cli.run.sealing)?;
 				Ok((cmd.run(client, import_queue), task_manager))
 			})
 		},
@@ -83,7 +83,7 @@ pub fn run() -> sc_cli::Result<()> {
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {
 				let PartialComponents { client, task_manager, ..}
-					= new_partial(&config, cli.run.manual_seal)?;
+					= new_partial(&config, cli.run.sealing)?;
 				Ok((cmd.run(client, config.database), task_manager))
 			})
 		},
@@ -91,7 +91,7 @@ pub fn run() -> sc_cli::Result<()> {
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {
 				let PartialComponents { client, task_manager, ..}
-					= new_partial(&config, cli.run.manual_seal)?;
+					= new_partial(&config, cli.run.sealing)?;
 				Ok((cmd.run(client, config.chain_spec), task_manager))
 			})
 		},
@@ -99,7 +99,7 @@ pub fn run() -> sc_cli::Result<()> {
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {
 				let PartialComponents { client, task_manager, import_queue, ..}
-					= new_partial(&config, cli.run.manual_seal)?;
+					= new_partial(&config, cli.run.sealing)?;
 				Ok((cmd.run(client, import_queue), task_manager))
 			})
 		},
@@ -111,7 +111,7 @@ pub fn run() -> sc_cli::Result<()> {
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {
 				let PartialComponents { client, task_manager, backend, ..}
-					= new_partial(&config, cli.run.manual_seal)?;
+					= new_partial(&config, cli.run.sealing)?;
 				Ok((cmd.run(client, backend), task_manager))
 			})
 		},
@@ -119,7 +119,7 @@ pub fn run() -> sc_cli::Result<()> {
 			let runner = cli.create_runner(&cli.run.base)?;
 			runner.run_node_until_exit(|config| match config.role {
 				Role::Light => service::new_light(config),
-				_ => service::new_full(config, cli.run.manual_seal),
+				_ => service::new_full(config, cli.run.sealing),
 			})
 		}
 	}

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -16,7 +16,6 @@ use sc_finality_grandpa::{
 };
 use sp_timestamp::InherentError;
 use crate::cli::Sealing;
-use std::time::SystemTime;
 
 // Our native executor instance.
 native_executor_instance!(
@@ -65,15 +64,7 @@ impl ProvideInherentData for MockInherentDataProvider {
 		inherent_data: &mut InherentData,
 	) -> Result<(), sp_inherents::Error> {
 		unsafe {
-			if CURRENT_TIMESTAMP == 0 {
-				let now = SystemTime::now()
-					.duration_since(SystemTime::UNIX_EPOCH)
-					.unwrap()
-					.as_millis() as u64;
-				CURRENT_TIMESTAMP = now;
-			} else {
-				CURRENT_TIMESTAMP += SLOT_DURATION;
-			}
+			CURRENT_TIMESTAMP += SLOT_DURATION;
 			inherent_data.put_data(INHERENT_IDENTIFIER, &CURRENT_TIMESTAMP)
 		}
 	}

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -47,9 +47,8 @@ pub enum ConsensusResult {
 
 pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"timstap0";
 
-/// Provide a mock duration since unix epoch in millisecond for timestamp inherent.
-/// First call will return current timestamp and others calls with increment
-/// it by slot_duration to make Aura think time has passed
+/// Provide a mock duration starting at 0 in millisecond for timestamp inherent.
+/// Each call will increment timestamp by slot_duration making Aura think time has passed.
 pub struct MockInherentDataProvider;
 
 static mut CURRENT_TIMESTAMP: u64 = 0;

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -94,7 +94,7 @@ pub fn new_partial(config: &Configuration, sealing: Option<Sealing>) -> Result<
 		client.clone(),
 	);
 
-	if sealing.is_some() {
+	if let Some(sealing) = sealing {
 		inherent_data_providers
 			.register_provider(MockTimestampInherentDataProvider)
 			.map_err(Into::into)
@@ -115,7 +115,7 @@ pub fn new_partial(config: &Configuration, sealing: Option<Sealing>) -> Result<
 		return Ok(sc_service::PartialComponents {
 			client, backend, task_manager, import_queue, keystore, select_chain, transaction_pool,
 			inherent_data_providers,
-			other: ConsensusResult::ManualSeal(frontier_block_import, sealing.expect("already checked above"))
+			other: ConsensusResult::ManualSeal(frontier_block_import, sealing)
 		})
 	}
 

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -292,7 +292,7 @@ pub fn new_full(config: Configuration, sealing: Option<Sealing>) -> Result<TaskM
 							}
 						);
 						// we spawn the future on a background thread managed by service.
-						task_manager.spawn_essential_handle().spawn_blocking("manual-seal", authorship_future);
+						task_manager.spawn_essential_handle().spawn_blocking("instant-seal", authorship_future);
 					}
 				};
 

--- a/ts-tests/tests/test-block.ts
+++ b/ts-tests/tests/test-block.ts
@@ -32,7 +32,7 @@ describeWithFrontier("Frontier RPC (Block)", `simple-specs.json`, (context) => {
 			receiptsRoot: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
 			size: 533,
 			stateRoot: "0x0000000000000000000000000000000000000000000000000000000000000000",
-			//timestamp: 1595012243836,
+			timestamp: 0,
 			totalDifficulty: null,
 			//transactions: [],
 			transactionsRoot: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
@@ -60,10 +60,7 @@ describeWithFrontier("Frontier RPC (Block)", `simple-specs.json`, (context) => {
 
 	step("should have valid timestamp after block production", async function () {
 		const block = await context.web3.eth.getBlock("latest");
-		const last5Minutes = (Date.now() / 1000) - 300;
-		const next5Minutes = (Date.now() / 1000) + 300;
-		expect(block.timestamp).to.be.least(last5Minutes);
-		expect(block.timestamp).to.be.below(next5Minutes);
+		expect(block.timestamp).to.be.eq(6);
 	});
 
 	step("retrieve block information", async function () {
@@ -83,9 +80,9 @@ describeWithFrontier("Frontier RPC (Block)", `simple-specs.json`, (context) => {
 			number: 1,
 			//parentHash: "0x04540257811b46d103d9896e7807040e7de5080e285841c5430d1a81588a0ce4",
 			receiptsRoot: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
-			size: 539,
+			size: 535,
 			stateRoot: "0x0000000000000000000000000000000000000000000000000000000000000000",
-			//timestamp: 1595012243836,
+			timestamp: 6,
 			totalDifficulty: null,
 			//transactions: [],
 			transactionsRoot: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",

--- a/ts-tests/tests/util.ts
+++ b/ts-tests/tests/util.ts
@@ -55,7 +55,7 @@ export async function startFrontierNode(specFilename: string): Promise<{ web3: W
 		`--execution=Native`, // Faster execution using native
 		`--no-telemetry`,
 		`--no-prometheus`,
-		`--manual-seal`,
+		`--sealing=Manual`,
 		`--no-grandpa`,
 		`--force-authoring`,
 		`-l${FRONTIER_LOG}`,


### PR DESCRIPTION
Add support instant sealing which is useful for testing contracts.

NOTE: Although I creating a MockProvider to make waffle works, I still have to add a little delay (0.1s) between transaction to make it work but it's better then 6s