### PR TITLE
Support pending transactions on rpc

### DIFF
--- a/client/consensus/Cargo.toml
+++ b/client/consensus/Cargo.toml
@@ -23,5 +23,3 @@ futures = { version = "0.3.1", features = ["compat"] }
 sp-timestamp = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 derive_more = "0.99.2"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/substrate.git", branch = "frontier"}
-ethereum = { version = "0.5", features = ["with-codec"] }
-fc-rpc-core = { path = "../rpc-core" }

--- a/client/consensus/Cargo.toml
+++ b/client/consensus/Cargo.toml
@@ -24,3 +24,4 @@ sp-timestamp = { version = "2.0.0", git = "https://github.com/paritytech/substra
 derive_more = "0.99.2"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/substrate.git", branch = "frontier"}
 ethereum = { version = "0.5", features = ["with-codec"] }
+fc-rpc-core = { path = "../rpc-core" }

--- a/client/consensus/src/lib.rs
+++ b/client/consensus/src/lib.rs
@@ -38,6 +38,8 @@ use fc_rpc_core::types::PendingTransactions;
 use log::*;
 use sc_client_api;
 
+const TRANSACTION_RETAIN_THRESHOLD: u64 = 5;
+
 #[derive(derive_more::Display, Debug)]
 pub enum Error {
 	#[display(fmt = "Multiple post-runtime Ethereum blocks, rejecting!")]
@@ -155,7 +157,7 @@ impl<B, I, C> BlockImport<B> for FrontierBlockImport<B, I, C> where
 									if transaction_hashes.contains(&k) {
 										return false;
 									}
-									if number < v.at_block + 5 {
+									if number < v.at_block + TRANSACTION_RETAIN_THRESHOLD {
 										return false;
 									}
 									true

--- a/client/consensus/src/lib.rs
+++ b/client/consensus/src/lib.rs
@@ -133,9 +133,7 @@ impl<B, I, C> BlockImport<B> for FrontierBlockImport<B, I, C> where
 		}
 		if let Some(pending) = &self.pending_transactions {
 			if let Ok(locked) = &mut pending.lock() {
-				println!("---> Clearing pending PRE {}", locked.len());
 				locked.clear();
-				println!("---> Clearing pending {}", locked.len());
 			}
 		}
 

--- a/client/consensus/src/lib.rs
+++ b/client/consensus/src/lib.rs
@@ -132,9 +132,11 @@ impl<B, I, C> BlockImport<B> for FrontierBlockImport<B, I, C> where
 			)
 		}
 		if let Some(pending) = &self.pending_transactions {
-			println!("---> Clearing pending PRE {}", pending.lock().unwrap().len());
-			pending.lock().unwrap().clear();
-			println!("---> Clearing pending {}", pending.lock().unwrap().len());
+			if let Ok(locked) = &mut pending.lock() {
+				println!("---> Clearing pending PRE {}", locked.len());
+				locked.clear();
+				println!("---> Clearing pending {}", locked.len());
+			}
 		}
 
 		let client = self.client.clone();

--- a/client/consensus/src/lib.rs
+++ b/client/consensus/src/lib.rs
@@ -62,7 +62,7 @@ impl std::convert::From<Error> for ConsensusError {
 pub struct FrontierBlockImport<B: BlockT, I, C> {
 	inner: I,
 	client: Arc<C>,
-	pending_transactions: Arc<Mutex<HashMap<H256, Transaction>>>,
+	pending_transactions: Option<Arc<Mutex<HashMap<H256, Transaction>>>>,
 	enabled: bool,
 	_marker: PhantomData<B>,
 }
@@ -89,7 +89,7 @@ impl<B, I, C> FrontierBlockImport<B, I, C> where
 	pub fn new(
 		inner: I,
 		client: Arc<C>,
-		pending_transactions: Arc<Mutex<HashMap<H256, Transaction>>>,
+		pending_transactions: Option<Arc<Mutex<HashMap<H256, Transaction>>>>,
 		enabled: bool,
 	) -> Self {
 		Self {
@@ -131,7 +131,11 @@ impl<B, I, C> BlockImport<B> for FrontierBlockImport<B, I, C> where
 				)
 			)
 		}
-		self.pending_transactions.lock().unwrap().clear();
+		if let Some(pending) = &self.pending_transactions {
+			println!("---> Clearing pending PRE {}", pending.lock().unwrap().len());
+			pending.lock().unwrap().clear();
+			println!("---> Clearing pending {}", pending.lock().unwrap().len());
+		}
 
 		let client = self.client.clone();
 

--- a/client/rpc-core/src/types/mod.rs
+++ b/client/rpc-core/src/types/mod.rs
@@ -47,6 +47,8 @@ pub use self::sync::{
 	SyncStatus, SyncInfo, Peers, PeerInfo, PeerNetworkInfo, PeerProtocolsInfo,
 	TransactionStats, ChainStatus, EthProtocolInfo, PipProtocolInfo,
 };
-pub use self::transaction::{Transaction, RichRawTransaction, LocalTransactionStatus};
+pub use self::transaction::{
+	Transaction, RichRawTransaction, LocalTransactionStatus, PendingTransactions, PendingTransaction,
+};
 pub use self::transaction_request::TransactionRequest;
 pub use self::work::Work;

--- a/client/rpc-core/src/types/transaction.rs
+++ b/client/rpc-core/src/types/transaction.rs
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use std::{sync::{Arc, Mutex}, time::Instant, collections::HashMap};
+use std::{sync::{Arc, Mutex}, collections::HashMap};
 use serde::{Serialize, Serializer};
 use serde::ser::SerializeStruct;
 use ethereum_types::{H160, H256, H512, U64, U256};
@@ -158,12 +158,12 @@ pub struct RichRawTransaction {
 
 pub struct PendingTransaction {
 	pub transaction: Transaction,
-	pub instant: Instant
+	pub at_block: u64
 }
 
 impl PendingTransaction {
-	pub fn new(transaction: Transaction, instant: Instant) -> Self {
-		Self { transaction, instant }
+	pub fn new(transaction: Transaction, at_block: u64) -> Self {
+		Self { transaction, at_block }
 	}
 }
 

--- a/client/rpc-core/src/types/transaction.rs
+++ b/client/rpc-core/src/types/transaction.rs
@@ -16,6 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+use std::{sync::{Arc, Mutex}, time::Instant, collections::HashMap};
 use serde::{Serialize, Serializer};
 use serde::ser::SerializeStruct;
 use ethereum_types::{H160, H256, H512, U64, U256};
@@ -154,3 +155,16 @@ pub struct RichRawTransaction {
 	#[serde(rename = "tx")]
 	pub transaction: Transaction
 }
+
+pub struct PendingTransaction {
+	pub transaction: Transaction,
+	pub instant: Instant
+}
+
+impl PendingTransaction {
+	pub fn new(transaction: Transaction, instant: Instant) -> Self {
+		Self { transaction, instant }
+	}
+}
+
+pub type PendingTransactions = Option<Arc<Mutex<HashMap<H256, PendingTransaction>>>>;

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -628,7 +628,6 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 								transaction_hash,
 								pending_transaction_build(transaction_hash, transaction)
 							);
-							println!("---> Inserting to pending {}", locked.len());
 						}
 					}
 					transaction_hash
@@ -664,7 +663,6 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 								transaction_hash,
 								pending_transaction_build(transaction_hash, transaction)
 							);
-							println!("---> Inserting to pending {}", locked.len());
 						}
 					}
 					transaction_hash

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -623,11 +623,13 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 				.compat()
 				.map(move |_| {
 					if let Some(pending) = pending {
-						pending.lock().unwrap().insert(
-							transaction_hash,
-							pending_transaction_build(transaction_hash, transaction)
-						);
-						println!("---> Inserting to pending {}", pending.lock().unwrap().len());
+						if let Ok(locked) = &mut pending.lock() {
+							locked.insert(
+								transaction_hash,
+								pending_transaction_build(transaction_hash, transaction)
+							);
+							println!("---> Inserting to pending {}", locked.len());
+						}
 					}
 					transaction_hash
 				})
@@ -657,11 +659,13 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 				.compat()
 				.map(move |_| {
 					if let Some(pending) = pending {
-						pending.lock().unwrap().insert(
-							transaction_hash,
-							pending_transaction_build(transaction_hash, transaction)
-						);
-						println!("---> Inserting to pending {}", pending.lock().unwrap().len());
+						if let Ok(locked) = &mut pending.lock() {
+							locked.insert(
+								transaction_hash,
+								pending_transaction_build(transaction_hash, transaction)
+							);
+							println!("---> Inserting to pending {}", locked.len());
+						}
 					}
 					transaction_hash
 				})

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -106,8 +106,8 @@ fn pending_transaction_build(hash: H256, transaction: EthereumTransaction) -> Tr
 		gas_price: transaction.gas_price,
 		gas: transaction.gas_limit,
 		input: Bytes(transaction.input),
-		creates: None, // TODO? Option<H160>
-		raw: Bytes(Vec::new()), // TODO raw transaction
+		creates: None,
+		raw: Bytes(Vec::new()),
 		public_key: match pubkey {
 			Some(pk) => Some(H512::from(pk)),
 			_ => None

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -778,8 +778,10 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 			Some((hash, index)) => (hash, index as usize),
 			None => {
 				if let Some(pending) = &self.pending_transactions {
-					if let Some(transaction) = pending.lock().unwrap().get(&hash) {
-						return Ok(Some(transaction.clone()));
+					if let Ok(locked) = &mut pending.lock() {
+						if let Some(transaction) = locked.get(&hash) {
+							return Ok(Some(transaction.clone()));
+						}
 					}
 				}
 				return Ok(None);

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use std::{marker::PhantomData, sync::Arc, time::Instant};
+use std::{marker::PhantomData, sync::Arc};
 use std::collections::BTreeMap;
 use ethereum::{
 	Block as EthereumBlock, Transaction as EthereumTransaction
@@ -591,6 +591,7 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 			Keccak256::digest(&rlp::encode(&transaction)).as_slice()
 		);
 		let hash = self.client.info().best_hash;
+		let number = self.client.info().best_number;
 		let pending = self.pending_transactions.clone();
 		Box::new(
 			self.pool
@@ -607,7 +608,9 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 								transaction_hash,
 								PendingTransaction::new(
 									transaction_build(transaction, None, None),
-									Instant::now()
+									UniqueSaturatedInto::<u64>::unique_saturated_into(
+										number
+									)
 								)
 							);
 						}
@@ -629,6 +632,7 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 			Keccak256::digest(&rlp::encode(&transaction)).as_slice()
 		);
 		let hash = self.client.info().best_hash;
+		let number = self.client.info().best_number;
 		let pending = self.pending_transactions.clone();
 		Box::new(
 			self.pool
@@ -645,7 +649,9 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 								transaction_hash,
 								PendingTransaction::new(
 									transaction_build(transaction, None, None),
-									Instant::now()
+									UniqueSaturatedInto::<u64>::unique_saturated_into(
+										number
+									)
 								)
 							);
 						}

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -160,13 +160,13 @@ fn transaction_build(
 				Keccak256::digest(&rlp::encode(&block.header)).as_slice()
 			))
 		}),
-		block_number: block.as_ref().map_or(None, |block| Some(block.header.number)),
-		transaction_index: status.as_ref().map_or(None, |status| {
-			Some(U256::from(
+		block_number: block.as_ref().map(|block| block.header.number),
+		transaction_index: status.as_ref().map(|status| {
+			U256::from(
 				UniqueSaturatedInto::<u32>::unique_saturated_into(
 					status.transaction_index
 				)
-			))
+			)
 		}),
 		from: status.as_ref().map_or({
 			match pubkey {
@@ -188,7 +188,7 @@ fn transaction_build(
 		input: Bytes(transaction.clone().input),
 		creates: status.as_ref().map_or(None, |status| status.contract_address),
 		raw: Bytes(rlp::encode(&transaction)),
-		public_key: pubkey.as_ref().map_or(None, |pk| Some(H512::from(pk))),
+		public_key: pubkey.as_ref().map(|pk| H512::from(pk)),
 		chain_id: transaction.signature.chain_id().map(U64::from),
 		standard_v: U256::from(transaction.signature.standard_v()),
 		v: U256::from(transaction.signature.v()),

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -23,6 +23,9 @@ pub use eth::{EthApi, EthApiServer, NetApi, NetApiServer, Web3Api, Web3ApiServer
 pub use eth_pubsub::{EthPubSubApi, EthPubSubApiServer, HexEncodedIdProvider};
 
 use ethereum_types::{H160, H256};
+use ethereum::{
+	Transaction as EthereumTransaction, TransactionMessage as EthereumTransactionMessage,
+};
 use jsonrpc_core::{ErrorCode, Error, Value};
 use rustc_hex::ToHex;
 use pallet_evm::ExitReason;
@@ -71,6 +74,19 @@ pub fn error_on_execution_failure(reason: &ExitReason, data: &[u8]) -> Result<()
 			})
 		},
 	}
+}
+
+pub fn public_key(transaction: &EthereumTransaction) -> Result<
+	[u8; 64], sp_io::EcdsaVerifyError
+> {
+	let mut sig = [0u8; 65];
+	let mut msg = [0u8; 32];
+	sig[0..32].copy_from_slice(&transaction.signature.r()[..]);
+	sig[32..64].copy_from_slice(&transaction.signature.s()[..]);
+	sig[64] = transaction.signature.standard_v();
+	msg.copy_from_slice(&EthereumTransactionMessage::from(transaction.clone()).hash()[..]);
+
+	sp_io::crypto::secp256k1_ecdsa_recover(&sig, &msg)
 }
 
 /// A generic Ethereum signer.

--- a/template/node/Cargo.toml
+++ b/template/node/Cargo.toml
@@ -49,6 +49,7 @@ sc-basic-authorship = { git = "https://github.com/paritytech/substrate.git", bra
 sp-block-builder = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 
 fc-consensus = { path = "../../client/consensus" }
+fp-consensus = { path = "../../primitives/consensus" }
 frontier-template-runtime = { path = "../runtime" }
 fc-rpc = { path = "../../client/rpc" }
 fp-rpc = { path = "../../primitives/rpc" }

--- a/template/node/Cargo.toml
+++ b/template/node/Cargo.toml
@@ -52,6 +52,7 @@ fc-consensus = { path = "../../client/consensus" }
 frontier-template-runtime = { path = "../runtime" }
 fc-rpc = { path = "../../client/rpc" }
 fp-rpc = { path = "../../primitives/rpc" }
+fc-rpc-core = { path = "../../client/rpc-core" }
 
 [build-dependencies]
 substrate-build-script-utils = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -46,7 +46,7 @@ pub struct FullDeps<C, P> {
 	pub enable_dev_signer: bool,
 	/// Network service
 	pub network: Arc<NetworkService<Block, Hash>>,
-	/// Ethereum pending transactions. 
+	/// Ethereum pending transactions.
 	pub pending_transactions: Option<Arc<Mutex<HashMap<H256, Transaction>>>>,
 	/// Manual seal command sink
 	pub command_sink: Option<futures::channel::mpsc::Sender<sc_consensus_manual_seal::rpc::EngineCommand<Hash>>>,

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -1,7 +1,9 @@
 //! A collection of node-specific RPC methods.
 
-use std::{sync::Arc, fmt};
+use std::{sync::{Arc, Mutex}, fmt, collections::HashMap};
 
+use fc_rpc_core::types::Transaction;
+use sp_core::H256;
 use sc_consensus_manual_seal::rpc::{ManualSeal, ManualSealApi};
 use frontier_template_runtime::{Hash, AccountId, Index, opaque::Block, Balance};
 use sp_api::ProvideRuntimeApi;
@@ -44,6 +46,8 @@ pub struct FullDeps<C, P> {
 	pub enable_dev_signer: bool,
 	/// Network service
 	pub network: Arc<NetworkService<Block, Hash>>,
+	/// Ethereum pending transactions. 
+	pub pending_transactions: Arc<Mutex<HashMap<H256, Transaction>>>,
 	/// Manual seal command sink
 	pub command_sink: Option<futures::channel::mpsc::Sender<sc_consensus_manual_seal::rpc::EngineCommand<Hash>>>,
 }
@@ -80,6 +84,7 @@ pub fn create_full<C, P, BE>(
 		deny_unsafe,
 		is_authority,
 		network,
+		pending_transactions,
 		command_sink,
 		enable_dev_signer,
 	} = deps;
@@ -101,6 +106,7 @@ pub fn create_full<C, P, BE>(
 			pool.clone(),
 			frontier_template_runtime::TransactionConverter,
 			network.clone(),
+			pending_transactions.clone(),
 			signers,
 			is_authority,
 		))

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -47,7 +47,7 @@ pub struct FullDeps<C, P> {
 	/// Network service
 	pub network: Arc<NetworkService<Block, Hash>>,
 	/// Ethereum pending transactions. 
-	pub pending_transactions: Arc<Mutex<HashMap<H256, Transaction>>>,
+	pub pending_transactions: Option<Arc<Mutex<HashMap<H256, Transaction>>>>,
 	/// Manual seal command sink
 	pub command_sink: Option<futures::channel::mpsc::Sender<sc_consensus_manual_seal::rpc::EngineCommand<Hash>>>,
 }

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -1,9 +1,8 @@
 //! A collection of node-specific RPC methods.
 
-use std::{sync::{Arc, Mutex}, fmt, collections::HashMap};
+use std::{sync::Arc, fmt};
 
-use fc_rpc_core::types::Transaction;
-use sp_core::H256;
+use fc_rpc_core::types::PendingTransactions;
 use sc_consensus_manual_seal::rpc::{ManualSeal, ManualSealApi};
 use frontier_template_runtime::{Hash, AccountId, Index, opaque::Block, Balance};
 use sp_api::ProvideRuntimeApi;
@@ -47,7 +46,7 @@ pub struct FullDeps<C, P> {
 	/// Network service
 	pub network: Arc<NetworkService<Block, Hash>>,
 	/// Ethereum pending transactions.
-	pub pending_transactions: Option<Arc<Mutex<HashMap<H256, Transaction>>>>,
+	pub pending_transactions: PendingTransactions,
 	/// Manual seal command sink
 	pub command_sink: Option<futures::channel::mpsc::Sender<sc_consensus_manual_seal::rpc::EngineCommand<Hash>>>,
 }

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -79,7 +79,7 @@ pub fn new_partial(config: &Configuration, sealing: Option<Sealing>) -> Result<
 		FullClient, FullBackend, FullSelectChain,
 		sp_consensus::import_queue::BasicQueue<Block, sp_api::TransactionFor<FullClient, Block>>,
 		sc_transaction_pool::FullPool<Block, FullClient>,
-		(ConsensusResult, Arc<Mutex<HashMap<H256, Transaction>>>),
+		(ConsensusResult, Option<Arc<Mutex<HashMap<H256, Transaction>>>>),
 >, ServiceError> {
 	let inherent_data_providers = sp_inherents::InherentDataProviders::new();
 
@@ -96,8 +96,8 @@ pub fn new_partial(config: &Configuration, sealing: Option<Sealing>) -> Result<
 		client.clone(),
 	);
 
-	let pending_transactions: Arc<Mutex<HashMap<H256, Transaction>>>
-		= Arc::new(Mutex::new(HashMap::new()));
+	let pending_transactions: Option<Arc<Mutex<HashMap<H256, Transaction>>>>
+		= Some(Arc::new(Mutex::new(HashMap::new())));
 
 	if let Some(sealing) = sealing {
 		inherent_data_providers

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -259,9 +259,9 @@ pub fn new_full(
 					}) = frontier_log {
 						// Retain all pending transactions that were not
 						// processed in the current block.
-						locked.retain(|&k, v| !transaction_hashes.contains(&k));
+						locked.retain(|&k, _| !transaction_hashes.contains(&k));
 					}
-					locked.retain(|&k, v| {
+					locked.retain(|_, v| {
 						// Drop all the transactions that exceeded the given lifespan.
 						let lifespan_limit = v.at_block + TRANSACTION_RETAIN_THRESHOLD;
 						lifespan_limit > imported_number

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -1,8 +1,7 @@
 //! Service and ServiceFactory implementation. Specialized wrapper over substrate service.
 
 use std::{sync::{Arc, Mutex}, cell::RefCell, time::Duration, collections::HashMap};
-use sp_core::H256;
-use fc_rpc_core::types::Transaction;
+use fc_rpc_core::types::PendingTransactions;
 use sc_client_api::{ExecutorProvider, RemoteBackend};
 use sc_consensus_manual_seal::{self as manual_seal};
 use fc_consensus::FrontierBlockImport;
@@ -77,7 +76,7 @@ pub fn new_partial(config: &Configuration, sealing: Option<Sealing>) -> Result<
 		FullClient, FullBackend, FullSelectChain,
 		sp_consensus::import_queue::BasicQueue<Block, sp_api::TransactionFor<FullClient, Block>>,
 		sc_transaction_pool::FullPool<Block, FullClient>,
-		(ConsensusResult, Option<Arc<Mutex<HashMap<H256, Transaction>>>>),
+		(ConsensusResult, PendingTransactions),
 >, ServiceError> {
 	let inherent_data_providers = sp_inherents::InherentDataProviders::new();
 
@@ -94,7 +93,7 @@ pub fn new_partial(config: &Configuration, sealing: Option<Sealing>) -> Result<
 		client.clone(),
 	);
 
-	let pending_transactions: Option<Arc<Mutex<HashMap<H256, Transaction>>>>
+	let pending_transactions: PendingTransactions
 		= Some(Arc::new(Mutex::new(HashMap::new())));
 
 	if let Some(sealing) = sealing {

--- a/ts-tests/tests/test-pending-pool.ts
+++ b/ts-tests/tests/test-pending-pool.ts
@@ -1,0 +1,52 @@
+import { expect } from "chai";
+
+import { createAndFinalizeBlock, customRequest, describeWithFrontier } from "./util";
+
+describeWithFrontier("Frontier RPC (Pending Pool)", `simple-specs.json`, (context) => {
+	const GENESIS_ACCOUNT = "0x6be02d1d3665660d22ff9624b7be0551ee1ac91b";
+	const GENESIS_ACCOUNT_PRIVATE_KEY = "0x99B3C12287537E38C90A9219D4CB074A89A16E9CDB20BF85728EBD97C343E342";
+
+	// Solidity: contract test { function multiply(uint a) public pure returns(uint d) {return a * 7;}}
+	const TEST_CONTRACT_BYTECODE =
+		"0x6080604052348015600f57600080fd5b5060ae8061001e6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c8063c6888fa114602d575b600080fd5b605660048036036020811015604157600080fd5b8101908080359060200190929190505050606c565b6040518082815260200191505060405180910390f35b600060078202905091905056fea265627a7a72315820f06085b229f27f9ad48b2ff3dd9714350c1698a37853a30136fa6c5a7762af7364736f6c63430005110032";
+	const FIRST_CONTRACT_ADDRESS = "0xc2bf5f29a4384b1ab0c063e1c666f02121b6084a";
+
+	it("should return a pending transaction", async function () {
+		this.timeout(15000);
+		const tx = await context.web3.eth.accounts.signTransaction(
+			{
+				from: GENESIS_ACCOUNT,
+				data: TEST_CONTRACT_BYTECODE,
+				value: "0x00",
+				gasPrice: "0x01",
+				gas: "0x100000",
+			},
+			GENESIS_ACCOUNT_PRIVATE_KEY
+		);
+
+        const tx_hash = (await customRequest(context.web3, "eth_sendRawTransaction", [tx.rawTransaction])).result;
+
+        const pending_transaction = (await customRequest(context.web3, "eth_getTransactionByHash", [tx_hash])).result;
+        // pending transactions do not know yet to which block they belong to
+        expect(pending_transaction).to.include({
+			blockNumber: null,
+            hash: tx_hash,
+            publicKey: "0x624f720eae676a04111631c9ca338c11d0f5a80ee42210c6be72983ceb620fbf645a96f951529fa2d70750432d11b7caba5270c4d677255be90b3871c8c58069",
+            r: "0x5431b25e8100a21ced6af01868357b19d58b94afa6f57dc7cbf81f4a922ddecc",
+            s: "0x22e05530d015ea702ffb37af313e691ce4423565c2734c267edd3c74aea0a010",
+            v: "0x77",
+		});
+
+        await createAndFinalizeBlock(context.web3);
+
+        const processed_transaction = (await customRequest(context.web3, "eth_getTransactionByHash", [tx_hash])).result;
+        expect(processed_transaction).to.include({
+			blockNumber: "0x1",
+            hash: tx_hash,
+            publicKey: "0x624f720eae676a04111631c9ca338c11d0f5a80ee42210c6be72983ceb620fbf645a96f951529fa2d70750432d11b7caba5270c4d677255be90b3871c8c58069",
+            r: "0x5431b25e8100a21ced6af01868357b19d58b94afa6f57dc7cbf81f4a922ddecc",
+            s: "0x22e05530d015ea702ffb37af313e691ce4423565c2734c267edd3c74aea0a010",
+            v: "0x77",
+		});
+	});
+});

--- a/ts-tests/tests/test-pending-pool.ts
+++ b/ts-tests/tests/test-pending-pool.ts
@@ -24,29 +24,29 @@ describeWithFrontier("Frontier RPC (Pending Pool)", `simple-specs.json`, (contex
 			GENESIS_ACCOUNT_PRIVATE_KEY
 		);
 
-        const tx_hash = (await customRequest(context.web3, "eth_sendRawTransaction", [tx.rawTransaction])).result;
+		const tx_hash = (await customRequest(context.web3, "eth_sendRawTransaction", [tx.rawTransaction])).result;
 
-        const pending_transaction = (await customRequest(context.web3, "eth_getTransactionByHash", [tx_hash])).result;
-        // pending transactions do not know yet to which block they belong to
-        expect(pending_transaction).to.include({
+		const pending_transaction = (await customRequest(context.web3, "eth_getTransactionByHash", [tx_hash])).result;
+		// pending transactions do not know yet to which block they belong to
+		expect(pending_transaction).to.include({
 			blockNumber: null,
-            hash: tx_hash,
-            publicKey: "0x624f720eae676a04111631c9ca338c11d0f5a80ee42210c6be72983ceb620fbf645a96f951529fa2d70750432d11b7caba5270c4d677255be90b3871c8c58069",
-            r: "0x5431b25e8100a21ced6af01868357b19d58b94afa6f57dc7cbf81f4a922ddecc",
-            s: "0x22e05530d015ea702ffb37af313e691ce4423565c2734c267edd3c74aea0a010",
-            v: "0x77",
+			hash: tx_hash,
+			publicKey: "0x624f720eae676a04111631c9ca338c11d0f5a80ee42210c6be72983ceb620fbf645a96f951529fa2d70750432d11b7caba5270c4d677255be90b3871c8c58069",
+			r: "0x5431b25e8100a21ced6af01868357b19d58b94afa6f57dc7cbf81f4a922ddecc",
+			s: "0x22e05530d015ea702ffb37af313e691ce4423565c2734c267edd3c74aea0a010",
+			v: "0x77",
 		});
 
-        await createAndFinalizeBlock(context.web3);
+		await createAndFinalizeBlock(context.web3);
 
-        const processed_transaction = (await customRequest(context.web3, "eth_getTransactionByHash", [tx_hash])).result;
-        expect(processed_transaction).to.include({
+		const processed_transaction = (await customRequest(context.web3, "eth_getTransactionByHash", [tx_hash])).result;
+		expect(processed_transaction).to.include({
 			blockNumber: "0x1",
-            hash: tx_hash,
-            publicKey: "0x624f720eae676a04111631c9ca338c11d0f5a80ee42210c6be72983ceb620fbf645a96f951529fa2d70750432d11b7caba5270c4d677255be90b3871c8c58069",
-            r: "0x5431b25e8100a21ced6af01868357b19d58b94afa6f57dc7cbf81f4a922ddecc",
-            s: "0x22e05530d015ea702ffb37af313e691ce4423565c2734c267edd3c74aea0a010",
-            v: "0x77",
+			hash: tx_hash,
+			publicKey: "0x624f720eae676a04111631c9ca338c11d0f5a80ee42210c6be72983ceb620fbf645a96f951529fa2d70750432d11b7caba5270c4d677255be90b3871c8c58069",
+			r: "0x5431b25e8100a21ced6af01868357b19d58b94afa6f57dc7cbf81f4a922ddecc",
+			s: "0x22e05530d015ea702ffb37af313e691ce4423565c2734c267edd3c74aea0a010",
+			v: "0x77",
 		});
 	});
 });


### PR DESCRIPTION
This PR adds optional support for getting `Transaction` object when using `eth_getTransactionByHash` for pending transactions.

- Defines a shared `Mutex<HashMap<H256, Transaction>>` at service level.
- Use it at rpc level to insert and read data.
- Clear data on a service task.