### PR TITLE
Docs CI naming

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Deploy docs
+name: Docs
 
 on:
     push:
@@ -7,7 +7,7 @@ on:
 
 jobs:
     release:
-        name: Release docs
+        name: Deploy docs
         runs-on: ubuntu-latest
 
         steps:


### PR DESCRIPTION
Change the action name to `Docs` and the task name to `Deploy docs`, to keep it consistent with the rest of actions.