### PR TITLE
If the transaction fails, the log data should also be revert

### DIFF
--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -279,9 +279,7 @@ impl<'config> SubstrateStackSubstate<'config> {
 	pub fn exit_revert(&mut self) -> Result<(), ExitError> {
 		let mut exited = *self.parent.take().expect("Cannot discard on root substate");
 		mem::swap(&mut exited, self);
-
 		self.metadata.swallow_revert(exited.metadata)?;
-		self.logs.append(&mut exited.logs);
 
 		sp_io::storage::rollback_transaction();
 		Ok(())
@@ -290,9 +288,7 @@ impl<'config> SubstrateStackSubstate<'config> {
 	pub fn exit_discard(&mut self) -> Result<(), ExitError> {
 		let mut exited = *self.parent.take().expect("Cannot discard on root substate");
 		mem::swap(&mut exited, self);
-
 		self.metadata.swallow_discard(exited.metadata)?;
-		self.logs.append(&mut exited.logs);
 
 		sp_io::storage::rollback_transaction();
 		Ok(())

--- a/ts-tests/tests/test-bloom.ts
+++ b/ts-tests/tests/test-bloom.ts
@@ -18,7 +18,7 @@ describeWithFrontier("Frontier RPC (Bloom)", `simple-specs.json`, (context) => {
 				data: TEST_CONTRACT_BYTECODE,
 				value: "0x00",
 				gasPrice: "0x01",
-				gas: "0x4F930",
+				gas: "0x100000",
 			},
 			GENESIS_ACCOUNT_PRIVATE_KEY
 		);

--- a/ts-tests/tests/test-filter-api.ts
+++ b/ts-tests/tests/test-filter-api.ts
@@ -19,7 +19,7 @@ describeWithFrontier("Frontier RPC (EthFilterApi)", `simple-specs.json`, (contex
 				data: TEST_CONTRACT_BYTECODE,
 				value: "0x00",
 				gasPrice: "0x01",
-				gas: "0x4F930",
+				gas: "0x100000",
 			},
 			GENESIS_ACCOUNT_PRIVATE_KEY
 		);

--- a/ts-tests/tests/test-subscription.ts
+++ b/ts-tests/tests/test-subscription.ts
@@ -21,7 +21,7 @@ describeWithFrontier("Frontier RPC (Subscription)", `simple-specs.json`, (contex
 				data: TEST_CONTRACT_BYTECODE,
 				value: "0x00",
 				gasPrice: "0x01",
-				gas: "0x4F930",
+				gas: "0x1000000",
 			},
 			GENESIS_ACCOUNT_PRIVATE_KEY
 		);


### PR DESCRIPTION
Referring to [This Answer](https://ethereum.stackexchange.com/questions/38019/is-it-possible-to-retrieve-an-event-log-from-a-reverted-transaction), we have tested it on the Ropsten and verified that this answer is correct.

A test contract like below:

```sol
pragma solidity ^0.7.0;
contract testlog {
    event Log(uint256 a);
    function test() public {
        emit Log(1);
        revert();
    }
}
```

Submit a `test` call and get the transaction receipt like:

```sh
{
   "blockHash":"0x9281ac790fe66da2fe8dd7b4c39836de45322064c05a1b9910650a4ae9dc62ac",
   "blockNumber":14,
   "contractAddress":null,
   "cumulativeGasUsed":22250,
   "from":"0xa3503704240f764cf91faba1775754b42fd2040f",
   "gasUsed":22250,
   "logs":[
      {
         "address":"0xfCA29754bB5d5a60F96cfba820F7e76A8E1b6f97",
         "blockHash":"0x9281ac790fe66da2fe8dd7b4c39836de45322064c05a1b9910650a4ae9dc62ac",
         "blockNumber":14,
         "data":"0x0000000000000000000000000000000000000000000000000000000000000001",
         "logIndex":0,
         "removed":false,
         "topics":[
            // Here should be empty
            "0x909c57d5c6ac08245cf2a6de3900e2b868513fa59099b92b27d8db823d92df9c"
         ],
         "transactionHash":"0x9281ac790fe66da2fe8dd7b4c39836de45322064c05a1b9910650a4ae9dc62ac",
         "transactionIndex":0,
         "transactionLogIndex":"0x0",
         "id":"log_428547dd"
      }
   ],
   "logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000100000004000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000020000000000000000000000000000000000000000",
   "status":false,
   "to":"0xfca29754bb5d5a60f96cfba820f7e76a8e1b6f97",
   "transactionHash":"0xda28bd8ac19582fbc02d3813703681df9d81a4f7de308ff08f73b205d5625b63",
   "transactionIndex":0
}
```