### PR TITLE
Add required `unsubscribe` per test step

### DIFF
--- a/ts-tests/tests/test-subscription.ts
+++ b/ts-tests/tests/test-subscription.ts
@@ -57,9 +57,9 @@ describeWithFrontier("Frontier RPC (Subscription)", `simple-specs.json`, (contex
 
 	step("should get newHeads stream", async function (done) {
 		subscription = context.web3.eth.subscribe("newBlockHeaders", function(error, result){});
-		await createAndFinalizeBlock(context.web3);
 		let data = null;
 		await new Promise((resolve) => {
+			createAndFinalizeBlock(context.web3);
 			subscription.on("data", function (d: any) {
 				data = d;
 				resolve();

--- a/ts-tests/tests/test-subscription.ts
+++ b/ts-tests/tests/test-subscription.ts
@@ -50,11 +50,13 @@ describeWithFrontier("Frontier RPC (Subscription)", `simple-specs.json`, (contex
 			});
 		});
 
+		subscription.unsubscribe();
 		expect(connected).to.equal(true);
 		expect(subscriptionId).to.have.lengthOf(16);
 	});
 
 	step("should get newHeads stream", async function (done) {
+		subscription = context.web3.eth.subscribe("newBlockHeaders", function(error, result){});
 		await createAndFinalizeBlock(context.web3);
 		let data = null;
 		await new Promise((resolve) => {
@@ -63,6 +65,7 @@ describeWithFrontier("Frontier RPC (Subscription)", `simple-specs.json`, (contex
 				resolve();
 			});
 		});
+		subscription.unsubscribe();
 		expect(data).to.include({
 			author: '0x0000000000000000000000000000000000000000',
 			difficulty: '0',
@@ -211,6 +214,7 @@ describeWithFrontier("Frontier RPC (Subscription)", `simple-specs.json`, (contex
 				}
 			});
 		});
+		subscription.unsubscribe();
 
 		expect(data).to.not.be.empty;
 		setTimeout(done,10000);


### PR DESCRIPTION
Some of `subscription.unsubscribe()` calls were missing on the tests. This leads to a race condition where `.on("data")` listener of previous steps captures data from subsequent steps.