### PR TITLE
Introduce ConsensusLog::PostBlock and ConsensusLog::PreBlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,7 +1376,10 @@ dependencies = [
 name = "fp-consensus"
 version = "0.1.0"
 dependencies = [
+ "ethereum",
  "parity-scale-codec",
+ "rlp",
+ "sha3 0.8.2",
  "sp-core",
  "sp-runtime",
  "sp-std",

--- a/client/consensus/src/lib.rs
+++ b/client/consensus/src/lib.rs
@@ -136,24 +136,25 @@ impl<B, I, C> BlockImport<B> for FrontierBlockImport<B, I, C> where
 		if self.enabled {
 			let log = find_frontier_log::<B>(&block.header)?;
 			let hash = block.post_hash();
-			match log {
-				ConsensusLog::EndBlock {
-					block_hash, transaction_hashes,
-				} => {
-					let res = aux_schema::write_block_hash(client.as_ref(), block_hash, hash, insert_closure!());
-					if res.is_err() { trace!(target: "frontier-consensus", "{:?}", res); }
+			let post_hashes = match log {
+				ConsensusLog::PostHashes(post_hashes) => post_hashes,
+				ConsensusLog::PreBlock(block) => fp_consensus::PostHashes::from_block(block),
+				ConsensusLog::PostBlock(block) => fp_consensus::PostHashes::from_block(block),
+			};
 
-					for (index, transaction_hash) in transaction_hashes.into_iter().enumerate() {
-						let res = aux_schema::write_transaction_metadata(
-							client.as_ref(),
-							transaction_hash,
-							(block_hash, index as u32),
-							insert_closure!(),
-						);
-						if res.is_err() { trace!(target: "frontier-consensus", "{:?}", res); }
-					}
-				},
+			let res = aux_schema::write_block_hash(client.as_ref(), post_hashes.block_hash, hash, insert_closure!());
+			if res.is_err() { trace!(target: "frontier-consensus", "{:?}", res); }
+
+			for (index, transaction_hash) in post_hashes.transaction_hashes.into_iter().enumerate() {
+				let res = aux_schema::write_transaction_metadata(
+					client.as_ref(),
+					transaction_hash,
+					(post_hashes.block_hash, index as u32),
+					insert_closure!(),
+				);
+				if res.is_err() { trace!(target: "frontier-consensus", "{:?}", res); }
 			}
+
 			// On importing block 1 we also map the genesis block in the auxiliary.
 			if block.header.number().clone() == One::one() {
 				let id = BlockId::Number(Zero::zero());

--- a/primitives/consensus/Cargo.toml
+++ b/primitives/consensus/Cargo.toml
@@ -13,6 +13,9 @@ sp-std = { version = "2.0.0", default-features = false, git = "https://github.co
 sp-runtime = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-core = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false, features = ["derive"] }
+ethereum = { version = "0.6.0", default-features = false, features = ["with-codec"] }
+rlp = { version = "0.5", default-features = false }
+sha3 = { version = "0.8", default-features = false }
 
 [features]
 default = ["std"]
@@ -21,4 +24,7 @@ std = [
 	"sp-runtime/std",
 	"sp-core/std",
 	"codec/std",
+	"ethereum/std",
+	"rlp/std",
+	"sha3/std",
 ]


### PR DESCRIPTION
`ConsensusLog::PostHashes` (which is the legacy one) and `ConsensusLog::PostBlock` are generated by the runtime, while `ConsensusLog::PreBlock` is supplied by consensus engine and consumed by runtime. This separation paves the way for direct Ethereum block importing.