### PR TITLE
Add ethereum header bloom to digest

### DIFF
--- a/client/consensus/src/lib.rs
+++ b/client/consensus/src/lib.rs
@@ -134,7 +134,7 @@ impl<B, I, C> BlockImport<B> for FrontierBlockImport<B, I, C> where
 
 			match log {
 				ConsensusLog::EndBlock {
-					block_hash, transaction_hashes,
+					block_hash, transaction_hashes, ..
 				} => {
 					aux_schema::write_block_hash(client.as_ref(), block_hash, hash, insert_closure!());
 

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -333,6 +333,7 @@ impl<T: Config> Module<T> {
 			ConsensusLog::EndBlock {
 				block_hash: block.header.hash(),
 				transaction_hashes,
+				logs_bloom: logs_bloom.data().to_vec(),
 			}.encode(),
 		);
 		frame_system::Module::<T>::deposit_log(digest.into());

--- a/primitives/consensus/src/lib.rs
+++ b/primitives/consensus/src/lib.rs
@@ -32,5 +32,7 @@ pub enum ConsensusLog {
 		block_hash: H256,
 		/// Transaction hashes of the Ethereum block.
 		transaction_hashes: Vec<H256>,
+		/// Ethereum header bloom data
+		logs_bloom: Vec<u8>,
 	},
 }


### PR DESCRIPTION
This PR adds one of the parts required for deep scanning the network for past events. This will allow identifying if an event occurred in a block by accessing the Ethereum bloom directly from the header digest.