### PR TITLE
Add min gas price for node to CLI

### DIFF
--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -658,7 +658,7 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 				future::result(Err(internal_err("decode transaction failed")))
 			),
 		};
-		
+
 		if transaction.gas_price < U256::from(self.minimum_gas_price) {
 			return Box::new(future::result(Err(internal_err("gas price too low"))));
 		}

--- a/template/node/src/cli.rs
+++ b/template/node/src/cli.rs
@@ -25,6 +25,9 @@ pub struct RunCmd {
 
 	#[structopt(long = "enable-dev-signer")]
 	pub enable_dev_signer: bool,
+
+	#[structopt(long = "minimum_gas_price", default_value = "0")]
+	pub minimum_gas_price: u128,
 }
 
 #[derive(Debug, StructOpt)]

--- a/template/node/src/command.rs
+++ b/template/node/src/command.rs
@@ -103,7 +103,7 @@ pub fn run() -> sc_cli::Result<()> {
 			runner.run_node_until_exit(|config| async move {
 				match config.role {
 					Role::Light => service::new_light(config),
-					_ => service::new_full(config, cli.run.sealing, cli.run.enable_dev_signer),
+					_ => service::new_full(config, cli.run.sealing, cli.run.enable_dev_signer, cli.run.minimum_gas_price),
 				}
 			})
 		}

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -43,6 +43,8 @@ pub struct FullDeps<C, P> {
 	pub is_authority: bool,
 	/// Whether to enable dev signer
 	pub enable_dev_signer: bool,
+	/// Minimum gas price for adding txes to txpool
+	pub minimum_gas_price: u128,
 	/// Network service
 	pub network: Arc<NetworkService<Block, Hash>>,
 	/// Ethereum pending transactions.
@@ -86,6 +88,7 @@ pub fn create_full<C, P, BE>(
 		pending_transactions,
 		command_sink,
 		enable_dev_signer,
+		minimum_gas_price,
 	} = deps;
 
 	io.extend_with(
@@ -108,6 +111,7 @@ pub fn create_full<C, P, BE>(
 			pending_transactions.clone(),
 			signers,
 			is_authority,
+			minimum_gas_price,
 		))
 	);
 

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -158,6 +158,7 @@ pub fn new_full(
 	config: Configuration,
 	sealing: Option<Sealing>,
 	enable_dev_signer: bool,
+	minimum_gas_price: u128,
 ) -> Result<TaskManager, ServiceError> {
 	let sc_service::PartialComponents {
 		client, backend, mut task_manager, import_queue, keystore_container,
@@ -208,7 +209,8 @@ pub fn new_full(
 				enable_dev_signer,
 				network: network.clone(),
 				pending_transactions: pending.clone(),
-				command_sink: Some(command_sink.clone())
+				command_sink: Some(command_sink.clone()),
+				minimum_gas_price: minimum_gas_price,
 			};
 			crate::rpc::create_full(
 				deps,


### PR DESCRIPTION
Adds a minimum gas price that defaults to 0 to the CLI. This will allow nodes to set a min gas price which will reject txes from entering the txpool for both `send_transaction` and `send_raw_transaction`.