### PR TITLE
Support for evm "estimate" flag for RPC estimation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1185,9 +1185,9 @@ checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 
 [[package]]
 name = "evm"
-version = "0.18.5"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5286da2277b078e7033491d62e674eeccd01d913a87bb60ec0cabbcf80ec62e9"
+checksum = "ea0da85b407262b8caaffec7c5cb04c255538afdc1245de482d6216580d1f5e2"
 dependencies = [
  "ethereum",
  "evm-core",
@@ -1203,9 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "evm-core"
-version = "0.18.3"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63c6c39300d7779427f461408d867426e202ea72ac7ece2455689ff0e4bddb6f"
+checksum = "decb1397cbc7c7e3c3fee6564eed1f294612a0365c66c90ab92726d19d253a6e"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -1214,9 +1214,9 @@ dependencies = [
 
 [[package]]
 name = "evm-gasometer"
-version = "0.18.3"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "689c481648c3f45b64b1278077c04284ad535e068c9d6872153c7b74da7ccb03"
+checksum = "da079283764366124ee955f0bd049e691c3d00895e88c79d9c3b744ff4cd6595"
 dependencies = [
  "evm-core",
  "evm-runtime",
@@ -1225,9 +1225,9 @@ dependencies = [
 
 [[package]]
 name = "evm-runtime"
-version = "0.18.3"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a148ad1b3e0af31aa03c6c3cc9df3a529e279dad8e29b4ef90dccad32601e4"
+checksum = "95524d03dfcd11ca540fa3481d76dcc891db1abf704c2bec7a67fc51cdf95e67"
 dependencies = [
  "evm-core",
  "primitive-types",
@@ -7611,7 +7611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f8ab788026715fa63b31960869617cba39117e520eb415b0139543e325ab59"
 dependencies = [
  "cfg-if 0.1.10",
- "rand 0.3.23",
+ "rand 0.7.3",
  "static_assertions",
 ]
 

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -632,6 +632,7 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 						gas_limit,
 						gas_price,
 						nonce,
+						false,
 					)
 					.map_err(|err| internal_err(format!("runtime error: {:?}", err)))?
 					.map_err(|err| internal_err(format!("execution fatal: {:?}", err)))?;
@@ -650,6 +651,7 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 						gas_limit,
 						gas_price,
 						nonce,
+						false,
 					)
 					.map_err(|err| internal_err(format!("runtime error: {:?}", err)))?
 					.map_err(|err| internal_err(format!("execution fatal: {:?}", err)))?;
@@ -689,6 +691,7 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 						gas_limit,
 						gas_price,
 						nonce,
+						true,
 					)
 					.map_err(|err| internal_err(format!("runtime error: {:?}", err)))?
 					.map_err(|err| internal_err(format!("execution fatal: {:?}", err)))?;
@@ -707,6 +710,7 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 						gas_limit,
 						gas_price,
 						nonce,
+						true,
 					)
 					.map_err(|err| internal_err(format!("runtime error: {:?}", err)))?
 					.map_err(|err| internal_err(format!("execution fatal: {:?}", err)))?;

--- a/frame/ethereum/Cargo.toml
+++ b/frame/ethereum/Cargo.toml
@@ -19,7 +19,7 @@ sp-runtime = { version = "2.0.0-dev", default-features = false, git = "https://g
 sp-std = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-evm = { version = "0.8.0", default-features = false, path = "../../primitives/evm" }
-evm = { version = "0.18.0", features = ["with-codec"], default-features = false }
+evm = { version = "0.19.0", features = ["with-codec"], default-features = false }
 ethereum = { version = "0.5", default-features = false, features = ["with-codec"] }
 ethereum-types = { version = "0.9", default-features = false }
 rlp = { version = "0.4", default-features = false }

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -133,6 +133,7 @@ decl_module! {
 				Some(transaction.gas_price),
 				Some(transaction.nonce),
 				transaction.action,
+				None,
 			)?;
 
 			let (reason, status, used_gas) = match info {
@@ -372,7 +373,7 @@ impl<T: Trait> Module<T> {
 		CurrentReceipts::get()
 	}
 
-	/// Execute an Ethereum transaction, ignoring transaction signatures.
+	/// Execute an Ethereum transaction.
 	pub fn execute(
 		from: H160,
 		input: Vec<u8>,
@@ -381,6 +382,7 @@ impl<T: Trait> Module<T> {
 		gas_price: Option<U256>,
 		nonce: Option<U256>,
 		action: TransactionAction,
+		config: Option<evm::Config>,
 	) -> Result<(Option<H160>, CallOrCreateInfo), DispatchError> {
 		match action {
 			ethereum::TransactionAction::Call(target) => {
@@ -392,7 +394,7 @@ impl<T: Trait> Module<T> {
 					gas_limit.low_u32(),
 					gas_price,
 					nonce,
-					T::config(),
+					config.as_ref().unwrap_or(T::config()),
 				).map_err(Into::into)?)))
 			},
 			ethereum::TransactionAction::Create => {
@@ -403,7 +405,7 @@ impl<T: Trait> Module<T> {
 					gas_limit.low_u32(),
 					gas_price,
 					nonce,
-					T::config(),
+					config.as_ref().unwrap_or(T::config()),
 				).map_err(Into::into)?)))
 			},
 		}

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -392,6 +392,7 @@ impl<T: Trait> Module<T> {
 					gas_limit.low_u32(),
 					gas_price,
 					nonce,
+					T::config(),
 				).map_err(Into::into)?)))
 			},
 			ethereum::TransactionAction::Create => {
@@ -402,6 +403,7 @@ impl<T: Trait> Module<T> {
 					gas_limit.low_u32(),
 					gas_price,
 					nonce,
+					T::config(),
 				).map_err(Into::into)?)))
 			},
 		}

--- a/frame/ethereum/src/tests.rs
+++ b/frame/ethereum/src/tests.rs
@@ -66,6 +66,7 @@ fn transaction_should_increment_nonce() {
 			Some(t.gas_price),
 			Some(t.nonce),
 			t.action,
+			None,
 		));
 		assert_eq!(Evm::account_basic(&alice.address).nonce, U256::from(1));
 	});
@@ -115,6 +116,7 @@ fn transaction_with_invalid_nonce_should_not_work() {
 			Some(t.gas_price),
 			Some(t.nonce),
 			t.action,
+			None,
 		));
 
 		transaction.nonce = U256::from(0);
@@ -143,6 +145,7 @@ fn contract_constructor_should_get_executed() {
 			Some(t.gas_price),
 			Some(t.nonce),
 			t.action,
+			None,
 		));
 		assert_eq!(Evm::account_storages(
 			erc20_address, alice_storage_address
@@ -204,6 +207,7 @@ fn contract_should_be_created_at_given_address() {
 			Some(t.gas_price),
 			Some(t.nonce),
 			t.action,
+			None,
 		));
 		assert_ne!(Evm::account_codes(erc20_address).len(), 0);
 	});
@@ -226,6 +230,7 @@ fn transaction_should_generate_correct_gas_used() {
 			Some(t.gas_price),
 			Some(t.nonce),
 			t.action,
+			None,
 		).unwrap();
 
 		match info {
@@ -270,6 +275,7 @@ fn call_should_handle_errors() {
 			Some(t.gas_price),
 			Some(t.nonce),
 			t.action,
+			None,
 		));
 
 		let contract_address: Vec<u8> = FromHex::from_hex("32dcab0ef3fb2de2fce1d2e0799d36239671f04a").unwrap();
@@ -285,6 +291,7 @@ fn call_should_handle_errors() {
 			Some(U256::from(1)),
 			Some(U256::from(1)),
 			TransactionAction::Call(H160::from_slice(&contract_address)),
+			None,
 		).unwrap();
 
 		match info {
@@ -302,7 +309,8 @@ fn call_should_handle_errors() {
 			U256::from(1048576),
 			Some(U256::from(1)),
 			Some(U256::from(2)),
-			TransactionAction::Call(H160::from_slice(&contract_address))
+			TransactionAction::Call(H160::from_slice(&contract_address)),
+			None,
 		).ok().unwrap();
 	});
 }

--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -26,9 +26,9 @@ sp-io = { version = "2.0.0", default-features = false, git = "https://github.com
 fp-evm = { version = "0.8.0", default-features = false, path = "../../primitives/evm" }
 primitive-types = { version = "0.7.0", default-features = false, features = ["rlp", "byteorder"] }
 rlp = { version = "0.4", default-features = false }
-evm = { version = "0.18.5", default-features = false, features = ["with-codec"] }
-evm-runtime = { version = "0.18", default-features = false }
-evm-gasometer = { version = "0.18", default-features = false }
+evm = { version = "0.19.0", default-features = false, features = ["with-codec"] }
+evm-runtime = { version = "0.19.0", default-features = false }
+evm-gasometer = { version = "0.19.0", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 impl-trait-for-tuples = "0.1"
 ripemd160 = { version = "0.9", default-features = false }

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -391,6 +391,7 @@ decl_module! {
 				gas_limit,
 				Some(gas_price),
 				nonce,
+				T::config(),
 			)?;
 
 			match info.exit_reason {
@@ -429,6 +430,7 @@ decl_module! {
 				gas_limit,
 				Some(gas_price),
 				nonce,
+				T::config(),
 			)?;
 
 			match info {
@@ -476,6 +478,7 @@ decl_module! {
 				gas_limit,
 				Some(gas_price),
 				nonce,
+				T::config(),
 			)?;
 
 			match info {

--- a/frame/evm/src/runner/builtin.rs
+++ b/frame/evm/src/runner/builtin.rs
@@ -55,7 +55,7 @@ impl<T: Trait> RunnerT<T> for Runner<T> {
 		gas_limit: u32,
 		gas_price: Option<U256>,
 		nonce: Option<U256>,
-		config: &'static evm::Config,
+		config: &evm::Config,
 	) -> Result<CallInfo, Self::Error> {
 		let gas_price = match gas_price {
 			Some(gas_price) => {
@@ -122,7 +122,7 @@ impl<T: Trait> RunnerT<T> for Runner<T> {
 		gas_limit: u32,
 		gas_price: Option<U256>,
 		nonce: Option<U256>,
-		config: &'static evm::Config,
+		config: &evm::Config,
 	) -> Result<CreateInfo, Self::Error> {
 		let gas_price = match gas_price {
 			Some(gas_price) => {
@@ -201,7 +201,7 @@ impl<T: Trait> RunnerT<T> for Runner<T> {
 		gas_limit: u32,
 		gas_price: Option<U256>,
 		nonce: Option<U256>,
-		config: &'static evm::Config,
+		config: &evm::Config,
 	) -> Result<CreateInfo, Self::Error> {
 		let gas_price = match gas_price {
 			Some(gas_price) => {

--- a/frame/evm/src/runner/builtin.rs
+++ b/frame/evm/src/runner/builtin.rs
@@ -55,6 +55,7 @@ impl<T: Trait> RunnerT<T> for Runner<T> {
 		gas_limit: u32,
 		gas_price: Option<U256>,
 		nonce: Option<U256>,
+		config: &'static evm::Config,
 	) -> Result<CallInfo, Self::Error> {
 		let gas_price = match gas_price {
 			Some(gas_price) => {
@@ -76,8 +77,6 @@ impl<T: Trait> RunnerT<T> for Runner<T> {
 				gas_price,
 				origin: source,
 			};
-
-			let config = T::config();
 
 			let mut substate = Handler::<T>::new_with_precompile(
 				&vicinity,
@@ -123,6 +122,7 @@ impl<T: Trait> RunnerT<T> for Runner<T> {
 		gas_limit: u32,
 		gas_price: Option<U256>,
 		nonce: Option<U256>,
+		config: &'static evm::Config,
 	) -> Result<CreateInfo, Self::Error> {
 		let gas_price = match gas_price {
 			Some(gas_price) => {
@@ -144,8 +144,6 @@ impl<T: Trait> RunnerT<T> for Runner<T> {
 				gas_price,
 				origin: source,
 			};
-
-			let config = T::config();
 
 			let mut substate = Handler::<T>::new_with_precompile(
 				&vicinity,
@@ -203,6 +201,7 @@ impl<T: Trait> RunnerT<T> for Runner<T> {
 		gas_limit: u32,
 		gas_price: Option<U256>,
 		nonce: Option<U256>,
+		config: &'static evm::Config,
 	) -> Result<CreateInfo, Self::Error> {
 		let gas_price = match gas_price {
 			Some(gas_price) => {
@@ -224,8 +223,6 @@ impl<T: Trait> RunnerT<T> for Runner<T> {
 				gas_price,
 				origin: source,
 			};
-
-			let config = T::config();
 
 			let mut substate = Handler::<T>::new_with_precompile(
 				&vicinity,

--- a/frame/evm/src/runner/mod.rs
+++ b/frame/evm/src/runner/mod.rs
@@ -34,7 +34,7 @@ pub trait Runner<T: Trait> {
 		gas_limit: u32,
 		gas_price: Option<U256>,
 		nonce: Option<U256>,
-		config: &'static evm::Config,
+		config: &evm::Config,
 	) -> Result<CallInfo, Self::Error>;
 
 	fn create(
@@ -44,7 +44,7 @@ pub trait Runner<T: Trait> {
 		gas_limit: u32,
 		gas_price: Option<U256>,
 		nonce: Option<U256>,
-		config: &'static evm::Config,
+		config: &evm::Config,
 	) -> Result<CreateInfo, Self::Error>;
 
 	fn create2(
@@ -55,6 +55,6 @@ pub trait Runner<T: Trait> {
 		gas_limit: u32,
 		gas_price: Option<U256>,
 		nonce: Option<U256>,
-		config: &'static evm::Config,
+		config: &evm::Config,
 	) -> Result<CreateInfo, Self::Error>;
 }

--- a/frame/evm/src/runner/mod.rs
+++ b/frame/evm/src/runner/mod.rs
@@ -34,6 +34,7 @@ pub trait Runner<T: Trait> {
 		gas_limit: u32,
 		gas_price: Option<U256>,
 		nonce: Option<U256>,
+		config: &'static evm::Config,
 	) -> Result<CallInfo, Self::Error>;
 
 	fn create(
@@ -43,6 +44,7 @@ pub trait Runner<T: Trait> {
 		gas_limit: u32,
 		gas_price: Option<U256>,
 		nonce: Option<U256>,
+		config: &'static evm::Config,
 	) -> Result<CreateInfo, Self::Error>;
 
 	fn create2(
@@ -53,5 +55,6 @@ pub trait Runner<T: Trait> {
 		gas_limit: u32,
 		gas_price: Option<U256>,
 		nonce: Option<U256>,
+		config: &'static evm::Config,
 	) -> Result<CreateInfo, Self::Error>;
 }

--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -44,6 +44,7 @@ impl<T: Trait> Runner<T> {
 		gas_limit: u32,
 		gas_price: Option<U256>,
 		nonce: Option<U256>,
+		config: &'static evm::Config,
 		f: F,
 	) -> Result<ExecutionInfo<R>, Error<T>> where
 		F: FnOnce(&mut StackExecutor<Backend<T>>) -> (ExitReason, R),
@@ -66,7 +67,7 @@ impl<T: Trait> Runner<T> {
 		let mut executor = StackExecutor::new_with_precompile(
 			&backend,
 			gas_limit as usize,
-			T::config(),
+			config,
 			T::Precompiles::execute,
 		);
 
@@ -120,6 +121,7 @@ impl<T: Trait> RunnerT<T> for Runner<T> {
 		gas_limit: u32,
 		gas_price: Option<U256>,
 		nonce: Option<U256>,
+		config: &'static evm::Config,
 	) -> Result<CallInfo, Self::Error> {
 		Self::execute(
 			source,
@@ -127,6 +129,7 @@ impl<T: Trait> RunnerT<T> for Runner<T> {
 			gas_limit,
 			gas_price,
 			nonce,
+			config,
 			|executor| executor.transact_call(
 				source,
 				target,
@@ -144,6 +147,7 @@ impl<T: Trait> RunnerT<T> for Runner<T> {
 		gas_limit: u32,
 		gas_price: Option<U256>,
 		nonce: Option<U256>,
+		config: &'static evm::Config,
 	) -> Result<CreateInfo, Self::Error> {
 		Self::execute(
 			source,
@@ -151,6 +155,7 @@ impl<T: Trait> RunnerT<T> for Runner<T> {
 			gas_limit,
 			gas_price,
 			nonce,
+			config,
 			|executor| {
 				let address = executor.create_address(
 					evm::CreateScheme::Legacy { caller: source },
@@ -173,6 +178,7 @@ impl<T: Trait> RunnerT<T> for Runner<T> {
 		gas_limit: u32,
 		gas_price: Option<U256>,
 		nonce: Option<U256>,
+		config: &'static evm::Config,
 	) -> Result<CreateInfo, Self::Error> {
 		let code_hash = H256::from_slice(Keccak256::digest(&init).as_slice());
 		Self::execute(
@@ -181,6 +187,7 @@ impl<T: Trait> RunnerT<T> for Runner<T> {
 			gas_limit,
 			gas_price,
 			nonce,
+			config,
 			|executor| {
 				let address = executor.create_address(
 					evm::CreateScheme::Create2 { caller: source, code_hash, salt },

--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -44,7 +44,7 @@ impl<T: Trait> Runner<T> {
 		gas_limit: u32,
 		gas_price: Option<U256>,
 		nonce: Option<U256>,
-		config: &'static evm::Config,
+		config: &evm::Config,
 		f: F,
 	) -> Result<ExecutionInfo<R>, Error<T>> where
 		F: FnOnce(&mut StackExecutor<Backend<T>>) -> (ExitReason, R),
@@ -121,7 +121,7 @@ impl<T: Trait> RunnerT<T> for Runner<T> {
 		gas_limit: u32,
 		gas_price: Option<U256>,
 		nonce: Option<U256>,
-		config: &'static evm::Config,
+		config: &evm::Config,
 	) -> Result<CallInfo, Self::Error> {
 		Self::execute(
 			source,
@@ -147,7 +147,7 @@ impl<T: Trait> RunnerT<T> for Runner<T> {
 		gas_limit: u32,
 		gas_price: Option<U256>,
 		nonce: Option<U256>,
-		config: &'static evm::Config,
+		config: &evm::Config,
 	) -> Result<CreateInfo, Self::Error> {
 		Self::execute(
 			source,
@@ -178,7 +178,7 @@ impl<T: Trait> RunnerT<T> for Runner<T> {
 		gas_limit: u32,
 		gas_price: Option<U256>,
 		nonce: Option<U256>,
-		config: &'static evm::Config,
+		config: &evm::Config,
 	) -> Result<CreateInfo, Self::Error> {
 		let code_hash = H256::from_slice(Keccak256::digest(&init).as_slice());
 		Self::execute(

--- a/primitives/evm/Cargo.toml
+++ b/primitives/evm/Cargo.toml
@@ -18,7 +18,7 @@ sp-core = { version = "2.0.0", git = "https://github.com/paritytech/substrate.gi
 sp-std = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier", default-features = false }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "1.3.4", default-features = false }
-evm = { version = "0.18.5", default-features = false, features = ["with-codec"] }
+evm = { version = "0.19.0", default-features = false, features = ["with-codec"] }
 
 [features]
 default = ["std"]

--- a/primitives/rpc/src/lib.rs
+++ b/primitives/rpc/src/lib.rs
@@ -63,7 +63,7 @@ sp_api::decl_runtime_apis! {
 		fn author() -> H160;
 		/// For a given account address and index, returns pallet_evm::AccountStorages.
 		fn storage_at(address: H160, index: U256) -> H256;
-		/// Returns a frame_ethereum::call response.
+		/// Returns a frame_ethereum::call response. If `estimate` is true,
 		fn call(
 			from: H160,
 			to: H160,
@@ -72,6 +72,7 @@ sp_api::decl_runtime_apis! {
 			gas_limit: U256,
 			gas_price: Option<U256>,
 			nonce: Option<U256>,
+			estimate: bool,
 		) -> Result<fp_evm::CallInfo, sp_runtime::DispatchError>;
 		/// Returns a frame_ethereum::create response.
 		fn create(
@@ -81,6 +82,7 @@ sp_api::decl_runtime_apis! {
 			gas_limit: U256,
 			gas_price: Option<U256>,
 			nonce: Option<U256>,
+			estimate: bool,
 		) -> Result<fp_evm::CreateInfo, sp_runtime::DispatchError>;
 		/// Return the current block.
 		fn current_block() -> Option<EthereumBlock>;

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -509,6 +509,7 @@ impl_runtime_apis! {
 				gas_limit.low_u32(),
 				gas_price,
 				nonce,
+				<Runtime as pallet_evm::Trait>::config(),
 			).map_err(|err| err.into())
 		}
 
@@ -527,6 +528,7 @@ impl_runtime_apis! {
 				gas_limit.low_u32(),
 				gas_price,
 				nonce,
+				<Runtime as pallet_evm::Trait>::config(),
 			).map_err(|err| err.into())
 		}
 

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -500,7 +500,16 @@ impl_runtime_apis! {
 			gas_limit: U256,
 			gas_price: Option<U256>,
 			nonce: Option<U256>,
+			estimate: bool,
 		) -> Result<pallet_evm::CallInfo, sp_runtime::DispatchError> {
+			let config = if estimate {
+				let mut config = <Runtime as pallet_evm::Trait>::config().clone();
+				config.estimate = true;
+				Some(config)
+			} else {
+				None
+			};
+
 			<Runtime as pallet_evm::Trait>::Runner::call(
 				from,
 				to,
@@ -509,7 +518,7 @@ impl_runtime_apis! {
 				gas_limit.low_u32(),
 				gas_price,
 				nonce,
-				<Runtime as pallet_evm::Trait>::config(),
+				config.as_ref().unwrap_or(<Runtime as pallet_evm::Trait>::config()),
 			).map_err(|err| err.into())
 		}
 
@@ -520,7 +529,16 @@ impl_runtime_apis! {
 			gas_limit: U256,
 			gas_price: Option<U256>,
 			nonce: Option<U256>,
+			estimate: bool,
 		) -> Result<pallet_evm::CreateInfo, sp_runtime::DispatchError> {
+			let config = if estimate {
+				let mut config = <Runtime as pallet_evm::Trait>::config().clone();
+				config.estimate = true;
+				Some(config)
+			} else {
+				None
+			};
+
 			<Runtime as pallet_evm::Trait>::Runner::create(
 				from,
 				data,
@@ -528,7 +546,7 @@ impl_runtime_apis! {
 				gas_limit.low_u32(),
 				gas_price,
 				nonce,
-				<Runtime as pallet_evm::Trait>::config(),
+				config.as_ref().unwrap_or(<Runtime as pallet_evm::Trait>::config()),
 			).map_err(|err| err.into())
 		}
 


### PR DESCRIPTION
This uses the new "estimate" flag available in `evm` 0.19 -- if enabled, all refunds are stripped, and SSTORE cost is always calculated at its highest value. Should be deal with most cases of #198.

This can be optionally combined with #229 (use Geth's binary search as fallback). However, it would be great to figure out a way to encourage people to submit issue reports if #229 is triggered (so that we can fix those cases "natively" in `evm`).