### PR TITLE
Add weight annotation to pallet Ethereum's transact extrinsic

### DIFF
--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -67,6 +67,7 @@ pub trait Trait: frame_system::Trait<Hash=H256> + pallet_balances::Trait + palle
 	/// The overarching event type.
 	type Event: From<Event> + Into<<Self as frame_system::Trait>::Event>;
 	/// Maps Ethereum gas to Substrate weight.
+	// TODO this should probably go in pallt evm actually, since it also assigns weights. Will open a Substrate PR
 	type GasToWeight: GasToWeight;
 	/// Find author for Ethereum.
 	type FindAuthor: FindAuthor<H160>;

--- a/frame/ethereum/src/mock.rs
+++ b/frame/ethereum/src/mock.rs
@@ -137,6 +137,7 @@ impl AddressMapping<AccountId32> for HashedAddressMapping {
 
 impl pallet_evm::Trait for Test {
 	type FeeCalculator = FixedGasPrice;
+	type GasToWeight = ();
 	type CallOrigin = EnsureAddressTruncated;
 	type WithdrawOrigin = EnsureAddressTruncated;
 	type AddressMapping = HashedAddressMapping;

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -393,7 +393,7 @@ decl_module! {
 				nonce,
 			)?;
 
-			 match info.exit_reason {
+			match info.exit_reason {
 				ExitReason::Succeed(_) => {
 					Module::<T>::deposit_event(Event::<T>::Executed(target));
 				},

--- a/frame/evm/src/tests.rs
+++ b/frame/evm/src/tests.rs
@@ -93,6 +93,7 @@ impl FeeCalculator for FixedGasPrice {
 
 impl Trait for Test {
 	type FeeCalculator = FixedGasPrice;
+	type GasToWeight = ();
 
 	type CallOrigin = EnsureAddressRoot<Self::AccountId>;
 	type WithdrawOrigin = EnsureAddressNever<Self::AccountId>;

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -332,6 +332,7 @@ impl<F: FindAuthor<u32>> FindAuthor<H160> for EthereumFindAuthor<F>
 
 impl pallet_ethereum::Trait for Runtime {
 	type Event = Event;
+	type GasToWeight = ();
 	type FindAuthor = EthereumFindAuthor<Aura>;
 }
 

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -301,6 +301,7 @@ parameter_types! {
 
 impl pallet_evm::Trait for Runtime {
 	type FeeCalculator = FixedGasPrice;
+	type GasToWeight = ();
 	type CallOrigin = EnsureAddressTruncated;
 	type WithdrawOrigin = EnsureAddressTruncated;
 	type AddressMapping = HashedAddressMapping<BlakeTwo256>;
@@ -332,7 +333,6 @@ impl<F: FindAuthor<u32>> FindAuthor<H160> for EthereumFindAuthor<F>
 
 impl pallet_ethereum::Trait for Runtime {
 	type Event = Event;
-	type GasToWeight = ();
 	type FindAuthor = EthereumFindAuthor<Aura>;
 }
 


### PR DESCRIPTION
This PR assigns a meaningful weight to pallet Ethereum's `transact` extrinsic, and updates the weight annotation of pallet EVM's extrinsics.

Some features:
* Weight is based only on gas limit, not gas price
* Customizable gas to weight mapping
* Default 1:1 gas weight mapping
* Uses Substrate's weight refund to return unused weight