### PR TITLE
Add GitHub Action to Publish Rustdocs as GitHub Page

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -28,7 +28,15 @@ jobs:
               with:
                 command: doc
                 args: --all --no-deps
-            
+
+            - name: Write index.html
+              uses: DamianReeves/write-file-action@v1.0
+              with:
+                path: ./target/doc/index.html
+                contents: |
+                  echo "<meta http-equiv=refresh content=0;url=frontier_rpc/index.html>"
+                write-mode: overwrite
+
             - name: Deploy Documentation
               uses: peaceiris/actions-gh-pages@v3
               with:

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -1,0 +1,38 @@
+name: Deploy Docs to GitHub Pages
+
+on:
+    push:
+        branches:
+            - master
+
+jobs:
+    release:
+        name: GitHub Pages
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout Repository
+              uses: actions/checkout@v1
+            - name: Rust Setup
+              run: |
+                scripts/init.sh
+                cargo --version
+                rustc --version
+                cargo +$WASM_BUILD_TOOLCHAIN --version
+                rustc +$WASM_BUILD_TOOLCHAIN --version
+              env:
+                WASM_BUILD_TOOLCHAIN: nightly-2020-08-29
+
+            - name: Build Documentation
+              uses: actions-rs/cargo@v1
+              with:
+                command: doc
+                args: --all --no-deps
+            
+            - name: Deploy Documentation
+              uses: peaceiris/actions-gh-pages@v3
+              with:
+                deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+                publish_branch: gh-pages
+                publish_dir: ./target/doc
+                keep_files: true


### PR DESCRIPTION
Follow [this doc](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-create-ssh-deploy-key) to create the necessary keys. Configure Pages per screenshot. See example deployment here https://danforbes.github.io/frontier
![image](https://user-images.githubusercontent.com/2193247/97647777-530b9900-1a10-11eb-89b7-59901b04120e.png)

Closes #177 