### PR TITLE
gh-pages: remove index.html file

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -29,14 +29,6 @@ jobs:
                 command: doc
                 args: --all --no-deps
 
-            - name: Write index.html
-              uses: DamianReeves/write-file-action@v1.0
-              with:
-                path: ./target/doc/index.html
-                contents: |
-                  echo "<meta http-equiv=refresh content=0;url=frontier_rpc/index.html>"
-                write-mode: overwrite
-
             - name: Deploy Documentation
               uses: peaceiris/actions-gh-pages@v3
               with:


### PR DESCRIPTION
It does not work now as the crate name has changed. I think in the future we can combine rustdoc with a proper landing page.