### PR TITLE
pallet-evm: move to Frontier (Part III)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,6 +1350,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fp-evm"
+version = "0.8.0"
+dependencies = [
+ "evm",
+ "parity-scale-codec",
+ "serde",
+ "sp-core",
+ "sp-std",
+]
+
+[[package]]
 name = "frame-benchmarking"
 version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7865a34b17c5881e1c73eb7579faf5affd2365c4"
@@ -1564,10 +1575,10 @@ version = "0.1.0"
 dependencies = [
  "ethereum",
  "ethereum-types",
+ "fp-evm",
  "parity-scale-codec",
  "sp-api",
  "sp-core",
- "sp-evm",
  "sp-runtime",
  "sp-std",
 ]
@@ -3769,6 +3780,7 @@ dependencies = [
  "ethereum",
  "ethereum-types",
  "evm",
+ "fp-evm",
  "frame-support",
  "frame-system",
  "frontier-consensus-primitives",
@@ -3783,7 +3795,6 @@ dependencies = [
  "serde",
  "sha3 0.8.2",
  "sp-core",
- "sp-evm",
  "sp-io",
  "sp-runtime",
  "sp-std",
@@ -3792,11 +3803,11 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7865a34b17c5881e1c73eb7579faf5affd2365c4"
 dependencies = [
  "evm",
  "evm-gasometer",
  "evm-runtime",
+ "fp-evm",
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
@@ -3809,7 +3820,6 @@ dependencies = [
  "serde",
  "sha3 0.8.2",
  "sp-core",
- "sp-evm",
  "sp-io",
  "sp-runtime",
  "sp-std",
@@ -6484,18 +6494,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "sp-evm"
-version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#7865a34b17c5881e1c73eb7579faf5affd2365c4"
-dependencies = [
- "evm",
- "parity-scale-codec",
- "serde",
- "sp-core",
- "sp-std",
 ]
 
 [[package]]

--- a/frame/ethereum/Cargo.toml
+++ b/frame/ethereum/Cargo.toml
@@ -14,11 +14,11 @@ frame-support = { version = "2.0.0-dev", default-features = false, git = "https:
 frame-system = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 pallet-balances = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 pallet-timestamp = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-pallet-evm = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+pallet-evm = { version = "2.0.0-dev", default-features = false, path = "../evm" }
 sp-runtime = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-std = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-evm = { version = "0.8.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+fp-evm = { version = "0.8.0", default-features = false, path = "../../primitives/evm" }
 evm = { version = "0.18.0", features = ["with-codec"], default-features = false }
 ethereum = { version = "0.5", default-features = false, features = ["with-codec"] }
 ethereum-types = { version = "0.9", default-features = false }
@@ -45,7 +45,7 @@ std = [
 	"pallet-evm/std",
 	"sp-io/std",
 	"sp-std/std",
-	"sp-evm/std",
+	"fp-evm/std",
 	"ethereum/std",
 	"ethereum-types/std",
 	"rlp/std",

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -36,7 +36,7 @@ use sp_runtime::{
 	generic::DigestItem, traits::UniqueSaturatedInto, DispatchError,
 };
 use evm::ExitReason;
-use sp_evm::CallOrCreateInfo;
+use fp_evm::CallOrCreateInfo;
 use pallet_evm::Runner;
 use sha3::{Digest, Keccak256};
 use codec::Encode;

--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -15,15 +15,15 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "1.3.4", default-features = false }
-frame-support = { version = "2.0.0", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0", default-features = false, path = "../system" }
-pallet-timestamp = { version = "2.0.0", default-features = false, path = "../timestamp" }
-pallet-balances = { version = "2.0.0", default-features = false, path = "../balances" }
-sp-core = { version = "2.0.0", default-features = false, path = "../../primitives/core" }
-sp-runtime = { version = "2.0.0", default-features = false, path = "../../primitives/runtime" }
-sp-std = { version = "2.0.0", default-features = false, path = "../../primitives/std" }
-sp-io = { version = "2.0.0", default-features = false, path = "../../primitives/io" }
-sp-evm = { version = "0.8.0", default-features = false, path = "../../primitives/evm" }
+frame-support = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+frame-system = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+pallet-timestamp = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+pallet-balances = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-core = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-runtime = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-std = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-io = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+fp-evm = { version = "0.8.0", default-features = false, path = "../../primitives/evm" }
 primitive-types = { version = "0.7.0", default-features = false, features = ["rlp", "byteorder"] }
 rlp = { version = "0.4", default-features = false }
 evm = { version = "0.18", default-features = false, features = ["with-codec"] }
@@ -45,7 +45,7 @@ std = [
 	"pallet-balances/std",
 	"sp-io/std",
 	"sp-std/std",
-	"sp-evm/std",
+	"fp-evm/std",
 	"sha3/std",
 	"rlp/std",
 	"primitive-types/std",

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -59,7 +59,7 @@ pub mod precompiles;
 
 pub use crate::precompiles::{Precompile, Precompiles};
 pub use crate::runner::Runner;
-pub use sp_evm::{Account, Log, Vicinity, ExecutionInfo, CallInfo, CreateInfo};
+pub use fp_evm::{Account, Log, Vicinity, ExecutionInfo, CallInfo, CreateInfo};
 pub use evm::{ExitReason, ExitSucceed, ExitError, ExitRevert, ExitFatal};
 
 use sp_std::vec::Vec;

--- a/frame/evm/src/runner/mod.rs
+++ b/frame/evm/src/runner/mod.rs
@@ -20,7 +20,7 @@ pub mod builtin;
 
 use sp_std::vec::Vec;
 use sp_core::{H160, U256, H256};
-use sp_evm::{CallInfo, CreateInfo};
+use fp_evm::{CallInfo, CreateInfo};
 use crate::Trait;
 
 pub trait Runner<T: Trait> {

--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -23,7 +23,7 @@ use sp_core::{U256, H256, H160};
 use sp_runtime::traits::UniqueSaturatedInto;
 use frame_support::{debug, ensure, traits::{Get, Currency}, storage::{StorageMap, StorageDoubleMap}};
 use sha3::{Keccak256, Digest};
-use sp_evm::{ExecutionInfo, CallInfo, CreateInfo, Account, Log, Vicinity};
+use fp_evm::{ExecutionInfo, CallInfo, CreateInfo, Account, Log, Vicinity};
 use evm::ExitReason;
 use evm::backend::{Backend as BackendT, ApplyBackend, Apply};
 use evm::executor::StackExecutor;

--- a/primitives/evm/Cargo.toml
+++ b/primitives/evm/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "fp-evm"
+version = "0.8.0"
+license = "Apache-2.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
+homepage = "https://substrate.dev"
+repository = "https://github.com/paritytech/substrate/"
+description = "Primitive EVM abstractions for Substrate."
+documentation = "https://docs.rs/sp-evm"
+readme = "README.md"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+sp-core = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier", default-features = false }
+sp-std = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier", default-features = false }
+serde = { version = "1.0.101", optional = true, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.3.4", default-features = false }
+evm = { version = "0.18", default-features = false, features = ["with-codec"] }
+
+[features]
+default = ["std"]
+std = [
+	"sp-core/std",
+	"sp-std/std",
+	"serde",
+	"codec/std",
+	"evm/std",
+	"evm/with-serde",
+]

--- a/primitives/evm/src/lib.rs
+++ b/primitives/evm/src/lib.rs
@@ -1,0 +1,56 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2017-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use codec::{Encode, Decode};
+#[cfg(feature = "std")]
+use serde::{Serialize, Deserialize};
+use sp_std::vec::Vec;
+use sp_core::{U256, H160};
+use evm::ExitReason;
+
+pub use evm::backend::{Basic as Account, Log};
+
+#[derive(Clone, Eq, PartialEq, Encode, Decode, Default)]
+#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
+/// External input from the transaction.
+pub struct Vicinity {
+	/// Current transaction gas price.
+	pub gas_price: U256,
+	/// Origin of the transaction.
+	pub origin: H160,
+}
+
+#[derive(Clone, Eq, PartialEq, Encode, Decode)]
+#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
+pub struct ExecutionInfo<T> {
+	pub exit_reason: ExitReason,
+	pub value: T,
+	pub used_gas: U256,
+	pub logs: Vec<Log>,
+}
+
+pub type CallInfo = ExecutionInfo<Vec<u8>>;
+pub type CreateInfo = ExecutionInfo<H160>;
+
+#[derive(Clone, Eq, PartialEq, Encode, Decode)]
+#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
+pub enum CallOrCreateInfo {
+	Call(CallInfo),
+	Create(CreateInfo),
+}

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -26,7 +26,7 @@ sc-service = { git = "https://github.com/paritytech/substrate.git", branch = "fr
 sc-client-api = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sc-rpc = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sc-network = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-pallet-evm = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+pallet-evm = { path = "../frame/evm" }
 pallet-ethereum = { path = "../frame/ethereum" }
 ethereum = { version = "0.5", features = ["with-codec"] }
 codec = { package = "parity-scale-codec", version = "1.0.0" }

--- a/rpc/primitives/Cargo.toml
+++ b/rpc/primitives/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 [dependencies]
 sp-core = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-api = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-evm = { version = "0.8.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+fp-evm = { version = "0.8.0", default-features = false, path = "../../primitives/evm" }
 ethereum = { version = "0.5", default-features = false, features = ["with-codec"] }
 ethereum-types = { version = "0.9", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
@@ -21,7 +21,7 @@ default = ["std"]
 std = [
 	"sp-core/std",
 	"sp-api/std",
-	"sp-evm/std",
+	"fp-evm/std",
 	"ethereum/std",
 	"ethereum-types/std",
 	"codec/std",

--- a/rpc/primitives/src/lib.rs
+++ b/rpc/primitives/src/lib.rs
@@ -53,7 +53,7 @@ sp_api::decl_runtime_apis! {
 		/// Returns runtime defined pallet_evm::ChainId.
 		fn chain_id() -> u64;
 		/// Returns pallet_evm::Accounts by address.
-		fn account_basic(address: H160) -> sp_evm::Account;
+		fn account_basic(address: H160) -> fp_evm::Account;
 		/// Returns FixedGasPrice::min_gas_price
 		fn gas_price() -> U256;
 		/// For a given account address, returns pallet_evm::AccountCodes.
@@ -71,7 +71,7 @@ sp_api::decl_runtime_apis! {
 			gas_limit: U256,
 			gas_price: Option<U256>,
 			nonce: Option<U256>,
-		) -> Result<sp_evm::CallInfo, sp_runtime::DispatchError>;
+		) -> Result<fp_evm::CallInfo, sp_runtime::DispatchError>;
 		/// Returns a frame_ethereum::create response.
 		fn create(
 			from: H160,
@@ -80,7 +80,7 @@ sp_api::decl_runtime_apis! {
 			gas_limit: U256,
 			gas_price: Option<U256>,
 			nonce: Option<U256>,
-		) -> Result<sp_evm::CreateInfo, sp_runtime::DispatchError>;
+		) -> Result<fp_evm::CreateInfo, sp_runtime::DispatchError>;
 		/// Return the current block.
 		fn current_block() -> Option<EthereumBlock>;
 		/// Return the current receipt.

--- a/template/node/Cargo.toml
+++ b/template/node/Cargo.toml
@@ -39,7 +39,7 @@ sc-consensus-manual-seal = { git = "https://github.com/paritytech/substrate.git"
 sp-consensus = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sc-consensus = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-timestamp = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-pallet-evm = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+pallet-evm = { path = "../../frame/evm" }
 pallet-ethereum = { path = "../../frame/ethereum" }
 sc-finality-grandpa = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-finality-grandpa = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }

--- a/template/runtime/Cargo.toml
+++ b/template/runtime/Cargo.toml
@@ -20,7 +20,7 @@ frame-system = { version = "2.0.0-dev", default-features = false, package = "fra
 frame-system-rpc-runtime-api = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 
 pallet-ethereum = { version = "0.1.0", default-features = false, path = "../../frame/ethereum" }
-pallet-evm = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+pallet-evm = { version = "2.0.0-dev", default-features = false, path = "../../frame/evm" }
 pallet-aura = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 pallet-balances = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 pallet-grandpa = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }


### PR DESCRIPTION
Integrate local `pallet-evm`, and remove its dependency on Substrate `pallet-evm`.