### PR TITLE
EVM execution error should not result in DispatchError

### DIFF
--- a/frame/ethereum/src/tests.rs
+++ b/frame/ethereum/src/tests.rs
@@ -294,8 +294,8 @@ fn call_should_handle_errors() {
 			CallOrCreateInfo::Create(_) => panic!("expected call info"),
 		}
 
-		// calling bar will revert
-		let err = Ethereum::execute(
+		// calling should always succeed even if the inner EVM execution fails.
+		Ethereum::execute(
 			alice.address,
 			bar,
 			U256::zero(),
@@ -303,8 +303,6 @@ fn call_should_handle_errors() {
 			Some(U256::from(1)),
 			Some(U256::from(2)),
 			TransactionAction::Call(H160::from_slice(&contract_address))
-		).err().unwrap();
-
-		assert_eq!(err, Error::<Test>::Reverted.into());
+		).ok().unwrap();
 	});
 }


### PR DESCRIPTION
fixes #178 

Even if the EVM execution fails, it should not result in DispatchError, because the state is still changed. The error should be communicated via a Substrate event.