### PR TITLE
Make EVM pallet's storage items public.

### DIFF
--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -274,8 +274,8 @@ pub struct GenesisAccount {
 
 decl_storage! {
 	trait Store for Module<T: Config> as EVM {
-		AccountCodes get(fn account_codes): map hasher(blake2_128_concat) H160 => Vec<u8>;
-		AccountStorages get(fn account_storages):
+		pub AccountCodes get(fn account_codes): map hasher(blake2_128_concat) H160 => Vec<u8>;
+		pub AccountStorages get(fn account_storages):
 			double_map hasher(blake2_128_concat) H160, hasher(blake2_128_concat) H256 => H256;
 	}
 


### PR DESCRIPTION
This is done to let other pallets read the storage.

Signed-off-by: lovesh <lovesh.bond@gmail.com>