### PR TITLE
WIP Modexp fixes

### DIFF
--- a/frame/evm/precompile/modexp/Cargo.toml
+++ b/frame/evm/precompile/modexp/Cargo.toml
@@ -15,6 +15,9 @@ fp-evm = { version = "0.8.0", default-features = false, path = "../../../../prim
 evm = { version = "0.20.0", default-features = false, features = ["with-codec"] }
 num = { version = "0.3", features = ["alloc"], default-features = false }
 
+[dev-dependencies]
+hex = "0.4.0"
+
 [features]
 default = ["std"]
 std = [

--- a/frame/evm/precompile/modexp/src/lib.rs
+++ b/frame/evm/precompile/modexp/src/lib.rs
@@ -83,7 +83,8 @@ impl LinearCostPrecompile for Modexp {
 		if bytes.len() == mod_len {
 			Ok((ExitSucceed::Returned, bytes.to_vec()))
 		} else if bytes.len() < mod_len {
-			let mut ret = vec![0u8; mod_len - bytes.len()];
+			let mut ret = Vec::with_capacity(mod_len);
+			ret.extend(core::iter::repeat(0).take(mod_len - bytes.len()));
 			ret.extend_from_slice(&bytes[..]);
 			Ok((ExitSucceed::Returned, ret.to_vec()))
 		} else {

--- a/frame/evm/precompile/modexp/src/lib.rs
+++ b/frame/evm/precompile/modexp/src/lib.rs
@@ -35,6 +35,10 @@ impl LinearCostPrecompile for Modexp {
 		input: &[u8],
 		_: usize,
 	) -> core::result::Result<(ExitSucceed, Vec<u8>), ExitError> {
+		if input.len() < 96 {
+			return Err(ExitError::Other("input must contain at least 96 bytes".into()));
+		};
+
 		let mut buf = [0; 32];
 		buf.copy_from_slice(&input[0..32]);
 		let mut len_bytes = [0u8; 8];
@@ -98,21 +102,19 @@ mod tests {
 	use super::*;
 	extern crate hex;
 
-	// TODO: this panics, as the input is expected to be some minimum size (96 bytes?)
-	//       it should probably handle this more gracefully (e.g. not panic)
 	#[test]
-	#[should_panic]
-	fn test_empty_input() {
+	fn test_empty_input() -> std::result::Result<(), ExitError> {
 
 		let input: [u8; 0] = [];
 		let cost: usize = 1;
 
 		match Modexp::execute(&input, cost) {
-			Ok((_, output)) => {
-				// TODO: evaluate output
+			Ok((_, _)) => {
+				panic!("Test not expected to pass");
 			},
-			Err(_) => {
-				panic!("Modexp::execute() returned error"); // TODO: how to pass error on?
+			Err(e) => {
+				assert_eq!(e, ExitError::Other("input must contain at least 96 bytes".into()));
+				Ok(())
 			}
 		}
 	}

--- a/frame/evm/precompile/modexp/src/lib.rs
+++ b/frame/evm/precompile/modexp/src/lib.rs
@@ -58,10 +58,6 @@ impl LinearCostPrecompile for Modexp {
 			BigUint::zero()
 		} else {
 
-			println!("base_len {}", base_len);
-			println!("exp_len {}", exp_len);
-			println!("mod_len {}", mod_len);
-
 			// read the numbers themselves.
 			let base_start = 96; // previous 3 32-byte fields
 			let base = BigUint::from_bytes_be(&input[base_start..base_start + base_len]);
@@ -72,18 +68,12 @@ impl LinearCostPrecompile for Modexp {
 			let mod_start = exp_start + exp_len;
 			let modulus = BigUint::from_bytes_be(&input[mod_start..mod_start + mod_len]);
 
-			println!("base {}", base);
-			println!("exp {}", exponent);
-			println!("mod {}", modulus);
-
 			if modulus.is_zero() || modulus.is_one() {
 				BigUint::zero()
 			} else {
 				base.modpow(&exponent, &modulus)
 			}
 		};
-
-		println!("r {}", r);
 
 		// write output to given memory, left padded and same length as the modulus.
 		let bytes = r.to_bytes_be();
@@ -149,8 +139,6 @@ mod tests {
 
 		let cost: usize = 1;
 
-		println!("input array: {:?}", input);
-
 		match Modexp::execute(&input, cost) {
 			Ok((_, output)) => {
 				assert_eq!(output.len(), 1); // should be same length as mod
@@ -179,8 +167,6 @@ mod tests {
 		// 59999 ^ 21 % 14452 = 10055
 
 		let cost: usize = 1;
-
-		println!("input array: {:?}", input);
 
 		match Modexp::execute(&input, cost) {
 			Ok((_, output)) => {


### PR DESCRIPTION
This PR fixes some logic issues with the ModExp precompile, and also adds some unit tests. Specifically, the previous logic seemed to crawl through the input buffer incorrectly when trying to pull out `base`, `exponent`, and `modulus` values.

There is still room for improvement around bounds-checking; the code will still gladly try to read an arbitrary size from the input buffer based on user input.