### PR TITLE
Add `StorageMetadata` to consensus logs

### DIFF
--- a/consensus/primitives/src/lib.rs
+++ b/consensus/primitives/src/lib.rs
@@ -32,5 +32,14 @@ pub enum ConsensusLog {
 		block_hash: H256,
 		/// Transaction hashes of the Ethereum block.
 		transaction_hashes: Vec<H256>,
+		/// Storage items metadata on upgrade.
+		metadata: Option<StorageMetadata>,
 	},
+}
+
+#[derive(Decode, Encode, Clone, PartialEq, Eq)]
+pub struct StorageMetadata {
+	pub block: Vec<u8>,
+	pub receipt: Vec<u8>,
+	pub status: Vec<u8>,
 }

--- a/template/node/src/chain_spec.rs
+++ b/template/node/src/chain_spec.rs
@@ -174,8 +174,6 @@ fn testnet_genesis(
 		pallet_evm: Some(EVMConfig {
 			accounts: BTreeMap::new(),
 		}),
-		pallet_ethereum: Some(EthereumConfig {
-			upgraded: false
-		}),
+		pallet_ethereum: Some(EthereumConfig {}),
 	}
 }

--- a/template/node/src/chain_spec.rs
+++ b/template/node/src/chain_spec.rs
@@ -174,6 +174,8 @@ fn testnet_genesis(
 		pallet_evm: Some(EVMConfig {
 			accounts: BTreeMap::new(),
 		}),
-		pallet_ethereum: Some(EthereumConfig {}),
+		pallet_ethereum: Some(EthereumConfig {
+			upgraded: false
+		}),
 	}
 }

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -401,7 +401,8 @@ pub type Executive = frame_executive::Executive<
 	Block,
 	frame_system::ChainContext<Runtime>,
 	Runtime,
-	AllModules
+	AllModules,
+	Ethereum
 >;
 
 impl_runtime_apis! {


### PR DESCRIPTION
Rel #175 

We want to use Storage API instead of Runtime API in Frontier, and we want to make sure we are using the right StorageKeys over time.

This draft is a proposal for writting custom `StorageMetadata` in auxiliary storage when a runtime upgrade happens, and then retrieve the right keys from it when an RPC call happens for any block.

`StorageMetadata` is a simple struct holding keys:

```
pub struct StorageMetadata {
	pub block: Vec<u8>,
	pub receipt: Vec<u8>,
	pub status: Vec<u8>,
}
```

**pallet-ethereum**

Uses `frame_support::traits::OnRuntimeUpgrade` to add the current `StorageMetadata` to the `ConsensusLog::EndBlock`.

**FrontierConsensus**

When metadata is found in EndBlock - a runtime upgrade happened - the `StorageMetadata` is mapped to the block number `X`.

**Usage example**

From the RPC code, two steps are required to retrieve the storage keys from the auxiliary for any given block number:

- Identify to which runtime upgrade `X` belongs the block number passed as part of the RPC call.
- Use StorageKeys mapped to `X` to query the `StorageProvider`.

```
// Load list of upgrades.
let upgrades = match frontier_consensus::load_upgrade_list();

// Find the upgrade X that the RPC call block number belongs to.
// ..

// Load the keys associated to X
let keys = match frontier_consensus::load_upgrade_metadata(X);

// Query the storage using the Storakey at that height
query_storage(
	id,
	&StorageKey(
		keys.block
	)
)
```