### PR TITLE
Deserialize decimal inputs on BlockNumber

### DIFF
--- a/client/rpc-core/src/types/index.rs
+++ b/client/rpc-core/src/types/index.rs
@@ -61,6 +61,10 @@ impl<'a> Visitor<'a> for IndexVisitor {
 	fn visit_string<E>(self, value: String) -> Result<Self::Value, E> where E: Error {
 		self.visit_str(value.as_ref())
 	}
+
+	fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> where E: Error {
+		Ok(Index(value as usize))
+	}
 }
 
 #[cfg(test)]
@@ -69,9 +73,9 @@ mod tests {
 	use serde_json;
 
 	#[test]
-	fn block_number_deserialization() {
-		let s = r#"["0xa", "10"]"#;
+	fn index_deserialization() {
+		let s = r#"["0xa", "10", 42]"#;
 		let deserialized: Vec<Index> = serde_json::from_str(s).unwrap();
-		assert_eq!(deserialized, vec![Index(10), Index(10)]);
+		assert_eq!(deserialized, vec![Index(10), Index(10), Index(42)]);
 	}
 }


### PR DESCRIPTION
This is a bit self-serving, but still adds value overall in being quite flexible in what it will accept. 

Generally the polkadot-js API will serialize bitLength <= 32 into decimal (a number of palettes will only use decimal values for these, not allowing hex), so this allows the `eth_*` RPCs to play along.

For both `BlockNumber` and `Index` we add a `u64` visitor, which handles decimal values. Additionally `BlockNumber` also aligns with `Index` in accepting `"1234"` decimal format string values.