### PR TITLE
Require explictly evm 0.18.5 or newer

### DIFF
--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -26,7 +26,7 @@ sp-io = { version = "2.0.0", default-features = false, git = "https://github.com
 fp-evm = { version = "0.8.0", default-features = false, path = "../../primitives/evm" }
 primitive-types = { version = "0.7.0", default-features = false, features = ["rlp", "byteorder"] }
 rlp = { version = "0.4", default-features = false }
-evm = { version = "0.18", default-features = false, features = ["with-codec"] }
+evm = { version = "0.18.5", default-features = false, features = ["with-codec"] }
 evm-runtime = { version = "0.18", default-features = false }
 evm-gasometer = { version = "0.18", default-features = false }
 sha3 = { version = "0.8", default-features = false }

--- a/primitives/evm/Cargo.toml
+++ b/primitives/evm/Cargo.toml
@@ -18,7 +18,7 @@ sp-core = { version = "2.0.0", git = "https://github.com/paritytech/substrate.gi
 sp-std = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier", default-features = false }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "1.3.4", default-features = false }
-evm = { version = "0.18", default-features = false, features = ["with-codec"] }
+evm = { version = "0.18.5", default-features = false, features = ["with-codec"] }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
The crate requires features from `evm` that is only available after this patch version, so while `evm` is backward compatible and the versioning is okay, for Frontier the specific patch version must be present.