### PR TITLE
Bug fix + multi-address parameter support for `eth_getLogs` .

### DIFF
--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -38,8 +38,7 @@ use sc_network::{NetworkService, ExHashT};
 use fc_rpc_core::{EthApi as EthApiT, NetApi as NetApiT, Web3Api as Web3ApiT};
 use fc_rpc_core::types::{
 	BlockNumber, Bytes, CallRequest, Filter, FilteredParams, Index, Log, Receipt, RichBlock,
-	SyncStatus, SyncInfo, Transaction, Work, Rich, Block, BlockTransactions, VariadicValue,
-	TransactionRequest,
+	SyncStatus, SyncInfo, Transaction, Work, Rich, Block, BlockTransactions, TransactionRequest,
 };
 use fp_rpc::{EthereumRuntimeRPCApi, ConvertTransaction, TransactionStatus};
 use crate::{internal_err, error_on_execution_failure, EthSigner};
@@ -984,27 +983,25 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 						transaction_log_index: None,
 						removed: false,
 					};
-					let mut add: bool = false;
+					let mut add: bool = true;
 					if let (
-						Some(VariadicValue::Single(_)),
-						Some(VariadicValue::Multiple(_))
+						Some(_),
+						Some(_)
 					) = (
 						filter.address.clone(),
 						filter.topics.clone(),
 					) {
-						if !params.filter_address(&log) && params.filter_topics(&log) {
-							add = true;
+						if !params.filter_address(&log) || !params.filter_topics(&log) {
+							add = false;
 						}
-					} else if let Some(VariadicValue::Single(_)) = filter.address {
+					} else if let Some(_) = filter.address {
 						if !params.filter_address(&log) {
-							add = true;
+							add = false;
 						}
-					} else if let Some(VariadicValue::Multiple(_)) = &filter.topics {
-						if params.filter_topics(&log) {
-							add = true;
+					} else if let Some(_) = &filter.topics {
+						if !params.filter_topics(&log) {
+							add = false;
 						}
-					} else {
-						add = true;
 					}
 					if add {
 						log.block_hash = Some(block_hash);

--- a/ts-tests/tests/test-subscription.ts
+++ b/ts-tests/tests/test-subscription.ts
@@ -172,6 +172,38 @@ describeWithFrontier("Frontier RPC (Subscription)", `simple-specs.json`, (contex
 		setTimeout(done,10000);
 	}).timeout(20000);
 
+	step("should subscribe to logs by multiple addresses", async function (done) {
+		subscription = context.web3.eth.subscribe("logs", {
+			address: [
+				"0xF8cef78E923919054037a1D03662bBD884fF4edf",
+				"0x42e2EE7Ba8975c473157634Ac2AF4098190fc741",
+				"0x5c4242beB94dE30b922f57241f1D02f36e906915",
+				"0xC2Bf5F29a4384b1aB0C063e1c666f02121B6084a"
+			]
+		}, function(error, result){});
+
+		await new Promise((resolve) => {
+			subscription.on("connected", function (d: any) {
+				resolve();
+			});
+		});
+
+		const tx = await sendTransaction(context);
+		let data = null;
+		await new Promise((resolve) => {
+			createAndFinalizeBlock(context.web3);
+			subscription.on("data", function (d: any) {
+				data = d;
+				logs_generated += 1;
+				resolve();
+			});
+		});
+		subscription.unsubscribe();
+
+		expect(data).to.not.be.null;
+		setTimeout(done,10000);
+	}).timeout(20000);
+
 	step("should subscribe to logs by topic", async function (done) {
 		subscription = context.web3.eth.subscribe("logs", {
 			topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"]
@@ -199,18 +231,94 @@ describeWithFrontier("Frontier RPC (Subscription)", `simple-specs.json`, (contex
 		setTimeout(done,10000);
 	}).timeout(20000);
 
-	step("should get past events on subscription", async function (done) {
+	step("should get past events #1: by topic", async function (done) {
 		subscription = context.web3.eth.subscribe("logs", {
-			fromBlock: "0x0"
+			fromBlock: "0x0",
+			topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"]
 		}, function(error, result){});
 
 		let data = [];
 		await new Promise((resolve) => {
 			subscription.on("data", function (d: any) {
 				data.push(d);
-				if (data.length == logs_generated) {
-					resolve();
-				}
+				setTimeout(function() {
+					if(data.length == logs_generated)
+						resolve();
+				},2000);
+			});
+		});
+		subscription.unsubscribe();
+
+		expect(data).to.not.be.empty;
+		setTimeout(done,10000);
+	}).timeout(20000);
+	
+	step("should get past events #2: by address", async function (done) {
+		subscription = context.web3.eth.subscribe("logs", {
+			fromBlock: "0x0",
+			address: "0x42e2EE7Ba8975c473157634Ac2AF4098190fc741"
+		}, function(error, result){});
+
+		let data = [];
+		await new Promise((resolve) => {
+			subscription.on("data", function (d: any) {
+				data.push(d);
+				setTimeout(function() {
+					if(data.length == 1)
+						resolve();
+				},2000);
+			});
+		});
+		subscription.unsubscribe();
+
+		expect(data).to.not.be.empty;
+		setTimeout(done,10000);
+	}).timeout(20000);
+	
+	step("should get past events #3: by address + topic", async function (done) {
+		subscription = context.web3.eth.subscribe("logs", {
+			fromBlock: "0x0",
+			topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"],
+			address: "0xC2Bf5F29a4384b1aB0C063e1c666f02121B6084a"
+		}, function(error, result){});
+
+		let data = [];
+		await new Promise((resolve) => {
+			subscription.on("data", function (d: any) {
+				data.push(d);
+				setTimeout(function() {
+					if(data.length == 1)
+						resolve();
+				},2000);
+			});
+		});
+		subscription.unsubscribe();
+
+		expect(data).to.not.be.empty;
+		setTimeout(done,10000);
+	}).timeout(20000);
+
+	step("should get past events #3: multiple addresses", async function (done) {
+		subscription = context.web3.eth.subscribe("logs", {
+			fromBlock: "0x0",
+			topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"],
+			address: [
+				"0xe573BCA813c741229ffB2488F7856C6cAa841041",
+				"0xF8cef78E923919054037a1D03662bBD884fF4edf",
+				"0x42e2EE7Ba8975c473157634Ac2AF4098190fc741",
+				"0x5c4242beB94dE30b922f57241f1D02f36e906915",
+				"0xC2Bf5F29a4384b1aB0C063e1c666f02121B6084a"
+			]
+		}, function(error, result){});
+
+		let data = [];
+		await new Promise((resolve) => {
+			subscription.on("data", function (d: any) {
+				data.push(d);
+				setTimeout(function() {
+					if(data.length == logs_generated)
+						resolve();
+				},2000);
 			});
 		});
 		subscription.unsubscribe();


### PR DESCRIPTION
- Fixes a bug where address matching was inverted in `eth_getLogs`.
- Only `VariadicValue::Single` parameter was supported in `EthApi` for address filtering.

Additionally:

- Follow the same filtering logic in both `EthApi` and `EthPubSubApi` to prevent further mismatches.
- Add more tests to cover different parameter combinations when asking for past events.