### PR TITLE
Support topic wildcards and conditional indexed parameters

### DIFF
--- a/rpc/core/src/types/filter.rs
+++ b/rpc/core/src/types/filter.rs
@@ -106,13 +106,12 @@ impl FilteredParams {
 		}
 		Self::default()
 	}
-	/// Cartesian product for VariadicValue conditional indexed parameters. 
+	/// Cartesian product for VariadicValue conditional indexed parameters.
 	/// Executed once on struct instance.
 	/// i.e. `[A,[B,C]]` to `[[A,B],[A,C]]`.
 	fn flatten(topic: &Topic) -> Vec<FlatTopic> {
 		fn cartesian(lists: &Vec<Vec<Option<H256>>>) -> Vec<Vec<Option<H256>>> {
 			let mut res = vec![];
-		 
 			let mut list_iter = lists.iter();
 			if let Some(first_list) = list_iter.next() {
 				for &i in first_list {
@@ -173,7 +172,7 @@ impl FilteredParams {
 
 	/// Replace None values - aka wildcards - for the log input value in that position.
 	pub fn replace(&self, log: &Log, topic: FlatTopic) -> Option<Vec<H256>> {
-		let mut out: Vec<H256> = Vec::new(); 
+		let mut out: Vec<H256> = Vec::new();
 		match topic {
 			VariadicValue::Single(value) => {
 				if let Some(value) = value {
@@ -269,7 +268,6 @@ impl FilteredParams {
 						if !log.topics.starts_with(&vec![single]) {
 							out = false;
 						}
-						
 					}
 				},
 				VariadicValue::Multiple(_) => {

--- a/rpc/core/src/types/filter.rs
+++ b/rpc/core/src/types/filter.rs
@@ -49,8 +49,12 @@ impl<'a, T> Deserialize<'a> for VariadicValue<T> where T: DeserializeOwned {
 
 /// Filter Address
 pub type FilterAddress = VariadicValue<H160>;
-/// Topic
-pub type Topic = VariadicValue<H256>;
+/// Topic, supports `A` | `null` | `[A,B,C]` | `[A,[B,C]]` | [null,[B,C]] | [null,[null,C]]
+pub type Topic = VariadicValue<Option<
+	VariadicValue<Option<H256>>
+>>;
+/// FlatTopic, simplifies the matching logic.
+pub type FlatTopic = VariadicValue<Option<H256>>;
 
 /// Filter
 #[derive(Debug, PartialEq, Clone, Deserialize, Eq, Hash)]

--- a/rpc/core/src/types/filter.rs
+++ b/rpc/core/src/types/filter.rs
@@ -73,6 +73,225 @@ pub struct Filter {
 	pub topics: Option<Topic>,
 }
 
+/// Helper for Filter matching.
+/// Supports conditional indexed parameters and wildcards.
+#[derive(Debug)]
+pub struct FilteredParams {
+	pub filter: Option<Filter>,
+	flat_topics: Vec<FlatTopic>,
+}
+
+impl Default for FilteredParams {
+	fn default() -> Self {
+		FilteredParams {
+			filter: None,
+			flat_topics: Vec::new()
+		}
+	}
+}
+
+impl FilteredParams {
+	pub fn new(
+		f: Option<Filter>,
+	) -> Self {
+		if let Some(f) = f {
+			return FilteredParams {
+				filter: Some(f.clone()),
+				flat_topics: {
+					if let Some(t) = f.clone().topics {
+						Self::flatten(&t)
+					} else { Vec:: new() }
+				}
+			};
+		}
+		Self::default()
+	}
+	/// Cartesian product for VariadicValue conditional indexed parameters. 
+	/// Executed once on struct instance.
+	/// i.e. `[A,[B,C]]` to `[[A,B],[A,C]]`.
+	fn flatten(topic: &Topic) -> Vec<FlatTopic> {
+		fn cartesian(lists: &Vec<Vec<Option<H256>>>) -> Vec<Vec<Option<H256>>> {
+			let mut res = vec![];
+		 
+			let mut list_iter = lists.iter();
+			if let Some(first_list) = list_iter.next() {
+				for &i in first_list {
+					res.push(vec![i]);
+				}
+			}
+			for l in list_iter {
+				let mut tmp = vec![];
+				for r in res {
+					for &el in l {
+						let mut tmp_el = r.clone();
+						tmp_el.push(el);
+						tmp.push(tmp_el);
+					}
+				}
+				res = tmp;
+			}
+			res
+		}
+		let mut out: Vec<FlatTopic> = Vec::new();
+		match topic {
+			VariadicValue::Multiple(multi) => {
+				let mut foo: Vec<Vec<Option<H256>>> = Vec::new();
+				for v in multi {
+					foo.push({
+						if let Some(v) = v {
+							match v {
+								VariadicValue::Single(s) => {
+									vec![s.clone()]
+								},
+								VariadicValue::Multiple(s) => {
+									s.clone()
+								},
+								VariadicValue::Null => {
+									vec![None]
+								},
+							}
+						} else  {
+							vec![None]
+						}
+					});
+				}
+				for permut in cartesian(&foo) {
+					out.push(FlatTopic::Multiple(permut));
+				}
+			},
+			VariadicValue::Single(single) => {
+				if let Some(single) = single {
+					out.push(single.clone());
+				}
+			},
+			VariadicValue::Null => {
+				out.push(FlatTopic::Null);
+			},
+		}
+		out
+	}
+
+	/// Replace None values - aka wildcards - for the log input value in that position.
+	pub fn replace(&self, log: &Log, topic: FlatTopic) -> Option<Vec<H256>> {
+		let mut out: Vec<H256> = Vec::new(); 
+		match topic {
+			VariadicValue::Single(value) => {
+				if let Some(value) = value {
+					out.push(value);
+				}
+			},
+			VariadicValue::Multiple(value) => {
+				for (k, v) in value.into_iter().enumerate() {
+					if let Some(v) = v {
+						out.push(v);
+					} else {
+						out.push(log.topics[k].clone());
+					}
+				}
+			},
+			_ => {}
+		};
+		if out.len() == 0 {
+			return None;
+		}
+		Some(out)
+	}
+
+	pub fn filter_block_range(
+		&self,
+		block_number: u64
+	) -> bool {
+		let mut out = true;
+		let filter = self.filter.clone().unwrap();
+		if let Some(from) = filter.from_block {
+			match from {
+				BlockNumber::Num(_) => {
+					if from.to_min_block_num().unwrap_or(0 as u64) > block_number {
+						out = false;
+					}
+				},
+				_ => {}
+			}
+		}
+		if let Some(to) = filter.to_block {
+			match to {
+				BlockNumber::Num(_) => {
+					if to.to_min_block_num().unwrap_or(0 as u64) < block_number {
+						out = false;
+					}
+				},
+				BlockNumber::Earliest => {
+					out = false;
+				},
+				_ => {}
+			}
+		}
+		out
+	}
+
+	pub fn filter_block_hash(
+		&self,
+		block_hash: H256
+	) -> bool {
+		if let Some(h) = self.filter.clone().unwrap().block_hash {
+			if h != block_hash { return false; }
+		}
+		true
+	}
+
+	pub fn filter_address(
+		&self,
+		log: &Log
+	) -> bool {
+		if let Some(input_address) = &self.filter.clone().unwrap().address {
+			match input_address {
+				VariadicValue::Single(x) => {
+					if log.address != *x { return false; }
+				},
+				VariadicValue::Multiple(x) => {
+					if !x.contains(&log.address) { return false; }
+				},
+				_ => { return true; }
+			}
+		}
+		true
+	}
+
+	pub fn filter_topics(
+		&self,
+		log: &Log
+	) -> bool {
+		let mut out: bool = true;
+		for topic in self.flat_topics.clone() {
+			match topic {
+				VariadicValue::Single(single) => {
+					if let Some(single) = single {
+						if !log.topics.starts_with(&vec![single]) {
+							out = false;
+						}
+						
+					}
+				},
+				VariadicValue::Multiple(_) => {
+					let replaced: Option<Vec<H256>> = self.replace(log, topic);
+					if let Some(replaced) = replaced {
+						out = false;
+						if log.topics.starts_with(
+							&replaced[..]
+						) {
+							out = true;
+						}
+					}
+				},
+				_ => {
+					out = true;
+				}
+			}
+		}
+		out
+	}
+}
+
 /// Results of the filter_changes RPC.
 #[derive(Debug, PartialEq)]
 pub enum FilterChanges {

--- a/rpc/core/src/types/mod.rs
+++ b/rpc/core/src/types/mod.rs
@@ -38,7 +38,7 @@ pub use self::bytes::Bytes;
 pub use self::block::{RichBlock, Block, BlockTransactions, Header, RichHeader, Rich};
 pub use self::block_number::BlockNumber;
 pub use self::call_request::CallRequest;
-pub use self::filter::{Filter, FilterChanges, VariadicValue, FilterAddress, Topic};
+pub use self::filter::{Filter, FilterChanges, VariadicValue, FilterAddress, Topic, FilteredParams};
 pub use self::index::Index;
 pub use self::log::Log;
 pub use self::receipt::Receipt;

--- a/rpc/src/eth.rs
+++ b/rpc/src/eth.rs
@@ -31,7 +31,7 @@ use sp_blockchain::{Error as BlockChainError, HeaderMetadata, HeaderBackend};
 use sc_network::{NetworkService, ExHashT};
 use frontier_rpc_core::{EthApi as EthApiT, NetApi as NetApiT};
 use frontier_rpc_core::types::{
-	BlockNumber, Bytes, CallRequest, Filter, Index, Log, Receipt, RichBlock,
+	BlockNumber, Bytes, CallRequest, Filter, FilteredParams, Index, Log, Receipt, RichBlock,
 	SyncStatus, SyncInfo, Transaction, Work, Rich, Block, BlockTransactions, VariadicValue
 };
 use frontier_rpc_primitives::{EthereumRuntimeRPCApi, ConvertTransaction, TransactionStatus};
@@ -790,6 +790,7 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 	fn logs(&self, filter: Filter) -> Result<Vec<Log>> {
 		let mut blocks_and_statuses = Vec::new();
 		let mut ret = Vec::new();
+		let params = FilteredParams::new(Some(filter.clone()));
 
 		if let Some(hash) = filter.block_hash {
 			let id = match self.load_hash(hash)
@@ -848,42 +849,49 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 				let logs = status.logs.clone();
 				let mut transaction_log_index: u32 = 0;
 				let transaction_hash = status.transaction_hash;
-				for log in logs {
+				for ethereum_log in logs {
+					let mut log = Log {
+						address: ethereum_log.address.clone(),
+						topics: ethereum_log.topics.clone(),
+						data: Bytes(ethereum_log.data.clone()),
+						block_hash: None,
+						block_number: None,
+						transaction_hash: None,
+						transaction_index: None,
+						log_index: None,
+						transaction_log_index: None,
+						removed: false,
+					};
 					let mut add: bool = false;
 					if let (
-						Some(VariadicValue::Single(address)),
-						Some(VariadicValue::Multiple(topics))
+						Some(VariadicValue::Single(_)),
+						Some(VariadicValue::Multiple(_))
 					) = (
 						filter.address.clone(),
 						filter.topics.clone(),
 					) {
-						if address == log.address && log.topics.starts_with(&topics) {
+						if !params.filter_address(&log) && params.filter_topics(&log) {
 							add = true;
 						}
-					} else if let Some(VariadicValue::Single(address)) = filter.address {
-						if address == log.address {
+					} else if let Some(VariadicValue::Single(_)) = filter.address {
+						if !params.filter_address(&log) {
 							add = true;
 						}
-					} else if let Some(VariadicValue::Multiple(topics)) = &filter.topics {
-						if log.topics.starts_with(&topics) {
+					} else if let Some(VariadicValue::Multiple(_)) = &filter.topics {
+						if params.filter_topics(&log) {
 							add = true;
 						}
 					} else {
 						add = true;
 					}
 					if add {
-						ret.push(Log {
-							address: log.address.clone(),
-							topics: log.topics.clone(),
-							data: Bytes(log.data.clone()),
-							block_hash: Some(block_hash),
-							block_number: Some(block.header.number.clone()),
-							transaction_hash: Some(transaction_hash),
-							transaction_index: Some(U256::from(status.transaction_index)),
-							log_index: Some(U256::from(block_log_index)),
-							transaction_log_index: Some(U256::from(transaction_log_index)),
-							removed: false,
-						});
+						log.block_hash = Some(block_hash);
+						log.block_number = Some(block.header.number.clone());
+						log.transaction_hash = Some(transaction_hash);
+						log.transaction_index = Some(U256::from(status.transaction_index));
+						log.log_index = Some(U256::from(block_log_index));
+						log.transaction_log_index = Some(U256::from(transaction_log_index));
+						ret.push(log);
 					}
 					transaction_log_index += 1;
 					block_log_index += 1;

--- a/rpc/src/eth_pubsub.rs
+++ b/rpc/src/eth_pubsub.rs
@@ -19,7 +19,7 @@ use log::warn;
 use jsonrpc_pubsub::{typed::Subscriber, SubscriptionId, manager::SubscriptionManager};
 use frontier_rpc_core::EthPubSubApi::{self as EthPubSubApiT};
 use frontier_rpc_core::types::{
-	BlockNumber, Rich, Header, Bytes, Log, FilterAddress, Topic, VariadicValue,
+	Rich, Header, Bytes, Log, FilteredParams,
 	pubsub::{Kind, Params, Result as PubSubResult, PubSubSyncStatus}
 };
 use ethereum_types::{H256, U256};
@@ -33,7 +33,6 @@ use jsonrpc_core::{Result as JsonRpcResult, futures::{Future, Sink}};
 use frontier_rpc_primitives::{EthereumRuntimeRPCApi, TransactionStatus};
 
 use sc_network::{NetworkService, ExHashT};
-use crate::internal_err;
 
 pub struct EthPubSubApi<B: BlockT, P, C, BE, H: ExHashT> {
 	_pool: Arc<P>,
@@ -51,202 +50,6 @@ impl<B: BlockT, P, C, BE, H: ExHashT> EthPubSubApi<B, P, C, BE, H> {
 		subscriptions: SubscriptionManager,
 	) -> Self {
 		Self { _pool, client, network, subscriptions, _marker: PhantomData }
-	}
-}
-
-impl<B: BlockT, P, C, BE, H: ExHashT> EthPubSubApi<B, P, C, BE, H> where
-	B: BlockT<Hash=H256> + Send + Sync + 'static,
-	P: TransactionPool<Block=B> + Send + Sync + 'static,
-	C: ProvideRuntimeApi<B> + StorageProvider<B,BE> +
-		BlockchainEvents<B> + AuxStore,
-	C: HeaderBackend<B> + HeaderMetadata<B, Error=BlockChainError> + 'static,
-	C::Api: EthereumRuntimeRPCApi<B>,
-	C: Send + Sync + 'static,
-	BE: Backend<B> + 'static,
-	BE::State: StateBackend<BlakeTwo256>,
-{
-	fn native_block_number(&self, number: Option<BlockNumber>) -> JsonRpcResult<Option<u32>> {
-		let mut native_number: Option<u32> = None;
-
-		if let Some(number) = number {
-			match number {
-				BlockNumber::Hash { hash, .. } => {
-					let id = self.load_hash(hash).unwrap_or(None);
-					if let Some(id) = id {
-						if let Ok(Some(block)) = self.client.runtime_api().current_block(&id) {
-							native_number = Some(block.header.number.as_u32());
-						}
-					}
-				},
-				BlockNumber::Num(_) => {
-					if let Some(number) = number.to_min_block_num() {
-						native_number = Some(number.unique_saturated_into());
-					}
-				},
-				BlockNumber::Latest => {
-					native_number = Some(
-						self.client.info().best_number.clone().unique_saturated_into() as u32
-					);
-				},
-				BlockNumber::Earliest => {
-					native_number = Some(0);
-				},
-				BlockNumber::Pending => {
-					native_number = None;
-				}
-			};
-		} else {
-			native_number = Some(
-				self.client.info().best_number.clone().unique_saturated_into() as u32
-			);
-		}
-		Ok(native_number)
-	}
-
-	fn filter_block(
-		&self,
-		params: Option<Params>
-	) -> (Option<u32>, Option<u32>) {
-		if let Some(Params::Logs(f)) = params {
-			let to_block: Option<u32> = if f.to_block.is_some() {
-				self.native_block_number(f.to_block).unwrap_or(None)
-			} else {
-				None
-			};
-			return (
-				self.native_block_number(f.from_block).unwrap_or(None),
-				to_block
-			);
-		}
-		(None, None)
-	}
-
-	// Asumes there is only one mapped canonical block in the AuxStore, otherwise something is wrong
-	fn load_hash(&self, hash: H256) -> JsonRpcResult<Option<BlockId<B>>> {
-		let hashes = match frontier_consensus::load_block_hash::<B, _>(self.client.as_ref(), hash)
-			.map_err(|err| internal_err(format!("fetch aux store failed: {:?}", err)))?
-		{
-			Some(hashes) => hashes,
-			None => return Ok(None),
-		};
-		let out: Vec<H256> = hashes.into_iter()
-			.filter_map(|h| {
-				if let Ok(Some(_)) = self.client.header(BlockId::Hash(h)) {
-					Some(h)
-				} else {
-					None
-				}
-			}).collect();
-
-		if out.len() == 1 {
-			return Ok(Some(
-				BlockId::Hash(out[0])
-			));
-		}
-		Ok(None)
-	}
-}
-
-struct FilteredParams {
-	from_block: Option<u32>,
-	to_block: Option<u32>,
-	block_hash: Option<H256>,
-	address: Option<FilterAddress>,
-	topics: Option<Topic>
-}
-
-impl FilteredParams {
-	pub fn new(
-		params: Option<Params>,
-		block_range: (Option<u32>, Option<u32>)
-	) -> Self {
-		if let Some(Params::Logs(d)) = params {
-			return FilteredParams {
-				from_block: block_range.0,
-				to_block: block_range.1,
-				block_hash: d.block_hash,
-				address: d.address,
-				topics: d.topics
-			};
-		}
-		FilteredParams {
-			from_block: None,
-			to_block: None,
-			block_hash: None,
-			address: None,
-			topics: None
-		}
-	}
-
-	pub fn filter_block_range(
-		&self,
-		block: &ethereum::Block
-	) -> bool {
-		let mut out = true;
-		let number: u32 = UniqueSaturatedInto::<u32>::unique_saturated_into(
-			block.header.number
-		);
-		if let Some(from) = self.from_block {
-			if from > number {
-				out = false;
-			}
-		}
-		if let Some(to) = self.to_block {
-			if to < number {
-				out = false;
-			}
-		}
-		out
-	}
-
-	fn filter_block_hash(
-		&self,
-		block_hash: H256
-	) -> bool {
-		if let Some(h) = self.block_hash {
-			if h != block_hash { return false; }
-		}
-		true
-	}
-
-	fn filter_address(
-		&self,
-		log: &ethereum::Log
-	) -> bool {
-		if let Some(input_address) = &self.address {
-			match input_address {
-				VariadicValue::Single(x) => {
-					if log.address != *x { return false; }
-				},
-				VariadicValue::Multiple(x) => {
-					if !x.contains(&log.address) { return false; }
-				},
-				_ => { return true; }
-			}
-		}
-		true
-	}
-
-	fn filter_topics(
-		&self,
-		log: &ethereum::Log
-	) -> bool {
-		if let Some(input_topics) = &self.topics {
-			match input_topics {
-				VariadicValue::Single(x) => {
-					if !log.topics.starts_with(&vec![*x]) {
-						return false;
-					}
-				},
-				VariadicValue::Multiple(x) => {
-					if !log.topics.starts_with(&x) {
-						return false;
-					}
-				},
-				_ => { return true; }
-			}
-		}
-		true
 	}
 }
 
@@ -343,14 +146,31 @@ impl SubscriptionResult {
 	fn add_log(
 		&self,
 		block_hash: H256,
-		log: &ethereum::Log,
+		ethereum_log: &ethereum::Log,
 		block: &ethereum::Block,
 		params: &FilteredParams
 	) -> bool {
-		if !params.filter_block_range(block) ||
-			!params.filter_block_hash(block_hash) ||
-			!params.filter_address(log) || !params.filter_topics(log) {
-			return false;
+		let log = Log {
+			address: ethereum_log.address.clone(),
+			topics: ethereum_log.topics.clone(),
+			data: Bytes(ethereum_log.data.clone()),
+			block_hash: None,
+			block_number: None,
+			transaction_hash: None,
+			transaction_index: None,
+			log_index: None,
+			transaction_log_index: None,
+			removed: false,
+		};
+		if let Some(_) = params.filter {
+			let block_number = UniqueSaturatedInto::<u64>::unique_saturated_into(
+				block.header.number
+			);
+			if !params.filter_block_range(block_number) ||
+				!params.filter_block_hash(block_hash) ||
+				!params.filter_address(&log) || !params.filter_topics(&log) {
+				return false;
+			}
 		}
 		true
 	}
@@ -395,8 +215,11 @@ impl<B: BlockT, P, C, BE, H: ExHashT> EthPubSubApiT for EthPubSubApi<B, P, C, BE
 		kind: Kind,
 		params: Option<Params>,
 	) {
-		let filter_block = self.filter_block(params.clone());
-		let filtered_params = FilteredParams::new(params, filter_block);
+		let filtered_params = match params {
+			Some(Params::Logs(filter)) => FilteredParams::new(Some(filter)),
+			_ => FilteredParams::default()
+		};
+
 		let client = self.client.clone();
 		let network = self.network.clone();
 		match kind {


### PR DESCRIPTION
In this PR:

- VariadicValue now supports optional values as well as nested VariadicValues.
- Filtering logic lives now in frontier-rpc-core types and is used by both ethGetLogs and logs subscriptions.
- Support for conditional indexed parameters (conditionally matching _events_) (i.e. [Web3](https://web3js.readthedocs.io/en/v1.2.7/web3-eth-subscribe.html#id16)).

Rel https://github.com/paritytech/frontier/issues/145

----

**What's in here**

In `eth_subscribe::logs` and `eth_getLogs` we want to support the use of wilcards - `null` arguments in `topics` that match any value at a given position - and conditional indexed parameters - groups of values that may occur at a given position. This functionality is used by many Dapps.

Topic pattern match should accept:

`0x0` | `null` | `[0x0,0x1,0x2...]` | `[0x0,[0x1,0x2]...]` | `[null,[0x1,0x2]...]` | `[null,[null,0x2]...]` (although the last one does not make sense, as would match anything).

For the matching algorithm I decided to use two strategies:

- **Conditionals**: a cartesian product will be applied to any statement including conditional groups (i.e. `[A,[B,C],null,[E,F,G]]`). This eases the matching strategy in both EthApi and EthPubSubApi. So for the previous example, we will end up with a collection of flatten statements that are cheap and easy to match with rust's `.starts_with`:

`[A,B,null,E]`, `[A,B,null,F]`, `[A,B,null,G]`, `[A,C,null,E]` ...

**TODOs**: products are expensive. The above is calculated once on subscription creation. We expect the nesting level to be 1 in most of the Dapp use cases, but there is no check mechanism to avoid large iterations. So that's TODO.

- **Wildcards**: each null occurence is replaced with the current log indexed parameter position we are trying to match. 

So for a `[null,0x0] `rule we will match logs that start with [`0x1,0x0]`, `[0x2, 0x0] `but not i.e. `[0x1,01]`