### PR TITLE
Abstract block gas limit

### DIFF
--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -79,6 +79,8 @@ pub trait Config: frame_system::Config<Hash=H256> + pallet_balances::Config + pa
 	type FindAuthor: FindAuthor<H160>;
 	/// How Ethereum state root is calculated.
 	type StateRoot: Get<H256>;
+	/// The block gas limit. Can be a simple constant, or an adjustment algorithm in another pallet.
+	type BlockGasLimit: Get<U256>;
 }
 
 decl_storage! {
@@ -309,7 +311,7 @@ impl<T: Config> Module<T> {
 					frame_system::Module::<T>::block_number()
 				)
 			),
-			gas_limit: U256::from(u32::max_value()), // TODO: set this using Ethereum's gas limit change algorithm.
+			gas_limit: T::BlockGasLimit::get(),
 			gas_used: receipts.clone().into_iter().fold(U256::zero(), |acc, r| acc + r.used_gas),
 			timestamp: UniqueSaturatedInto::<u64>::unique_saturated_into(
 				pallet_timestamp::Module::<T>::get()

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -80,7 +80,7 @@ pub trait Config: frame_system::Config<Hash=H256> + pallet_balances::Config + pa
 	/// How Ethereum state root is calculated.
 	type StateRoot: Get<H256>;
 	/// The block gas limit. Can be a simple constant, or an adjustment algorithm in another pallet.
-	type BlockGasLimit: Get<U256>;
+	type BlockGasLimit: Get<u32>;
 }
 
 decl_storage! {

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -80,7 +80,7 @@ pub trait Config: frame_system::Config<Hash=H256> + pallet_balances::Config + pa
 	/// How Ethereum state root is calculated.
 	type StateRoot: Get<H256>;
 	/// The block gas limit. Can be a simple constant, or an adjustment algorithm in another pallet.
-	type BlockGasLimit: Get<u32>;
+	type BlockGasLimit: Get<U256>;
 }
 
 decl_storage! {

--- a/frame/ethereum/src/mock.rs
+++ b/frame/ethereum/src/mock.rs
@@ -149,10 +149,15 @@ impl pallet_evm::Config for Test {
 	type ChainId = ChainId;
 }
 
+parameter_types! {
+	pub const BlockGasLimit: U256 = U256::MAX;
+}
+
 impl Config for Test {
 	type Event = ();
 	type FindAuthor = EthereumFindAuthor;
 	type StateRoot = IntermediateStateRoot;
+	type BlockGasLimit = BlockGasLimit;
 }
 
 pub type System = frame_system::Module<Test>;

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -316,10 +316,15 @@ impl<F: FindAuthor<u32>> FindAuthor<H160> for EthereumFindAuthor<F>
 	}
 }
 
+parameter_types! {
+	pub const BlockGasLimit: u32 = u32::max_value();
+}
+
 impl pallet_ethereum::Config for Runtime {
 	type Event = Event;
 	type FindAuthor = EthereumFindAuthor<Aura>;
 	type StateRoot = pallet_ethereum::IntermediateStateRoot;
+	type BlockGasLimit = BlockGasLimit;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -317,7 +317,7 @@ impl<F: FindAuthor<u32>> FindAuthor<H160> for EthereumFindAuthor<F>
 }
 
 parameter_types! {
-	pub const BlockGasLimit: U256 = U256::MAX;
+	pub BlockGasLimit: U256 = U256::from(u32::max_value());
 }
 
 impl pallet_ethereum::Config for Runtime {

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -317,7 +317,7 @@ impl<F: FindAuthor<u32>> FindAuthor<H160> for EthereumFindAuthor<F>
 }
 
 parameter_types! {
-	pub const BlockGasLimit: u32 = u32::max_value();
+	pub const BlockGasLimit: U256 = U256::MAX;
 }
 
 impl pallet_ethereum::Config for Runtime {


### PR DESCRIPTION
This PR removes the hard coded block gas limit from pallet ethereum and replaces it with a type in the `Config` trait. The template now uses `U256::MAX` instead of u32.

This allows chains using Frontier to use their own hard-coded value, calculate based on Substrate weight, or implement an adjustment algorithm in another pallet.