### PR TITLE
Set block header `state_root`

### DIFF
--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -277,7 +277,13 @@ impl<T: Trait> Module<T> {
 			mix_hash: H256::default(),
 			nonce: H64::default(),
 		};
-		let block = ethereum::Block::new(partial_header, transactions.clone(), ommers);
+		let mut block = ethereum::Block::new(partial_header, transactions.clone(), ommers);
+		block.header.state_root = {
+			let mut state_root = [0u8; 64];
+			state_root[..32].copy_from_slice(&frame_system::Module::<T>::parent_hash()[..]);
+			state_root[32..64].copy_from_slice(&block.header.hash()[..]);
+			H256::from_slice(Keccak256::digest(&state_root).as_slice())
+		};
 
 		let mut transaction_hashes = Vec::new();
 

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -279,10 +279,10 @@ impl<T: Trait> Module<T> {
 		};
 		let mut block = ethereum::Block::new(partial_header, transactions.clone(), ommers);
 		block.header.state_root = {
-			let mut state_root = [0u8; 64];
-			state_root[..32].copy_from_slice(&frame_system::Module::<T>::parent_hash()[..]);
-			state_root[32..64].copy_from_slice(&block.header.hash()[..]);
-			H256::from_slice(Keccak256::digest(&state_root).as_slice())
+			let mut input = [0u8; 64];
+			input[..32].copy_from_slice(&frame_system::Module::<T>::parent_hash()[..]);
+			input[32..64].copy_from_slice(&block.header.hash()[..]);
+			H256::from_slice(Keccak256::digest(&input).as_slice())
 		};
 
 		let mut transaction_hashes = Vec::new();

--- a/ts-tests/tests/test-block.ts
+++ b/ts-tests/tests/test-block.ts
@@ -29,7 +29,6 @@ describeWithFrontier("Frontier RPC (Block)", `simple-specs.json`, (context) => {
 			number: 0,
 			receiptsRoot: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
 			size: 501,
-			stateRoot: "0x0000000000000000000000000000000000000000000000000000000000000000",
 			timestamp: 0,
 			totalDifficulty: null,
 		});
@@ -88,7 +87,6 @@ describeWithFrontier("Frontier RPC (Block)", `simple-specs.json`, (context) => {
 			//parentHash: "0x04540257811b46d103d9896e7807040e7de5080e285841c5430d1a81588a0ce4",
 			receiptsRoot: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
 			size: 503,
-			stateRoot: "0x0000000000000000000000000000000000000000000000000000000000000000",
 			timestamp: 6,
 			totalDifficulty: null,
 			//transactions: [],

--- a/ts-tests/tests/test-revert-receipt.ts
+++ b/ts-tests/tests/test-revert-receipt.ts
@@ -46,25 +46,16 @@ describeWithFrontier("Frontier RPC (Constructor Revert)", `simple-specs.json`, (
 		//TODO Actually, why doesn't this receipt have a status in it?
 		// I guess because the RPC handler in eth.rs sets `status_code: None`??
 		await createAndFinalizeBlock(context.web3);
-		expect(
-			await customRequest(context.web3, "eth_getTransactionReceipt", [GOOD_TX_HASH])
-		).to.deep.equal({
-			id: 1,
-			jsonrpc: "2.0",
-			result: {
-				"blockHash": "0x523389d52a34094ad401153dd8486fe6af7099da388a4728ed3b09e285ca8604",
-				"blockNumber": "0x1",
-				"contractAddress": "0xc2bf5f29a4384b1ab0c063e1c666f02121b6084a",
-				"cumulativeGasUsed": "0x1069f",
-				"from": "0x6be02d1d3665660d22ff9624b7be0551ee1ac91b",
-				"gasUsed": "0x1069f",
-				"logs": [],
-				"logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-				"root": "0x0000000000000000000000000000000000000000000000000000000000000000",
-				"to": null,
-				"transactionHash": GOOD_TX_HASH,
-				"transactionIndex": "0x0",
-			}
+		const receipt = await context.web3.eth.getTransactionReceipt(GOOD_TX_HASH);
+		expect(receipt).to.include({
+			blockNumber: 1,
+			contractAddress: '0xC2Bf5F29a4384b1aB0C063e1c666f02121B6084a',
+			cumulativeGasUsed: 67231,
+			from: '0x6be02d1d3665660d22ff9624b7be0551ee1ac91b',
+			gasUsed: 67231,
+			to: null,
+			transactionHash: '0xae813c533aac0719fbca4db6e3bb05cfb5859bdeaaa7dc5c9dbd24083301be8d',
+			transactionIndex: 0
 		});
 	});
 
@@ -94,25 +85,16 @@ describeWithFrontier("Frontier RPC (Constructor Revert)", `simple-specs.json`, (
 		});
 		
 		await createAndFinalizeBlock(context.web3);
-		expect(
-			await customRequest(context.web3, "eth_getTransactionReceipt", [FAIL_TX_HASH])
-		).to.deep.equal({
-			id: 1,
-			jsonrpc: "2.0",
-			result: {
-				"blockHash": "0x459bb7c418c22239392a4a1e7c2190afbcc6fbd87cb6d547509deac588f27536",
-				"blockNumber": "0x2",
-				"contractAddress": "0x5c4242beb94de30b922f57241f1d02f36e906915",
-				"cumulativeGasUsed": "0xd548",
-				"from": "0x6be02d1d3665660d22ff9624b7be0551ee1ac91b",
-				"gasUsed": "0xd548",
-				"logs": [],
-				"logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-				"root": "0x0000000000000000000000000000000000000000000000000000000000000000",
-				"to": null,
-				"transactionHash": FAIL_TX_HASH,
-				"transactionIndex": "0x0",
-			}
+		const receipt = await context.web3.eth.getTransactionReceipt(FAIL_TX_HASH);
+		expect(receipt).to.include({
+			blockNumber: 2,
+			contractAddress: '0x5c4242beB94dE30b922f57241f1D02f36e906915',
+			cumulativeGasUsed: 54600,
+			from: '0x6be02d1d3665660d22ff9624b7be0551ee1ac91b',
+			gasUsed: 54600,
+			to: null,
+			transactionHash: '0x640df9deb183d565addc45bdc8f95b30c7c03ce7e69df49456be9929352e4347',
+			transactionIndex: 0
 		});
 	});
 });

--- a/ts-tests/tests/test-subscription.ts
+++ b/ts-tests/tests/test-subscription.ts
@@ -75,7 +75,6 @@ describeWithFrontier("Frontier RPC (Subscription)", `simple-specs.json`, (contex
 			number: 2,
 			receiptsRoot: '0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347',
 			sha3Uncles: '0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347',
-			stateRoot: '0x0000000000000000000000000000000000000000000000000000000000000000',
 			transactionsRoot: '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421'
 		});
 		expect((data as any).sealFields).to.eql([


### PR DESCRIPTION
Uses `frame_system::parent_hash` and `header.hash` to create a unique 256 bit `state_root` before storing the block.

