### PR TITLE
Pending nonce

### DIFF
--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -31,7 +31,7 @@ use frame_system::ensure_none;
 use ethereum_types::{H160, H64, H256, U256, Bloom};
 use sp_runtime::{
 	transaction_validity::{
-		TransactionValidity, TransactionSource, ValidTransaction, InvalidTransaction,
+		TransactionValidity, TransactionSource, InvalidTransaction, ValidTransactionBuilder,
 	},
 	generic::DigestItem, traits::UniqueSaturatedInto, DispatchError,
 };
@@ -256,8 +256,8 @@ impl<T: Trait> frame_support::unsigned::ValidateUnsigned for Module<T> {
 				return InvalidTransaction::Payment.into();
 			}
 
-			let mut builder = ValidTransaction::with_tag_prefix("Ethereum")
-				.and_provides((&origin, transaction.nonce));
+			let mut builder = ValidTransactionBuilder::default()
+				.and_provides((origin, transaction.nonce));
 
 			if transaction.nonce > account_data.nonce {
 				if let Some(prev_nonce) = transaction.nonce.checked_sub(1.into()) {

--- a/frame/ethereum/src/tests.rs
+++ b/frame/ethereum/src/tests.rs
@@ -98,9 +98,9 @@ fn transaction_with_invalid_nonce_should_not_work() {
 
 		assert_eq!(
 			Ethereum::validate_unsigned(TransactionSource::External, &Call::transact(signed)),
-			ValidTransaction::with_tag_prefix("Ethereum")
-				.and_provides((&alice.address, U256::from(1)))
-				.and_requires((&alice.address, U256::from(0)))
+			ValidTransactionBuilder::default()
+				.and_provides((alice.address, U256::from(1)))
+				.and_requires((alice.address, U256::from(0)))
 				.build()
 		);
 

--- a/ts-tests/tests/test-nonce.ts
+++ b/ts-tests/tests/test-nonce.ts
@@ -3,10 +3,6 @@ import { step } from "mocha-steps";
 
 import { createAndFinalizeBlock, describeWithFrontier, customRequest } from "./util";
 
-const delay = () => new Promise((resolve) => {
-	setTimeout(resolve, 1000);
-})
-
 describeWithFrontier("Frontier RPC (Nonce)", `simple-specs.json`, (context) => {
 	const GENESIS_ACCOUNT = "0x6be02d1d3665660d22ff9624b7be0551ee1ac91b";
 	const GENESIS_ACCOUNT_PRIVATE_KEY = "0x99B3C12287537E38C90A9219D4CB074A89A16E9CDB20BF85728EBD97C343E342";

--- a/ts-tests/tests/test-nonce.ts
+++ b/ts-tests/tests/test-nonce.ts
@@ -1,0 +1,38 @@
+import { expect } from "chai";
+import { step } from "mocha-steps";
+
+import { createAndFinalizeBlock, describeWithFrontier, customRequest } from "./util";
+
+const delay = () => new Promise((resolve) => {
+	setTimeout(resolve, 1000);
+})
+
+describeWithFrontier("Frontier RPC (Nonce)", `simple-specs.json`, (context) => {
+	const GENESIS_ACCOUNT = "0x6be02d1d3665660d22ff9624b7be0551ee1ac91b";
+	const GENESIS_ACCOUNT_PRIVATE_KEY = "0x99B3C12287537E38C90A9219D4CB074A89A16E9CDB20BF85728EBD97C343E342";
+	const TEST_ACCOUNT = "0x1111111111111111111111111111111111111111";
+
+	step("get nonce", async function () {
+		this.timeout(10_000);
+		const tx = await context.web3.eth.accounts.signTransaction({
+			from: GENESIS_ACCOUNT,
+			to: TEST_ACCOUNT,
+			value: "0x200", // Must me higher than ExistentialDeposit (500)
+			gasPrice: "0x01",
+			gas: "0x100000",
+		}, GENESIS_ACCOUNT_PRIVATE_KEY);
+
+		expect(await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT, 'earliest')).to.eq(0);
+
+		await customRequest(context.web3, "eth_sendRawTransaction", [tx.rawTransaction]);
+
+		expect(await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT, 'latest')).to.eq(0);
+		expect(await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT, 'pending')).to.eq(1);
+
+		await createAndFinalizeBlock(context.web3);
+
+		expect(await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT, 'latest')).to.eq(1);
+		expect(await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT, 'pending')).to.eq(1);
+		expect(await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT, 'earliest')).to.eq(0);
+	});
+});


### PR DESCRIPTION
Fixes #171 

This implementation uses the same approach as SystemApi `adjust_nonce` by iterating the pool and finding pending tx. https://github.com/paritytech/substrate/blob/46faa92432e3b85fde64e7fa504839ab81a462d1/utils/frame/rpc/system/src/lib.rs#L249
Although substrate will provide `(AccountId, Nonce)`, palletEthereum provides `(Address, Nonce)`. Not sure if we need to make it provide AccountId in order to treat transactions the same. Anyway I removed "Ethereum" prefix to make it easy compare