### PR TITLE
Allow handling fee deductions done by EVM

### DIFF
--- a/frame/ethereum/src/mock.rs
+++ b/frame/ethereum/src/mock.rs
@@ -143,6 +143,7 @@ impl pallet_evm::Config for Test {
 	type Precompiles = ();
 	type Runner = pallet_evm::runner::stack::Runner<Self>;
 	type ChainId = ChainId;
+	type OnChargeTransaction = ();
 }
 
 parameter_types! {

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -53,599 +53,599 @@
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
 
-pub mod runner;
 mod tests;
+pub mod runner;
 
 pub use crate::runner::Runner;
-pub use evm::{ExitError, ExitFatal, ExitReason, ExitRevert, ExitSucceed};
 pub use fp_evm::{
-    Account, CallInfo, CreateInfo, ExecutionInfo, LinearCostPrecompile, Log, Precompile,
-    PrecompileSet, Vicinity,
+	Account, Log, Vicinity, ExecutionInfo, CallInfo, CreateInfo, Precompile,
+	PrecompileSet, LinearCostPrecompile,
 };
+pub use evm::{ExitReason, ExitSucceed, ExitError, ExitRevert, ExitFatal};
 
+use sp_std::vec::Vec;
 #[cfg(feature = "std")]
-use codec::{Decode, Encode};
-use evm::Config as EvmConfig;
+use codec::{Encode, Decode};
+#[cfg(feature = "std")]
+use serde::{Serialize, Deserialize};
+use frame_support::{decl_module, decl_storage, decl_event, decl_error};
+use frame_support::weights::{Weight, Pays, PostDispatchInfo};
+use frame_support::traits::{Currency, ExistenceRequirement, Get, WithdrawReasons, Imbalance, OnUnbalanced};
 use frame_support::dispatch::DispatchResultWithPostInfo;
-use frame_support::traits::{
-    Currency, ExistenceRequirement, Get, Imbalance, OnUnbalanced, WithdrawReasons,
-};
-use frame_support::weights::{Pays, PostDispatchInfo, Weight};
-use frame_support::{decl_error, decl_event, decl_module, decl_storage};
 use frame_system::RawOrigin;
-#[cfg(feature = "std")]
-use serde::{Deserialize, Serialize};
-use sp_core::{Hasher, H160, H256, U256};
-use sp_runtime::{
-    traits::{BadOrigin, Saturating, UniqueSaturatedInto},
-    AccountId32,
-};
-use sp_std::{marker::PhantomData, vec::Vec};
+use sp_core::{U256, H256, H160, Hasher};
+use sp_runtime::{AccountId32, traits::{UniqueSaturatedInto, BadOrigin, Saturating}};
+use evm::Config as EvmConfig;
 
 /// Type alias for currency balance.
-pub type BalanceOf<T> =
-    <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+pub type BalanceOf<T> = <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 
-type NegativeImbalanceOf<C, T> =
-    <C as Currency<<T as frame_system::Config>::AccountId>>::NegativeImbalance;
+/// Type alias for negative imbalance during fees
+type NegativeImbalanceOf<C, T> = <C as Currency<<T as frame_system::Config>::AccountId>>::NegativeImbalance;
 
 /// Trait that outputs the current transaction gas price.
 pub trait FeeCalculator {
-    /// Return the minimal required gas price.
-    fn min_gas_price() -> U256;
+	/// Return the minimal required gas price.
+	fn min_gas_price() -> U256;
 }
 
 impl FeeCalculator for () {
-    fn min_gas_price() -> U256 {
-        U256::zero()
-    }
+	fn min_gas_price() -> U256 { U256::zero() }
 }
 
 pub trait EnsureAddressOrigin<OuterOrigin> {
-    /// Success return type.
-    type Success;
+	/// Success return type.
+	type Success;
 
-    /// Perform the origin check.
-    fn ensure_address_origin(
-        address: &H160,
-        origin: OuterOrigin,
-    ) -> Result<Self::Success, BadOrigin> {
-        Self::try_address_origin(address, origin).map_err(|_| BadOrigin)
-    }
+	/// Perform the origin check.
+	fn ensure_address_origin(
+		address: &H160,
+		origin: OuterOrigin,
+	) -> Result<Self::Success, BadOrigin> {
+		Self::try_address_origin(address, origin).map_err(|_| BadOrigin)
+	}
 
-    /// Try with origin.
-    fn try_address_origin(
-        address: &H160,
-        origin: OuterOrigin,
-    ) -> Result<Self::Success, OuterOrigin>;
+	/// Try with origin.
+	fn try_address_origin(
+		address: &H160,
+		origin: OuterOrigin,
+	) -> Result<Self::Success, OuterOrigin>;
 }
 
 /// Ensure that the EVM address is the same as the Substrate address. This only works if the account
 /// ID is `H160`.
 pub struct EnsureAddressSame;
 
-impl<OuterOrigin> EnsureAddressOrigin<OuterOrigin> for EnsureAddressSame
-where
-    OuterOrigin: Into<Result<RawOrigin<H160>, OuterOrigin>> + From<RawOrigin<H160>>,
+impl<OuterOrigin> EnsureAddressOrigin<OuterOrigin> for EnsureAddressSame where
+	OuterOrigin: Into<Result<RawOrigin<H160>, OuterOrigin>> + From<RawOrigin<H160>>,
 {
-    type Success = H160;
+	type Success = H160;
 
-    fn try_address_origin(address: &H160, origin: OuterOrigin) -> Result<H160, OuterOrigin> {
-        origin.into().and_then(|o| match o {
-            RawOrigin::Signed(who) if &who == address => Ok(who),
-            r => Err(OuterOrigin::from(r)),
-        })
-    }
+	fn try_address_origin(
+		address: &H160,
+		origin: OuterOrigin,
+	) -> Result<H160, OuterOrigin> {
+		origin.into().and_then(|o| match o {
+			RawOrigin::Signed(who) if &who == address => Ok(who),
+			r => Err(OuterOrigin::from(r))
+		})
+	}
 }
 
 /// Ensure that the origin is root.
 pub struct EnsureAddressRoot<AccountId>(sp_std::marker::PhantomData<AccountId>);
 
-impl<OuterOrigin, AccountId> EnsureAddressOrigin<OuterOrigin> for EnsureAddressRoot<AccountId>
-where
-    OuterOrigin: Into<Result<RawOrigin<AccountId>, OuterOrigin>> + From<RawOrigin<AccountId>>,
+impl<OuterOrigin, AccountId> EnsureAddressOrigin<OuterOrigin> for EnsureAddressRoot<AccountId> where
+	OuterOrigin: Into<Result<RawOrigin<AccountId>, OuterOrigin>> + From<RawOrigin<AccountId>>,
 {
-    type Success = ();
+	type Success = ();
 
-    fn try_address_origin(_address: &H160, origin: OuterOrigin) -> Result<(), OuterOrigin> {
-        origin.into().and_then(|o| match o {
-            RawOrigin::Root => Ok(()),
-            r => Err(OuterOrigin::from(r)),
-        })
-    }
+	fn try_address_origin(
+		_address: &H160,
+		origin: OuterOrigin,
+	) -> Result<(), OuterOrigin> {
+		origin.into().and_then(|o| match o {
+			RawOrigin::Root => Ok(()),
+			r => Err(OuterOrigin::from(r)),
+		})
+	}
 }
 
 /// Ensure that the origin never happens.
 pub struct EnsureAddressNever<AccountId>(sp_std::marker::PhantomData<AccountId>);
 
 impl<OuterOrigin, AccountId> EnsureAddressOrigin<OuterOrigin> for EnsureAddressNever<AccountId> {
-    type Success = AccountId;
+	type Success = AccountId;
 
-    fn try_address_origin(_address: &H160, origin: OuterOrigin) -> Result<AccountId, OuterOrigin> {
-        Err(origin)
-    }
+	fn try_address_origin(
+		_address: &H160,
+		origin: OuterOrigin,
+	) -> Result<AccountId, OuterOrigin> {
+		Err(origin)
+	}
 }
 
 /// Ensure that the address is truncated hash of the origin. Only works if the account id is
 /// `AccountId32`.
 pub struct EnsureAddressTruncated;
 
-impl<OuterOrigin> EnsureAddressOrigin<OuterOrigin> for EnsureAddressTruncated
-where
-    OuterOrigin: Into<Result<RawOrigin<AccountId32>, OuterOrigin>> + From<RawOrigin<AccountId32>>,
+impl<OuterOrigin> EnsureAddressOrigin<OuterOrigin> for EnsureAddressTruncated where
+	OuterOrigin: Into<Result<RawOrigin<AccountId32>, OuterOrigin>> + From<RawOrigin<AccountId32>>,
 {
-    type Success = AccountId32;
+	type Success = AccountId32;
 
-    fn try_address_origin(address: &H160, origin: OuterOrigin) -> Result<AccountId32, OuterOrigin> {
-        origin.into().and_then(|o| match o {
-            RawOrigin::Signed(who) if AsRef::<[u8; 32]>::as_ref(&who)[0..20] == address[0..20] => {
-                Ok(who)
-            }
-            r => Err(OuterOrigin::from(r)),
-        })
-    }
+	fn try_address_origin(
+		address: &H160,
+		origin: OuterOrigin,
+	) -> Result<AccountId32, OuterOrigin> {
+		origin.into().and_then(|o| match o {
+			RawOrigin::Signed(who)
+				if AsRef::<[u8; 32]>::as_ref(&who)[0..20] == address[0..20] => Ok(who),
+			r => Err(OuterOrigin::from(r))
+		})
+	}
 }
 
 pub trait AddressMapping<A> {
-    fn into_account_id(address: H160) -> A;
+	fn into_account_id(address: H160) -> A;
 }
 
 /// Identity address mapping.
 pub struct IdentityAddressMapping;
 
 impl AddressMapping<H160> for IdentityAddressMapping {
-    fn into_account_id(address: H160) -> H160 {
-        address
-    }
+	fn into_account_id(address: H160) -> H160 { address }
 }
 
 /// Hashed address mapping.
 pub struct HashedAddressMapping<H>(sp_std::marker::PhantomData<H>);
 
-impl<H: Hasher<Out = H256>> AddressMapping<AccountId32> for HashedAddressMapping<H> {
-    fn into_account_id(address: H160) -> AccountId32 {
-        let mut data = [0u8; 24];
-        data[0..4].copy_from_slice(b"evm:");
-        data[4..24].copy_from_slice(&address[..]);
-        let hash = H::hash(&data);
+impl<H: Hasher<Out=H256>> AddressMapping<AccountId32> for HashedAddressMapping<H> {
+	fn into_account_id(address: H160) -> AccountId32 {
+		let mut data = [0u8; 24];
+		data[0..4].copy_from_slice(b"evm:");
+		data[4..24].copy_from_slice(&address[..]);
+		let hash = H::hash(&data);
 
-        AccountId32::from(Into::<[u8; 32]>::into(hash))
-    }
+		AccountId32::from(Into::<[u8; 32]>::into(hash))
+	}
 }
 
 /// A mapping function that converts Ethereum gas to Substrate weight
 pub trait GasWeightMapping {
-    fn gas_to_weight(gas: u64) -> Weight;
-    fn weight_to_gas(weight: Weight) -> u64;
+	fn gas_to_weight(gas: u64) -> Weight;
+	fn weight_to_gas(weight: Weight) -> u64;
 }
 
 impl GasWeightMapping for () {
-    fn gas_to_weight(gas: u64) -> Weight {
-        gas as Weight
-    }
-    fn weight_to_gas(weight: Weight) -> u64 {
-        weight as u64
-    }
+	fn gas_to_weight(gas: u64) -> Weight {
+		gas as Weight
+	}
+	fn weight_to_gas(weight: Weight) -> u64 {
+		weight as u64
+	}
 }
 
 static ISTANBUL_CONFIG: EvmConfig = EvmConfig::istanbul();
 
 /// EVM module trait
 pub trait Config: frame_system::Config + pallet_timestamp::Config {
-    /// Calculator for current gas price.
-    type FeeCalculator: FeeCalculator;
+	/// Calculator for current gas price.
+	type FeeCalculator: FeeCalculator;
 
-    /// Maps Ethereum gas to Substrate weight.
-    type GasWeightMapping: GasWeightMapping;
+	/// Maps Ethereum gas to Substrate weight.
+	type GasWeightMapping: GasWeightMapping;
 
-    /// Allow the origin to call on behalf of given address.
-    type CallOrigin: EnsureAddressOrigin<Self::Origin>;
-    /// Allow the origin to withdraw on behalf of given address.
-    type WithdrawOrigin: EnsureAddressOrigin<Self::Origin, Success = Self::AccountId>;
+	/// Allow the origin to call on behalf of given address.
+	type CallOrigin: EnsureAddressOrigin<Self::Origin>;
+	/// Allow the origin to withdraw on behalf of given address.
+	type WithdrawOrigin: EnsureAddressOrigin<Self::Origin, Success=Self::AccountId>;
 
-    /// Mapping from address to account id.
-    type AddressMapping: AddressMapping<Self::AccountId>;
-    /// Currency type for withdraw and balance storage.
-    type Currency: Currency<Self::AccountId>;
+	/// Mapping from address to account id.
+	type AddressMapping: AddressMapping<Self::AccountId>;
+	/// Currency type for withdraw and balance storage.
+	type Currency: Currency<Self::AccountId>;
 
-    /// The overarching event type.
-    type Event: From<Event<Self>> + Into<<Self as frame_system::Config>::Event>;
-    /// Precompiles associated with this EVM engine.
-    type Precompiles: PrecompileSet;
-    /// Chain ID of EVM.
-    type ChainId: Get<u64>;
-    /// EVM execution runner.
-    type Runner: Runner<Self>;
+	/// The overarching event type.
+	type Event: From<Event<Self>> + Into<<Self as frame_system::Config>::Event>;
+	/// Precompiles associated with this EVM engine.
+	type Precompiles: PrecompileSet;
+	/// Chain ID of EVM.
+	type ChainId: Get<u64>;
+	/// EVM execution runner.
+	type Runner: Runner<Self>;
 
-    /// To handle fee deduction for EVM transactions. An example is this pallet being used by `pallet_ethereum`
-    /// where the chain implementing `pallet_ethereum` should be able to configure what happens to the fees
-    /// Similar to `OnChargeTransaction` of `pallet_transaction_payment`
-    type OnChargeTransaction: OnChargeEVMTransaction<Self>;
+	/// To handle fee deduction for EVM transactions. An example is this pallet being used by `pallet_ethereum`
+	/// where the chain implementing `pallet_ethereum` should be able to configure what happens to the fees
+	/// Similar to `OnChargeTransaction` of `pallet_transaction_payment`
+	type OnChargeTransaction: OnChargeEVMTransaction<Self>;
 
-    /// EVM config used in the module.
-    fn config() -> &'static EvmConfig {
-        &ISTANBUL_CONFIG
-    }
+	/// EVM config used in the module.
+	fn config() -> &'static EvmConfig {
+		&ISTANBUL_CONFIG
+	}
 }
 
 #[cfg(feature = "std")]
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, Serialize, Deserialize)]
 /// Account definition used for genesis block construction.
 pub struct GenesisAccount {
-    /// Account nonce.
-    pub nonce: U256,
-    /// Account balance.
-    pub balance: U256,
-    /// Full account storage.
-    pub storage: std::collections::BTreeMap<H256, H256>,
-    /// Account code.
-    pub code: Vec<u8>,
+	/// Account nonce.
+	pub nonce: U256,
+	/// Account balance.
+	pub balance: U256,
+	/// Full account storage.
+	pub storage: std::collections::BTreeMap<H256, H256>,
+	/// Account code.
+	pub code: Vec<u8>,
 }
 
 decl_storage! {
-    trait Store for Module<T: Config> as EVM {
-        pub AccountCodes get(fn account_codes): map hasher(blake2_128_concat) H160 => Vec<u8>;
-        pub AccountStorages get(fn account_storages):
-            double_map hasher(blake2_128_concat) H160, hasher(blake2_128_concat) H256 => H256;
-    }
+	trait Store for Module<T: Config> as EVM {
+		pub AccountCodes get(fn account_codes): map hasher(blake2_128_concat) H160 => Vec<u8>;
+		pub AccountStorages get(fn account_storages):
+			double_map hasher(blake2_128_concat) H160, hasher(blake2_128_concat) H256 => H256;
+	}
 
-    add_extra_genesis {
-        config(accounts): std::collections::BTreeMap<H160, GenesisAccount>;
-        build(|config: &GenesisConfig| {
-            for (address, account) in &config.accounts {
-                let account_id = T::AddressMapping::into_account_id(*address);
+	add_extra_genesis {
+		config(accounts): std::collections::BTreeMap<H160, GenesisAccount>;
+		build(|config: &GenesisConfig| {
+			for (address, account) in &config.accounts {
+				let account_id = T::AddressMapping::into_account_id(*address);
 
-                // ASSUME: in one single EVM transaction, the nonce will not increase more than
-                // `u128::max_value()`.
-                for _ in 0..account.nonce.low_u128() {
-                    frame_system::Module::<T>::inc_account_nonce(&account_id);
-                }
+				// ASSUME: in one single EVM transaction, the nonce will not increase more than
+				// `u128::max_value()`.
+				for _ in 0..account.nonce.low_u128() {
+					frame_system::Module::<T>::inc_account_nonce(&account_id);
+				}
 
-                T::Currency::deposit_creating(
-                    &account_id,
-                    account.balance.low_u128().unique_saturated_into(),
-                );
+				T::Currency::deposit_creating(
+					&account_id,
+					account.balance.low_u128().unique_saturated_into(),
+				);
 
-                AccountCodes::insert(address, &account.code);
+				AccountCodes::insert(address, &account.code);
 
-                for (index, value) in &account.storage {
-                    AccountStorages::insert(address, index, value);
-                }
-            }
-        });
-    }
+				for (index, value) in &account.storage {
+					AccountStorages::insert(address, index, value);
+				}
+			}
+		});
+	}
 }
 
 decl_event! {
-    /// EVM events
-    pub enum Event<T> where
-        <T as frame_system::Config>::AccountId,
-    {
-        /// Ethereum events from contracts.
-        Log(Log),
-        /// A contract has been created at given \[address\].
-        Created(H160),
-        /// A \[contract\] was attempted to be created, but the execution failed.
-        CreatedFailed(H160),
-        /// A \[contract\] has been executed successfully with states applied.
-        Executed(H160),
-        /// A \[contract\] has been executed with errors. States are reverted with only gas fees applied.
-        ExecutedFailed(H160),
-        /// A deposit has been made at a given address. \[sender, address, value\]
-        BalanceDeposit(AccountId, H160, U256),
-        /// A withdrawal has been made from a given address. \[sender, address, value\]
-        BalanceWithdraw(AccountId, H160, U256),
-    }
+	/// EVM events
+	pub enum Event<T> where
+		<T as frame_system::Config>::AccountId,
+	{
+		/// Ethereum events from contracts.
+		Log(Log),
+		/// A contract has been created at given \[address\].
+		Created(H160),
+		/// A \[contract\] was attempted to be created, but the execution failed.
+		CreatedFailed(H160),
+		/// A \[contract\] has been executed successfully with states applied.
+		Executed(H160),
+		/// A \[contract\] has been executed with errors. States are reverted with only gas fees applied.
+		ExecutedFailed(H160),
+		/// A deposit has been made at a given address. \[sender, address, value\]
+		BalanceDeposit(AccountId, H160, U256),
+		/// A withdrawal has been made from a given address. \[sender, address, value\]
+		BalanceWithdraw(AccountId, H160, U256),
+	}
 }
 
 decl_error! {
-    pub enum Error for Module<T: Config> {
-        /// Not enough balance to perform action
-        BalanceLow,
-        /// Calculating total fee overflowed
-        FeeOverflow,
-        /// Calculating total payment overflowed
-        PaymentOverflow,
-        /// Withdraw fee failed
-        WithdrawFailed,
-        /// Gas price is too low.
-        GasPriceTooLow,
-        /// Nonce is invalid
-        InvalidNonce,
-    }
+	pub enum Error for Module<T: Config> {
+		/// Not enough balance to perform action
+		BalanceLow,
+		/// Calculating total fee overflowed
+		FeeOverflow,
+		/// Calculating total payment overflowed
+		PaymentOverflow,
+		/// Withdraw fee failed
+		WithdrawFailed,
+		/// Gas price is too low.
+		GasPriceTooLow,
+		/// Nonce is invalid
+		InvalidNonce,
+	}
 }
 
 decl_module! {
-    pub struct Module<T: Config> for enum Call where origin: T::Origin {
-        type Error = Error<T>;
+	pub struct Module<T: Config> for enum Call where origin: T::Origin {
+		type Error = Error<T>;
 
-        fn deposit_event() = default;
+		fn deposit_event() = default;
 
-        /// Withdraw balance from EVM into currency/balances module.
-        #[weight = 0]
-        fn withdraw(origin, address: H160, value: BalanceOf<T>) {
-            let destination = T::WithdrawOrigin::ensure_address_origin(&address, origin)?;
-            let address_account_id = T::AddressMapping::into_account_id(address);
+		/// Withdraw balance from EVM into currency/balances module.
+		#[weight = 0]
+		fn withdraw(origin, address: H160, value: BalanceOf<T>) {
+			let destination = T::WithdrawOrigin::ensure_address_origin(&address, origin)?;
+			let address_account_id = T::AddressMapping::into_account_id(address);
 
-            T::Currency::transfer(
-                &address_account_id,
-                &destination,
-                value,
-                ExistenceRequirement::AllowDeath
-            )?;
-        }
+			T::Currency::transfer(
+				&address_account_id,
+				&destination,
+				value,
+				ExistenceRequirement::AllowDeath
+			)?;
+		}
 
-        /// Issue an EVM call operation. This is similar to a message call transaction in Ethereum.
-        #[weight = T::GasWeightMapping::gas_to_weight(*gas_limit)]
-        fn call(
-            origin,
-            source: H160,
-            target: H160,
-            input: Vec<u8>,
-            value: U256,
-            gas_limit: u64,
-            gas_price: U256,
-            nonce: Option<U256>,
-        ) -> DispatchResultWithPostInfo {
-            T::CallOrigin::ensure_address_origin(&source, origin)?;
+		/// Issue an EVM call operation. This is similar to a message call transaction in Ethereum.
+		#[weight = T::GasWeightMapping::gas_to_weight(*gas_limit)]
+		fn call(
+			origin,
+			source: H160,
+			target: H160,
+			input: Vec<u8>,
+			value: U256,
+			gas_limit: u64,
+			gas_price: U256,
+			nonce: Option<U256>,
+		) -> DispatchResultWithPostInfo {
+			T::CallOrigin::ensure_address_origin(&source, origin)?;
 
-            let info = T::Runner::call(
-                source,
-                target,
-                input,
-                value,
-                gas_limit,
-                Some(gas_price),
-                nonce,
-                T::config(),
-            )?;
+			let info = T::Runner::call(
+				source,
+				target,
+				input,
+				value,
+				gas_limit,
+				Some(gas_price),
+				nonce,
+				T::config(),
+			)?;
 
-            match info.exit_reason {
-                ExitReason::Succeed(_) => {
-                    Module::<T>::deposit_event(Event::<T>::Executed(target));
-                },
-                _ => {
-                    Module::<T>::deposit_event(Event::<T>::ExecutedFailed(target));
-                },
-            };
+			match info.exit_reason {
+				ExitReason::Succeed(_) => {
+					Module::<T>::deposit_event(Event::<T>::Executed(target));
+				},
+				_ => {
+					Module::<T>::deposit_event(Event::<T>::ExecutedFailed(target));
+				},
+			};
 
-            Ok(PostDispatchInfo {
-                actual_weight: Some(T::GasWeightMapping::gas_to_weight(info.used_gas.unique_saturated_into())),
-                pays_fee: Pays::No,
-            })
-        }
+			Ok(PostDispatchInfo {
+				actual_weight: Some(T::GasWeightMapping::gas_to_weight(info.used_gas.unique_saturated_into())),
+				pays_fee: Pays::No,
+			})
+		}
 
-        /// Issue an EVM create operation. This is similar to a contract creation transaction in
-        /// Ethereum.
-        #[weight = T::GasWeightMapping::gas_to_weight(*gas_limit)]
-        fn create(
-            origin,
-            source: H160,
-            init: Vec<u8>,
-            value: U256,
-            gas_limit: u64,
-            gas_price: U256,
-            nonce: Option<U256>,
-        ) -> DispatchResultWithPostInfo {
-            T::CallOrigin::ensure_address_origin(&source, origin)?;
+		/// Issue an EVM create operation. This is similar to a contract creation transaction in
+		/// Ethereum.
+		#[weight = T::GasWeightMapping::gas_to_weight(*gas_limit)]
+		fn create(
+			origin,
+			source: H160,
+			init: Vec<u8>,
+			value: U256,
+			gas_limit: u64,
+			gas_price: U256,
+			nonce: Option<U256>,
+		) -> DispatchResultWithPostInfo {
+			T::CallOrigin::ensure_address_origin(&source, origin)?;
 
-            let info = T::Runner::create(
-                source,
-                init,
-                value,
-                gas_limit,
-                Some(gas_price),
-                nonce,
-                T::config(),
-            )?;
+			let info = T::Runner::create(
+				source,
+				init,
+				value,
+				gas_limit,
+				Some(gas_price),
+				nonce,
+				T::config(),
+			)?;
 
-            match info {
-                CreateInfo {
-                    exit_reason: ExitReason::Succeed(_),
-                    value: create_address,
-                    ..
-                } => {
-                    Module::<T>::deposit_event(Event::<T>::Created(create_address));
-                },
-                CreateInfo {
-                    exit_reason: _,
-                    value: create_address,
-                    ..
-                } => {
-                    Module::<T>::deposit_event(Event::<T>::CreatedFailed(create_address));
-                },
-            }
+			match info {
+				CreateInfo {
+					exit_reason: ExitReason::Succeed(_),
+					value: create_address,
+					..
+				} => {
+					Module::<T>::deposit_event(Event::<T>::Created(create_address));
+				},
+				CreateInfo {
+					exit_reason: _,
+					value: create_address,
+					..
+				} => {
+					Module::<T>::deposit_event(Event::<T>::CreatedFailed(create_address));
+				},
+			}
 
-            Ok(PostDispatchInfo {
-                actual_weight: Some(T::GasWeightMapping::gas_to_weight(info.used_gas.unique_saturated_into())),
-                pays_fee: Pays::No,
-            })
-        }
+			Ok(PostDispatchInfo {
+				actual_weight: Some(T::GasWeightMapping::gas_to_weight(info.used_gas.unique_saturated_into())),
+				pays_fee: Pays::No,
+			})
+		}
 
-        /// Issue an EVM create2 operation.
-        #[weight = T::GasWeightMapping::gas_to_weight(*gas_limit)]
-        fn create2(
-            origin,
-            source: H160,
-            init: Vec<u8>,
-            salt: H256,
-            value: U256,
-            gas_limit: u64,
-            gas_price: U256,
-            nonce: Option<U256>,
-        ) -> DispatchResultWithPostInfo {
-            T::CallOrigin::ensure_address_origin(&source, origin)?;
+		/// Issue an EVM create2 operation.
+		#[weight = T::GasWeightMapping::gas_to_weight(*gas_limit)]
+		fn create2(
+			origin,
+			source: H160,
+			init: Vec<u8>,
+			salt: H256,
+			value: U256,
+			gas_limit: u64,
+			gas_price: U256,
+			nonce: Option<U256>,
+		) -> DispatchResultWithPostInfo {
+			T::CallOrigin::ensure_address_origin(&source, origin)?;
 
-            let info = T::Runner::create2(
-                source,
-                init,
-                salt,
-                value,
-                gas_limit,
-                Some(gas_price),
-                nonce,
-                T::config(),
-            )?;
+			let info = T::Runner::create2(
+				source,
+				init,
+				salt,
+				value,
+				gas_limit,
+				Some(gas_price),
+				nonce,
+				T::config(),
+			)?;
 
-            match info {
-                CreateInfo {
-                    exit_reason: ExitReason::Succeed(_),
-                    value: create_address,
-                    ..
-                } => {
-                    Module::<T>::deposit_event(Event::<T>::Created(create_address));
-                },
-                CreateInfo {
-                    exit_reason: _,
-                    value: create_address,
-                    ..
-                } => {
-                    Module::<T>::deposit_event(Event::<T>::CreatedFailed(create_address));
-                },
-            }
+			match info {
+				CreateInfo {
+					exit_reason: ExitReason::Succeed(_),
+					value: create_address,
+					..
+				} => {
+					Module::<T>::deposit_event(Event::<T>::Created(create_address));
+				},
+				CreateInfo {
+					exit_reason: _,
+					value: create_address,
+					..
+				} => {
+					Module::<T>::deposit_event(Event::<T>::CreatedFailed(create_address));
+				},
+			}
 
-            Ok(PostDispatchInfo {
-                actual_weight: Some(T::GasWeightMapping::gas_to_weight(info.used_gas.unique_saturated_into())),
-                pays_fee: Pays::No,
-            })
-        }
-    }
+			Ok(PostDispatchInfo {
+				actual_weight: Some(T::GasWeightMapping::gas_to_weight(info.used_gas.unique_saturated_into())),
+				pays_fee: Pays::No,
+			})
+		}
+	}
 }
 
 impl<T: Config> Module<T> {
-    /// Check whether an account is empty.
-    pub fn is_account_empty(address: &H160) -> bool {
-        let account = Self::account_basic(address);
-        let code_len = AccountCodes::decode_len(address).unwrap_or(0);
+	/// Check whether an account is empty.
+	pub fn is_account_empty(address: &H160) -> bool {
+		let account = Self::account_basic(address);
+		let code_len = AccountCodes::decode_len(address).unwrap_or(0);
 
-        account.nonce == U256::zero() && account.balance == U256::zero() && code_len == 0
-    }
+		account.nonce == U256::zero() &&
+			account.balance == U256::zero() &&
+			code_len == 0
+	}
 
-    /// Remove an account if its empty.
-    pub fn remove_account_if_empty(address: &H160) {
-        if Self::is_account_empty(address) {
-            Self::remove_account(address);
-        }
-    }
+	/// Remove an account if its empty.
+	pub fn remove_account_if_empty(address: &H160) {
+		if Self::is_account_empty(address) {
+			Self::remove_account(address);
+		}
+	}
 
-    /// Remove an account.
-    pub fn remove_account(address: &H160) {
-        if AccountCodes::contains_key(address) {
-            let account_id = T::AddressMapping::into_account_id(*address);
-            frame_system::Module::<T>::dec_ref(&account_id);
-        }
+	/// Remove an account.
+	pub fn remove_account(address: &H160) {
+		if AccountCodes::contains_key(address) {
+			let account_id = T::AddressMapping::into_account_id(*address);
+			frame_system::Module::<T>::dec_ref(&account_id);
+		}
 
-        AccountCodes::remove(address);
-        AccountStorages::remove_prefix(address);
-    }
+		AccountCodes::remove(address);
+		AccountStorages::remove_prefix(address);
+	}
 
-    /// Create an account.
-    pub fn create_account(address: H160, code: Vec<u8>) {
-        if code.is_empty() {
-            return;
-        }
+	/// Create an account.
+	pub fn create_account(address: H160, code: Vec<u8>) {
+		if code.is_empty() {
+			return
+		}
 
-        if !AccountCodes::contains_key(&address) {
-            let account_id = T::AddressMapping::into_account_id(address);
-            frame_system::Module::<T>::inc_ref(&account_id);
-        }
+		if !AccountCodes::contains_key(&address) {
+			let account_id = T::AddressMapping::into_account_id(address);
+			frame_system::Module::<T>::inc_ref(&account_id);
+		}
 
-        AccountCodes::insert(address, code);
-    }
+		AccountCodes::insert(address, code);
+	}
 
-    /// Get the account basic in EVM format.
-    pub fn account_basic(address: &H160) -> Account {
-        let account_id = T::AddressMapping::into_account_id(*address);
+	/// Get the account basic in EVM format.
+	pub fn account_basic(address: &H160) -> Account {
+		let account_id = T::AddressMapping::into_account_id(*address);
 
-        let nonce = frame_system::Module::<T>::account_nonce(&account_id);
-        let balance = T::Currency::free_balance(&account_id);
+		let nonce = frame_system::Module::<T>::account_nonce(&account_id);
+		let balance = T::Currency::free_balance(&account_id);
 
-        Account {
-            nonce: U256::from(UniqueSaturatedInto::<u128>::unique_saturated_into(nonce)),
-            balance: U256::from(UniqueSaturatedInto::<u128>::unique_saturated_into(balance)),
-        }
-    }
+		Account {
+			nonce: U256::from(UniqueSaturatedInto::<u128>::unique_saturated_into(nonce)),
+			balance: U256::from(UniqueSaturatedInto::<u128>::unique_saturated_into(balance)),
+		}
+	}
 }
 
 /// Handle withdrawing, refunding and depositing of transaction fees.
 /// Similar to `OnChargeTransaction` of `pallet_transaction_payment`
 pub trait OnChargeEVMTransaction<T: Config> {
-    type LiquidityInfo: Default;
+	type LiquidityInfo: Default;
 
-    /// Before the transaction is executed the payment of the transaction fees
-    /// need to be secured.
-    fn withdraw_fee(who: &H160, fee: U256) -> Result<Self::LiquidityInfo, Error<T>>;
+	/// Before the transaction is executed the payment of the transaction fees
+	/// need to be secured.
+	fn withdraw_fee(who: &H160, fee: U256) -> Result<Self::LiquidityInfo, Error<T>>;
 
-    /// After the transaction was executed the actual fee can be calculated.
-    /// This function should refund any overpaid fees and optionally deposit
-    /// the corrected amount.
-    fn correct_and_deposit_fee(
-        who: &H160,
-        corrected_fee: U256,
-        already_withdrawn: Self::LiquidityInfo,
-    ) -> Result<(), Error<T>>;
+	/// After the transaction was executed the actual fee can be calculated.
+	/// This function should refund any overpaid fees and optionally deposit
+	/// the corrected amount.
+	fn correct_and_deposit_fee(
+		who: &H160,
+		corrected_fee: U256,
+		already_withdrawn: Self::LiquidityInfo,
+	) -> Result<(), Error<T>>;
 }
 
 /// Implements the transaction payment for a module implementing the `Currency`
 /// trait (eg. the pallet_balances) using an unbalance handler (implementing
 /// `OnUnbalanced`).
 /// Similar to `CurrencyAdapter` of `pallet_transaction_payment`
-pub struct EVMCurrencyAdapter<C, OU>(PhantomData<(C, OU)>);
+pub struct EVMCurrencyAdapter<C, OU>(sp_std::marker::PhantomData<(C, OU)>);
 
 impl<T, C, OU> OnChargeEVMTransaction<T> for EVMCurrencyAdapter<C, OU>
 where
-    T: Config,
-    C: Currency<<T as frame_system::Config>::AccountId>,
-    C::PositiveImbalance: Imbalance<
-        <C as Currency<<T as frame_system::Config>::AccountId>>::Balance,
-        Opposite = C::NegativeImbalance,
-    >,
-    C::NegativeImbalance: Imbalance<
-        <C as Currency<<T as frame_system::Config>::AccountId>>::Balance,
-        Opposite = C::PositiveImbalance,
-    >,
-    OU: OnUnbalanced<NegativeImbalanceOf<C, T>>,
+	T: Config,
+	C: Currency<<T as frame_system::Config>::AccountId>,
+	C::PositiveImbalance: Imbalance<
+		<C as Currency<<T as frame_system::Config>::AccountId>>::Balance,
+		Opposite = C::NegativeImbalance,
+	>,
+	C::NegativeImbalance: Imbalance<
+		<C as Currency<<T as frame_system::Config>::AccountId>>::Balance,
+		Opposite = C::PositiveImbalance,
+	>,
+	OU: OnUnbalanced<NegativeImbalanceOf<C, T>>,
 {
-    // Kept type as Option to satisfy bound of Default
-    type LiquidityInfo = Option<NegativeImbalanceOf<C, T>>;
+	// Kept type as Option to satisfy bound of Default
+	type LiquidityInfo = Option<NegativeImbalanceOf<C, T>>;
 
-    fn withdraw_fee(who: &H160, fee: U256) -> Result<Self::LiquidityInfo, Error<T>> {
-        let account_id = T::AddressMapping::into_account_id(*who);
-        let imbalance = C::withdraw(
-            &account_id,
-            fee.low_u128().unique_saturated_into(),
-            WithdrawReasons::FEE,
-            ExistenceRequirement::AllowDeath,
-        )
-        .map_err(|_| Error::<T>::BalanceLow)?;
-        Ok(Some(imbalance))
-    }
+	fn withdraw_fee(who: &H160, fee: U256) -> Result<Self::LiquidityInfo, Error<T>> {
+		let account_id = T::AddressMapping::into_account_id(*who);
+		let imbalance = C::withdraw(
+			&account_id,
+			fee.low_u128().unique_saturated_into(),
+			WithdrawReasons::FEE,
+			ExistenceRequirement::AllowDeath,
+		)
+		.map_err(|_| Error::<T>::BalanceLow)?;
+		Ok(Some(imbalance))
+	}
 
-    fn correct_and_deposit_fee(
-        who: &H160,
-        corrected_fee: U256,
-        already_withdrawn: Self::LiquidityInfo,
-    ) -> Result<(), Error<T>> {
-        if let Some(paid) = already_withdrawn {
-            let account_id = T::AddressMapping::into_account_id(*who);
+	fn correct_and_deposit_fee(
+		who: &H160,
+		corrected_fee: U256,
+		already_withdrawn: Self::LiquidityInfo,
+	) -> Result<(), Error<T>> {
+		if let Some(paid) = already_withdrawn {
+			let account_id = T::AddressMapping::into_account_id(*who);
 
-            // Calculate how much refund we should return
-            let refund_amount = paid
-                .peek()
-                .saturating_sub(corrected_fee.low_u128().unique_saturated_into());
-            // refund to the account that paid the fees. If this fails, the
-            // account might have dropped below the existential balance. In
-            // that case we don't refund anything.
-            let refund_imbalance = C::deposit_into_existing(&account_id, refund_amount)
-                .unwrap_or_else(|_| C::PositiveImbalance::zero());
-            // merge the imbalance caused by paying the fees and refunding parts of it again.
-            let adjusted_paid = paid
-                .offset(refund_imbalance)
-                .map_err(|_| Error::<T>::BalanceLow)?;
-            OU::on_unbalanced(adjusted_paid);
-        }
-        Ok(())
-    }
+			// Calculate how much refund we should return
+			let refund_amount = paid
+				.peek()
+				.saturating_sub(corrected_fee.low_u128().unique_saturated_into());
+			// refund to the account that paid the fees. If this fails, the
+			// account might have dropped below the existential balance. In
+			// that case we don't refund anything.
+			let refund_imbalance = C::deposit_into_existing(&account_id, refund_amount)
+				.unwrap_or_else(|_| C::PositiveImbalance::zero());
+			// merge the imbalance caused by paying the fees and refunding parts of it again.
+			let adjusted_paid = paid
+				.offset(refund_imbalance)
+				.map_err(|_| Error::<T>::BalanceLow)?;
+			OU::on_unbalanced(adjusted_paid);
+		}
+		Ok(())
+	}
 }
 
 /// Implementation for () does not specify what to do with imbalance

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -53,532 +53,624 @@
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
 
-mod tests;
 pub mod runner;
+mod tests;
 
 pub use crate::runner::Runner;
+pub use evm::{ExitError, ExitFatal, ExitReason, ExitRevert, ExitSucceed};
 pub use fp_evm::{
-	Account, Log, Vicinity, ExecutionInfo, CallInfo, CreateInfo, Precompile,
-	PrecompileSet, LinearCostPrecompile,
+    Account, CallInfo, CreateInfo, ExecutionInfo, LinearCostPrecompile, Log, Precompile,
+    PrecompileSet, Vicinity,
 };
-pub use evm::{ExitReason, ExitSucceed, ExitError, ExitRevert, ExitFatal};
 
-use sp_std::vec::Vec;
 #[cfg(feature = "std")]
-use codec::{Encode, Decode};
-#[cfg(feature = "std")]
-use serde::{Serialize, Deserialize};
-use frame_support::{decl_module, decl_storage, decl_event, decl_error};
-use frame_support::weights::{Weight, Pays, PostDispatchInfo};
-use frame_support::traits::{Currency, ExistenceRequirement, Get, WithdrawReasons};
-use frame_support::dispatch::DispatchResultWithPostInfo;
-use frame_system::RawOrigin;
-use sp_core::{U256, H256, H160, Hasher};
-use sp_runtime::{AccountId32, traits::{UniqueSaturatedInto, BadOrigin}};
+use codec::{Decode, Encode};
 use evm::Config as EvmConfig;
+use frame_support::dispatch::DispatchResultWithPostInfo;
+use frame_support::traits::{
+    Currency, ExistenceRequirement, Get, Imbalance, OnUnbalanced, WithdrawReasons,
+};
+use frame_support::weights::{Pays, PostDispatchInfo, Weight};
+use frame_support::{decl_error, decl_event, decl_module, decl_storage};
+use frame_system::RawOrigin;
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
+use sp_core::{Hasher, H160, H256, U256};
+use sp_runtime::{
+    traits::{BadOrigin, Saturating, UniqueSaturatedInto},
+    AccountId32,
+};
+use sp_std::{marker::PhantomData, vec::Vec};
 
 /// Type alias for currency balance.
-pub type BalanceOf<T> = <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+pub type BalanceOf<T> =
+    <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+
+type NegativeImbalanceOf<C, T> =
+    <C as Currency<<T as frame_system::Config>::AccountId>>::NegativeImbalance;
 
 /// Trait that outputs the current transaction gas price.
 pub trait FeeCalculator {
-	/// Return the minimal required gas price.
-	fn min_gas_price() -> U256;
+    /// Return the minimal required gas price.
+    fn min_gas_price() -> U256;
 }
 
 impl FeeCalculator for () {
-	fn min_gas_price() -> U256 { U256::zero() }
+    fn min_gas_price() -> U256 {
+        U256::zero()
+    }
 }
 
 pub trait EnsureAddressOrigin<OuterOrigin> {
-	/// Success return type.
-	type Success;
+    /// Success return type.
+    type Success;
 
-	/// Perform the origin check.
-	fn ensure_address_origin(
-		address: &H160,
-		origin: OuterOrigin,
-	) -> Result<Self::Success, BadOrigin> {
-		Self::try_address_origin(address, origin).map_err(|_| BadOrigin)
-	}
+    /// Perform the origin check.
+    fn ensure_address_origin(
+        address: &H160,
+        origin: OuterOrigin,
+    ) -> Result<Self::Success, BadOrigin> {
+        Self::try_address_origin(address, origin).map_err(|_| BadOrigin)
+    }
 
-	/// Try with origin.
-	fn try_address_origin(
-		address: &H160,
-		origin: OuterOrigin,
-	) -> Result<Self::Success, OuterOrigin>;
+    /// Try with origin.
+    fn try_address_origin(
+        address: &H160,
+        origin: OuterOrigin,
+    ) -> Result<Self::Success, OuterOrigin>;
 }
 
 /// Ensure that the EVM address is the same as the Substrate address. This only works if the account
 /// ID is `H160`.
 pub struct EnsureAddressSame;
 
-impl<OuterOrigin> EnsureAddressOrigin<OuterOrigin> for EnsureAddressSame where
-	OuterOrigin: Into<Result<RawOrigin<H160>, OuterOrigin>> + From<RawOrigin<H160>>,
+impl<OuterOrigin> EnsureAddressOrigin<OuterOrigin> for EnsureAddressSame
+where
+    OuterOrigin: Into<Result<RawOrigin<H160>, OuterOrigin>> + From<RawOrigin<H160>>,
 {
-	type Success = H160;
+    type Success = H160;
 
-	fn try_address_origin(
-		address: &H160,
-		origin: OuterOrigin,
-	) -> Result<H160, OuterOrigin> {
-		origin.into().and_then(|o| match o {
-			RawOrigin::Signed(who) if &who == address => Ok(who),
-			r => Err(OuterOrigin::from(r))
-		})
-	}
+    fn try_address_origin(address: &H160, origin: OuterOrigin) -> Result<H160, OuterOrigin> {
+        origin.into().and_then(|o| match o {
+            RawOrigin::Signed(who) if &who == address => Ok(who),
+            r => Err(OuterOrigin::from(r)),
+        })
+    }
 }
 
 /// Ensure that the origin is root.
 pub struct EnsureAddressRoot<AccountId>(sp_std::marker::PhantomData<AccountId>);
 
-impl<OuterOrigin, AccountId> EnsureAddressOrigin<OuterOrigin> for EnsureAddressRoot<AccountId> where
-	OuterOrigin: Into<Result<RawOrigin<AccountId>, OuterOrigin>> + From<RawOrigin<AccountId>>,
+impl<OuterOrigin, AccountId> EnsureAddressOrigin<OuterOrigin> for EnsureAddressRoot<AccountId>
+where
+    OuterOrigin: Into<Result<RawOrigin<AccountId>, OuterOrigin>> + From<RawOrigin<AccountId>>,
 {
-	type Success = ();
+    type Success = ();
 
-	fn try_address_origin(
-		_address: &H160,
-		origin: OuterOrigin,
-	) -> Result<(), OuterOrigin> {
-		origin.into().and_then(|o| match o {
-			RawOrigin::Root => Ok(()),
-			r => Err(OuterOrigin::from(r)),
-		})
-	}
+    fn try_address_origin(_address: &H160, origin: OuterOrigin) -> Result<(), OuterOrigin> {
+        origin.into().and_then(|o| match o {
+            RawOrigin::Root => Ok(()),
+            r => Err(OuterOrigin::from(r)),
+        })
+    }
 }
 
 /// Ensure that the origin never happens.
 pub struct EnsureAddressNever<AccountId>(sp_std::marker::PhantomData<AccountId>);
 
 impl<OuterOrigin, AccountId> EnsureAddressOrigin<OuterOrigin> for EnsureAddressNever<AccountId> {
-	type Success = AccountId;
+    type Success = AccountId;
 
-	fn try_address_origin(
-		_address: &H160,
-		origin: OuterOrigin,
-	) -> Result<AccountId, OuterOrigin> {
-		Err(origin)
-	}
+    fn try_address_origin(_address: &H160, origin: OuterOrigin) -> Result<AccountId, OuterOrigin> {
+        Err(origin)
+    }
 }
 
 /// Ensure that the address is truncated hash of the origin. Only works if the account id is
 /// `AccountId32`.
 pub struct EnsureAddressTruncated;
 
-impl<OuterOrigin> EnsureAddressOrigin<OuterOrigin> for EnsureAddressTruncated where
-	OuterOrigin: Into<Result<RawOrigin<AccountId32>, OuterOrigin>> + From<RawOrigin<AccountId32>>,
+impl<OuterOrigin> EnsureAddressOrigin<OuterOrigin> for EnsureAddressTruncated
+where
+    OuterOrigin: Into<Result<RawOrigin<AccountId32>, OuterOrigin>> + From<RawOrigin<AccountId32>>,
 {
-	type Success = AccountId32;
+    type Success = AccountId32;
 
-	fn try_address_origin(
-		address: &H160,
-		origin: OuterOrigin,
-	) -> Result<AccountId32, OuterOrigin> {
-		origin.into().and_then(|o| match o {
-			RawOrigin::Signed(who)
-				if AsRef::<[u8; 32]>::as_ref(&who)[0..20] == address[0..20] => Ok(who),
-			r => Err(OuterOrigin::from(r))
-		})
-	}
+    fn try_address_origin(address: &H160, origin: OuterOrigin) -> Result<AccountId32, OuterOrigin> {
+        origin.into().and_then(|o| match o {
+            RawOrigin::Signed(who) if AsRef::<[u8; 32]>::as_ref(&who)[0..20] == address[0..20] => {
+                Ok(who)
+            }
+            r => Err(OuterOrigin::from(r)),
+        })
+    }
 }
 
 pub trait AddressMapping<A> {
-	fn into_account_id(address: H160) -> A;
+    fn into_account_id(address: H160) -> A;
 }
 
 /// Identity address mapping.
 pub struct IdentityAddressMapping;
 
 impl AddressMapping<H160> for IdentityAddressMapping {
-	fn into_account_id(address: H160) -> H160 { address }
+    fn into_account_id(address: H160) -> H160 {
+        address
+    }
 }
 
 /// Hashed address mapping.
 pub struct HashedAddressMapping<H>(sp_std::marker::PhantomData<H>);
 
-impl<H: Hasher<Out=H256>> AddressMapping<AccountId32> for HashedAddressMapping<H> {
-	fn into_account_id(address: H160) -> AccountId32 {
-		let mut data = [0u8; 24];
-		data[0..4].copy_from_slice(b"evm:");
-		data[4..24].copy_from_slice(&address[..]);
-		let hash = H::hash(&data);
+impl<H: Hasher<Out = H256>> AddressMapping<AccountId32> for HashedAddressMapping<H> {
+    fn into_account_id(address: H160) -> AccountId32 {
+        let mut data = [0u8; 24];
+        data[0..4].copy_from_slice(b"evm:");
+        data[4..24].copy_from_slice(&address[..]);
+        let hash = H::hash(&data);
 
-		AccountId32::from(Into::<[u8; 32]>::into(hash))
-	}
+        AccountId32::from(Into::<[u8; 32]>::into(hash))
+    }
 }
 
 /// A mapping function that converts Ethereum gas to Substrate weight
 pub trait GasWeightMapping {
-	fn gas_to_weight(gas: u64) -> Weight;
-	fn weight_to_gas(weight: Weight) -> u64;
+    fn gas_to_weight(gas: u64) -> Weight;
+    fn weight_to_gas(weight: Weight) -> u64;
 }
 
 impl GasWeightMapping for () {
-	fn gas_to_weight(gas: u64) -> Weight {
-		gas as Weight
-	}
-	fn weight_to_gas(weight: Weight) -> u64 {
-		weight as u64
-	}
+    fn gas_to_weight(gas: u64) -> Weight {
+        gas as Weight
+    }
+    fn weight_to_gas(weight: Weight) -> u64 {
+        weight as u64
+    }
 }
 
 static ISTANBUL_CONFIG: EvmConfig = EvmConfig::istanbul();
 
 /// EVM module trait
 pub trait Config: frame_system::Config + pallet_timestamp::Config {
-	/// Calculator for current gas price.
-	type FeeCalculator: FeeCalculator;
+    /// Calculator for current gas price.
+    type FeeCalculator: FeeCalculator;
 
-	/// Maps Ethereum gas to Substrate weight.
-	type GasWeightMapping: GasWeightMapping;
+    /// Maps Ethereum gas to Substrate weight.
+    type GasWeightMapping: GasWeightMapping;
 
-	/// Allow the origin to call on behalf of given address.
-	type CallOrigin: EnsureAddressOrigin<Self::Origin>;
-	/// Allow the origin to withdraw on behalf of given address.
-	type WithdrawOrigin: EnsureAddressOrigin<Self::Origin, Success=Self::AccountId>;
+    /// Allow the origin to call on behalf of given address.
+    type CallOrigin: EnsureAddressOrigin<Self::Origin>;
+    /// Allow the origin to withdraw on behalf of given address.
+    type WithdrawOrigin: EnsureAddressOrigin<Self::Origin, Success = Self::AccountId>;
 
-	/// Mapping from address to account id.
-	type AddressMapping: AddressMapping<Self::AccountId>;
-	/// Currency type for withdraw and balance storage.
-	type Currency: Currency<Self::AccountId>;
+    /// Mapping from address to account id.
+    type AddressMapping: AddressMapping<Self::AccountId>;
+    /// Currency type for withdraw and balance storage.
+    type Currency: Currency<Self::AccountId>;
 
-	/// The overarching event type.
-	type Event: From<Event<Self>> + Into<<Self as frame_system::Config>::Event>;
-	/// Precompiles associated with this EVM engine.
-	type Precompiles: PrecompileSet;
-	/// Chain ID of EVM.
-	type ChainId: Get<u64>;
-	/// EVM execution runner.
-	type Runner: Runner<Self>;
+    /// The overarching event type.
+    type Event: From<Event<Self>> + Into<<Self as frame_system::Config>::Event>;
+    /// Precompiles associated with this EVM engine.
+    type Precompiles: PrecompileSet;
+    /// Chain ID of EVM.
+    type ChainId: Get<u64>;
+    /// EVM execution runner.
+    type Runner: Runner<Self>;
 
-	/// EVM config used in the module.
-	fn config() -> &'static EvmConfig {
-		&ISTANBUL_CONFIG
-	}
+    /// To handle fee deduction for EVM transactions. An example is this pallet being used by `pallet_ethereum`
+    /// where the chain implementing `pallet_ethereum` should be able to configure what happens to the fees
+    /// Similar to `OnChargeTransaction` of `pallet_transaction_payment`
+    type OnChargeTransaction: OnChargeEVMTransaction<Self>;
+
+    /// EVM config used in the module.
+    fn config() -> &'static EvmConfig {
+        &ISTANBUL_CONFIG
+    }
 }
 
 #[cfg(feature = "std")]
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, Serialize, Deserialize)]
 /// Account definition used for genesis block construction.
 pub struct GenesisAccount {
-	/// Account nonce.
-	pub nonce: U256,
-	/// Account balance.
-	pub balance: U256,
-	/// Full account storage.
-	pub storage: std::collections::BTreeMap<H256, H256>,
-	/// Account code.
-	pub code: Vec<u8>,
+    /// Account nonce.
+    pub nonce: U256,
+    /// Account balance.
+    pub balance: U256,
+    /// Full account storage.
+    pub storage: std::collections::BTreeMap<H256, H256>,
+    /// Account code.
+    pub code: Vec<u8>,
 }
 
 decl_storage! {
-	trait Store for Module<T: Config> as EVM {
-		pub AccountCodes get(fn account_codes): map hasher(blake2_128_concat) H160 => Vec<u8>;
-		pub AccountStorages get(fn account_storages):
-			double_map hasher(blake2_128_concat) H160, hasher(blake2_128_concat) H256 => H256;
-	}
+    trait Store for Module<T: Config> as EVM {
+        pub AccountCodes get(fn account_codes): map hasher(blake2_128_concat) H160 => Vec<u8>;
+        pub AccountStorages get(fn account_storages):
+            double_map hasher(blake2_128_concat) H160, hasher(blake2_128_concat) H256 => H256;
+    }
 
-	add_extra_genesis {
-		config(accounts): std::collections::BTreeMap<H160, GenesisAccount>;
-		build(|config: &GenesisConfig| {
-			for (address, account) in &config.accounts {
-				let account_id = T::AddressMapping::into_account_id(*address);
+    add_extra_genesis {
+        config(accounts): std::collections::BTreeMap<H160, GenesisAccount>;
+        build(|config: &GenesisConfig| {
+            for (address, account) in &config.accounts {
+                let account_id = T::AddressMapping::into_account_id(*address);
 
-				// ASSUME: in one single EVM transaction, the nonce will not increase more than
-				// `u128::max_value()`.
-				for _ in 0..account.nonce.low_u128() {
-					frame_system::Module::<T>::inc_account_nonce(&account_id);
-				}
+                // ASSUME: in one single EVM transaction, the nonce will not increase more than
+                // `u128::max_value()`.
+                for _ in 0..account.nonce.low_u128() {
+                    frame_system::Module::<T>::inc_account_nonce(&account_id);
+                }
 
-				T::Currency::deposit_creating(
-					&account_id,
-					account.balance.low_u128().unique_saturated_into(),
-				);
+                T::Currency::deposit_creating(
+                    &account_id,
+                    account.balance.low_u128().unique_saturated_into(),
+                );
 
-				AccountCodes::insert(address, &account.code);
+                AccountCodes::insert(address, &account.code);
 
-				for (index, value) in &account.storage {
-					AccountStorages::insert(address, index, value);
-				}
-			}
-		});
-	}
+                for (index, value) in &account.storage {
+                    AccountStorages::insert(address, index, value);
+                }
+            }
+        });
+    }
 }
 
 decl_event! {
-	/// EVM events
-	pub enum Event<T> where
-		<T as frame_system::Config>::AccountId,
-	{
-		/// Ethereum events from contracts.
-		Log(Log),
-		/// A contract has been created at given \[address\].
-		Created(H160),
-		/// A \[contract\] was attempted to be created, but the execution failed.
-		CreatedFailed(H160),
-		/// A \[contract\] has been executed successfully with states applied.
-		Executed(H160),
-		/// A \[contract\] has been executed with errors. States are reverted with only gas fees applied.
-		ExecutedFailed(H160),
-		/// A deposit has been made at a given address. \[sender, address, value\]
-		BalanceDeposit(AccountId, H160, U256),
-		/// A withdrawal has been made from a given address. \[sender, address, value\]
-		BalanceWithdraw(AccountId, H160, U256),
-	}
+    /// EVM events
+    pub enum Event<T> where
+        <T as frame_system::Config>::AccountId,
+    {
+        /// Ethereum events from contracts.
+        Log(Log),
+        /// A contract has been created at given \[address\].
+        Created(H160),
+        /// A \[contract\] was attempted to be created, but the execution failed.
+        CreatedFailed(H160),
+        /// A \[contract\] has been executed successfully with states applied.
+        Executed(H160),
+        /// A \[contract\] has been executed with errors. States are reverted with only gas fees applied.
+        ExecutedFailed(H160),
+        /// A deposit has been made at a given address. \[sender, address, value\]
+        BalanceDeposit(AccountId, H160, U256),
+        /// A withdrawal has been made from a given address. \[sender, address, value\]
+        BalanceWithdraw(AccountId, H160, U256),
+    }
 }
 
 decl_error! {
-	pub enum Error for Module<T: Config> {
-		/// Not enough balance to perform action
-		BalanceLow,
-		/// Calculating total fee overflowed
-		FeeOverflow,
-		/// Calculating total payment overflowed
-		PaymentOverflow,
-		/// Withdraw fee failed
-		WithdrawFailed,
-		/// Gas price is too low.
-		GasPriceTooLow,
-		/// Nonce is invalid
-		InvalidNonce,
-	}
+    pub enum Error for Module<T: Config> {
+        /// Not enough balance to perform action
+        BalanceLow,
+        /// Calculating total fee overflowed
+        FeeOverflow,
+        /// Calculating total payment overflowed
+        PaymentOverflow,
+        /// Withdraw fee failed
+        WithdrawFailed,
+        /// Gas price is too low.
+        GasPriceTooLow,
+        /// Nonce is invalid
+        InvalidNonce,
+    }
 }
 
 decl_module! {
-	pub struct Module<T: Config> for enum Call where origin: T::Origin {
-		type Error = Error<T>;
+    pub struct Module<T: Config> for enum Call where origin: T::Origin {
+        type Error = Error<T>;
 
-		fn deposit_event() = default;
+        fn deposit_event() = default;
 
-		/// Withdraw balance from EVM into currency/balances module.
-		#[weight = 0]
-		fn withdraw(origin, address: H160, value: BalanceOf<T>) {
-			let destination = T::WithdrawOrigin::ensure_address_origin(&address, origin)?;
-			let address_account_id = T::AddressMapping::into_account_id(address);
+        /// Withdraw balance from EVM into currency/balances module.
+        #[weight = 0]
+        fn withdraw(origin, address: H160, value: BalanceOf<T>) {
+            let destination = T::WithdrawOrigin::ensure_address_origin(&address, origin)?;
+            let address_account_id = T::AddressMapping::into_account_id(address);
 
-			T::Currency::transfer(
-				&address_account_id,
-				&destination,
-				value,
-				ExistenceRequirement::AllowDeath
-			)?;
-		}
+            T::Currency::transfer(
+                &address_account_id,
+                &destination,
+                value,
+                ExistenceRequirement::AllowDeath
+            )?;
+        }
 
-		/// Issue an EVM call operation. This is similar to a message call transaction in Ethereum.
-		#[weight = T::GasWeightMapping::gas_to_weight(*gas_limit)]
-		fn call(
-			origin,
-			source: H160,
-			target: H160,
-			input: Vec<u8>,
-			value: U256,
-			gas_limit: u64,
-			gas_price: U256,
-			nonce: Option<U256>,
-		) -> DispatchResultWithPostInfo {
-			T::CallOrigin::ensure_address_origin(&source, origin)?;
+        /// Issue an EVM call operation. This is similar to a message call transaction in Ethereum.
+        #[weight = T::GasWeightMapping::gas_to_weight(*gas_limit)]
+        fn call(
+            origin,
+            source: H160,
+            target: H160,
+            input: Vec<u8>,
+            value: U256,
+            gas_limit: u64,
+            gas_price: U256,
+            nonce: Option<U256>,
+        ) -> DispatchResultWithPostInfo {
+            T::CallOrigin::ensure_address_origin(&source, origin)?;
 
-			let info = T::Runner::call(
-				source,
-				target,
-				input,
-				value,
-				gas_limit,
-				Some(gas_price),
-				nonce,
-				T::config(),
-			)?;
+            let info = T::Runner::call(
+                source,
+                target,
+                input,
+                value,
+                gas_limit,
+                Some(gas_price),
+                nonce,
+                T::config(),
+            )?;
 
-			match info.exit_reason {
-				ExitReason::Succeed(_) => {
-					Module::<T>::deposit_event(Event::<T>::Executed(target));
-				},
-				_ => {
-					Module::<T>::deposit_event(Event::<T>::ExecutedFailed(target));
-				},
-			};
+            match info.exit_reason {
+                ExitReason::Succeed(_) => {
+                    Module::<T>::deposit_event(Event::<T>::Executed(target));
+                },
+                _ => {
+                    Module::<T>::deposit_event(Event::<T>::ExecutedFailed(target));
+                },
+            };
 
-			Ok(PostDispatchInfo {
-				actual_weight: Some(T::GasWeightMapping::gas_to_weight(info.used_gas.unique_saturated_into())),
-				pays_fee: Pays::No,
-			})
-		}
+            Ok(PostDispatchInfo {
+                actual_weight: Some(T::GasWeightMapping::gas_to_weight(info.used_gas.unique_saturated_into())),
+                pays_fee: Pays::No,
+            })
+        }
 
-		/// Issue an EVM create operation. This is similar to a contract creation transaction in
-		/// Ethereum.
-		#[weight = T::GasWeightMapping::gas_to_weight(*gas_limit)]
-		fn create(
-			origin,
-			source: H160,
-			init: Vec<u8>,
-			value: U256,
-			gas_limit: u64,
-			gas_price: U256,
-			nonce: Option<U256>,
-		) -> DispatchResultWithPostInfo {
-			T::CallOrigin::ensure_address_origin(&source, origin)?;
+        /// Issue an EVM create operation. This is similar to a contract creation transaction in
+        /// Ethereum.
+        #[weight = T::GasWeightMapping::gas_to_weight(*gas_limit)]
+        fn create(
+            origin,
+            source: H160,
+            init: Vec<u8>,
+            value: U256,
+            gas_limit: u64,
+            gas_price: U256,
+            nonce: Option<U256>,
+        ) -> DispatchResultWithPostInfo {
+            T::CallOrigin::ensure_address_origin(&source, origin)?;
 
-			let info = T::Runner::create(
-				source,
-				init,
-				value,
-				gas_limit,
-				Some(gas_price),
-				nonce,
-				T::config(),
-			)?;
+            let info = T::Runner::create(
+                source,
+                init,
+                value,
+                gas_limit,
+                Some(gas_price),
+                nonce,
+                T::config(),
+            )?;
 
-			match info {
-				CreateInfo {
-					exit_reason: ExitReason::Succeed(_),
-					value: create_address,
-					..
-				} => {
-					Module::<T>::deposit_event(Event::<T>::Created(create_address));
-				},
-				CreateInfo {
-					exit_reason: _,
-					value: create_address,
-					..
-				} => {
-					Module::<T>::deposit_event(Event::<T>::CreatedFailed(create_address));
-				},
-			}
+            match info {
+                CreateInfo {
+                    exit_reason: ExitReason::Succeed(_),
+                    value: create_address,
+                    ..
+                } => {
+                    Module::<T>::deposit_event(Event::<T>::Created(create_address));
+                },
+                CreateInfo {
+                    exit_reason: _,
+                    value: create_address,
+                    ..
+                } => {
+                    Module::<T>::deposit_event(Event::<T>::CreatedFailed(create_address));
+                },
+            }
 
-			Ok(PostDispatchInfo {
-				actual_weight: Some(T::GasWeightMapping::gas_to_weight(info.used_gas.unique_saturated_into())),
-				pays_fee: Pays::No,
-			})
-		}
+            Ok(PostDispatchInfo {
+                actual_weight: Some(T::GasWeightMapping::gas_to_weight(info.used_gas.unique_saturated_into())),
+                pays_fee: Pays::No,
+            })
+        }
 
-		/// Issue an EVM create2 operation.
-		#[weight = T::GasWeightMapping::gas_to_weight(*gas_limit)]
-		fn create2(
-			origin,
-			source: H160,
-			init: Vec<u8>,
-			salt: H256,
-			value: U256,
-			gas_limit: u64,
-			gas_price: U256,
-			nonce: Option<U256>,
-		) -> DispatchResultWithPostInfo {
-			T::CallOrigin::ensure_address_origin(&source, origin)?;
+        /// Issue an EVM create2 operation.
+        #[weight = T::GasWeightMapping::gas_to_weight(*gas_limit)]
+        fn create2(
+            origin,
+            source: H160,
+            init: Vec<u8>,
+            salt: H256,
+            value: U256,
+            gas_limit: u64,
+            gas_price: U256,
+            nonce: Option<U256>,
+        ) -> DispatchResultWithPostInfo {
+            T::CallOrigin::ensure_address_origin(&source, origin)?;
 
-			let info = T::Runner::create2(
-				source,
-				init,
-				salt,
-				value,
-				gas_limit,
-				Some(gas_price),
-				nonce,
-				T::config(),
-			)?;
+            let info = T::Runner::create2(
+                source,
+                init,
+                salt,
+                value,
+                gas_limit,
+                Some(gas_price),
+                nonce,
+                T::config(),
+            )?;
 
-			match info {
-				CreateInfo {
-					exit_reason: ExitReason::Succeed(_),
-					value: create_address,
-					..
-				} => {
-					Module::<T>::deposit_event(Event::<T>::Created(create_address));
-				},
-				CreateInfo {
-					exit_reason: _,
-					value: create_address,
-					..
-				} => {
-					Module::<T>::deposit_event(Event::<T>::CreatedFailed(create_address));
-				},
-			}
+            match info {
+                CreateInfo {
+                    exit_reason: ExitReason::Succeed(_),
+                    value: create_address,
+                    ..
+                } => {
+                    Module::<T>::deposit_event(Event::<T>::Created(create_address));
+                },
+                CreateInfo {
+                    exit_reason: _,
+                    value: create_address,
+                    ..
+                } => {
+                    Module::<T>::deposit_event(Event::<T>::CreatedFailed(create_address));
+                },
+            }
 
-			Ok(PostDispatchInfo {
-				actual_weight: Some(T::GasWeightMapping::gas_to_weight(info.used_gas.unique_saturated_into())),
-				pays_fee: Pays::No,
-			})
-		}
-	}
+            Ok(PostDispatchInfo {
+                actual_weight: Some(T::GasWeightMapping::gas_to_weight(info.used_gas.unique_saturated_into())),
+                pays_fee: Pays::No,
+            })
+        }
+    }
 }
 
 impl<T: Config> Module<T> {
-	/// Check whether an account is empty.
-	pub fn is_account_empty(address: &H160) -> bool {
-		let account = Self::account_basic(address);
-		let code_len = AccountCodes::decode_len(address).unwrap_or(0);
+    /// Check whether an account is empty.
+    pub fn is_account_empty(address: &H160) -> bool {
+        let account = Self::account_basic(address);
+        let code_len = AccountCodes::decode_len(address).unwrap_or(0);
 
-		account.nonce == U256::zero() &&
-			account.balance == U256::zero() &&
-			code_len == 0
+        account.nonce == U256::zero() && account.balance == U256::zero() && code_len == 0
+    }
+
+    /// Remove an account if its empty.
+    pub fn remove_account_if_empty(address: &H160) {
+        if Self::is_account_empty(address) {
+            Self::remove_account(address);
+        }
+    }
+
+    /// Remove an account.
+    pub fn remove_account(address: &H160) {
+        if AccountCodes::contains_key(address) {
+            let account_id = T::AddressMapping::into_account_id(*address);
+            frame_system::Module::<T>::dec_ref(&account_id);
+        }
+
+        AccountCodes::remove(address);
+        AccountStorages::remove_prefix(address);
+    }
+
+    /// Create an account.
+    pub fn create_account(address: H160, code: Vec<u8>) {
+        if code.is_empty() {
+            return;
+        }
+
+        if !AccountCodes::contains_key(&address) {
+            let account_id = T::AddressMapping::into_account_id(address);
+            frame_system::Module::<T>::inc_ref(&account_id);
+        }
+
+        AccountCodes::insert(address, code);
+    }
+
+    /// Get the account basic in EVM format.
+    pub fn account_basic(address: &H160) -> Account {
+        let account_id = T::AddressMapping::into_account_id(*address);
+
+        let nonce = frame_system::Module::<T>::account_nonce(&account_id);
+        let balance = T::Currency::free_balance(&account_id);
+
+        Account {
+            nonce: U256::from(UniqueSaturatedInto::<u128>::unique_saturated_into(nonce)),
+            balance: U256::from(UniqueSaturatedInto::<u128>::unique_saturated_into(balance)),
+        }
+    }
+}
+
+/// Handle withdrawing, refunding and depositing of transaction fees.
+/// Similar to `OnChargeTransaction` of `pallet_transaction_payment`
+pub trait OnChargeEVMTransaction<T: Config> {
+    type LiquidityInfo: Default;
+
+    /// Before the transaction is executed the payment of the transaction fees
+    /// need to be secured.
+    fn withdraw_fee(who: &H160, fee: U256) -> Result<Self::LiquidityInfo, Error<T>>;
+
+    /// After the transaction was executed the actual fee can be calculated.
+    /// This function should refund any overpaid fees and optionally deposit
+    /// the corrected amount.
+    fn correct_and_deposit_fee(
+        who: &H160,
+        corrected_fee: U256,
+        already_withdrawn: Self::LiquidityInfo,
+    ) -> Result<(), Error<T>>;
+}
+
+/// Implements the transaction payment for a module implementing the `Currency`
+/// trait (eg. the pallet_balances) using an unbalance handler (implementing
+/// `OnUnbalanced`).
+/// Similar to `CurrencyAdapter` of `pallet_transaction_payment`
+pub struct EVMCurrencyAdapter<C, OU>(PhantomData<(C, OU)>);
+
+impl<T, C, OU> OnChargeEVMTransaction<T> for EVMCurrencyAdapter<C, OU>
+where
+    T: Config,
+    C: Currency<<T as frame_system::Config>::AccountId>,
+    C::PositiveImbalance: Imbalance<
+        <C as Currency<<T as frame_system::Config>::AccountId>>::Balance,
+        Opposite = C::NegativeImbalance,
+    >,
+    C::NegativeImbalance: Imbalance<
+        <C as Currency<<T as frame_system::Config>::AccountId>>::Balance,
+        Opposite = C::PositiveImbalance,
+    >,
+    OU: OnUnbalanced<NegativeImbalanceOf<C, T>>,
+{
+    // Kept type as Option to satisfy bound of Default
+    type LiquidityInfo = Option<NegativeImbalanceOf<C, T>>;
+
+    fn withdraw_fee(who: &H160, fee: U256) -> Result<Self::LiquidityInfo, Error<T>> {
+        let account_id = T::AddressMapping::into_account_id(*who);
+        let imbalance = C::withdraw(
+            &account_id,
+            fee.low_u128().unique_saturated_into(),
+            WithdrawReasons::FEE,
+            ExistenceRequirement::AllowDeath,
+        )
+        .map_err(|_| Error::<T>::BalanceLow)?;
+        Ok(Some(imbalance))
+    }
+
+    fn correct_and_deposit_fee(
+        who: &H160,
+        corrected_fee: U256,
+        already_withdrawn: Self::LiquidityInfo,
+    ) -> Result<(), Error<T>> {
+        if let Some(paid) = already_withdrawn {
+            let account_id = T::AddressMapping::into_account_id(*who);
+
+            // Calculate how much refund we should return
+            let refund_amount = paid
+                .peek()
+                .saturating_sub(corrected_fee.low_u128().unique_saturated_into());
+            // refund to the account that paid the fees. If this fails, the
+            // account might have dropped below the existential balance. In
+            // that case we don't refund anything.
+            let refund_imbalance = C::deposit_into_existing(&account_id, refund_amount)
+                .unwrap_or_else(|_| C::PositiveImbalance::zero());
+            // merge the imbalance caused by paying the fees and refunding parts of it again.
+            let adjusted_paid = paid
+                .offset(refund_imbalance)
+                .map_err(|_| Error::<T>::BalanceLow)?;
+            OU::on_unbalanced(adjusted_paid);
+        }
+        Ok(())
+    }
+}
+
+/// Implementation for () does not specify what to do with imbalance
+impl<T> OnChargeEVMTransaction<T> for ()
+	where
+	T: Config,
+	<T::Currency as Currency<<T as frame_system::Config>::AccountId>>::PositiveImbalance:
+		Imbalance<<T::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance, Opposite = <T::Currency as Currency<<T as frame_system::Config>::AccountId>>::NegativeImbalance>,
+	<T::Currency as Currency<<T as frame_system::Config>::AccountId>>::NegativeImbalance:
+		Imbalance<<T::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance, Opposite = <T::Currency as Currency<<T as frame_system::Config>::AccountId>>::PositiveImbalance>, {
+	// Kept type as Option to satisfy bound of Default
+	type LiquidityInfo = Option<NegativeImbalanceOf<T::Currency, T>>;
+
+	fn withdraw_fee(
+		who: &H160,
+		fee: U256,
+	) -> Result<Self::LiquidityInfo, Error<T>> {
+		EVMCurrencyAdapter::<<T as Config>::Currency, ()>::withdraw_fee(who, fee)
 	}
 
-	/// Remove an account if its empty.
-	pub fn remove_account_if_empty(address: &H160) {
-		if Self::is_account_empty(address) {
-			Self::remove_account(address);
-		}
-	}
-
-	/// Remove an account.
-	pub fn remove_account(address: &H160) {
-		if AccountCodes::contains_key(address) {
-			let account_id = T::AddressMapping::into_account_id(*address);
-			frame_system::Module::<T>::dec_ref(&account_id);
-		}
-
-		AccountCodes::remove(address);
-		AccountStorages::remove_prefix(address);
-	}
-
-	/// Create an account.
-	pub fn create_account(address: H160, code: Vec<u8>) {
-		if code.is_empty() {
-			return
-		}
-
-		if !AccountCodes::contains_key(&address) {
-			let account_id = T::AddressMapping::into_account_id(address);
-			frame_system::Module::<T>::inc_ref(&account_id);
-		}
-
-		AccountCodes::insert(address, code);
-	}
-
-	/// Get the account basic in EVM format.
-	pub fn account_basic(address: &H160) -> Account {
-		let account_id = T::AddressMapping::into_account_id(*address);
-
-		let nonce = frame_system::Module::<T>::account_nonce(&account_id);
-		let balance = T::Currency::free_balance(&account_id);
-
-		Account {
-			nonce: U256::from(UniqueSaturatedInto::<u128>::unique_saturated_into(nonce)),
-			balance: U256::from(UniqueSaturatedInto::<u128>::unique_saturated_into(balance)),
-		}
-	}
-
-	/// Withdraw fee.
-	pub fn withdraw_fee(address: &H160, value: U256) -> Result<(), Error<T>> {
-		let account_id = T::AddressMapping::into_account_id(*address);
-
-		drop(T::Currency::withdraw(
-			&account_id,
-			value.low_u128().unique_saturated_into(),
-			WithdrawReasons::FEE,
-			ExistenceRequirement::AllowDeath,
-		).map_err(|_| Error::<T>::BalanceLow)?);
-
-		Ok(())
-	}
-
-	/// Deposit fee.
-	pub fn deposit_fee(address: &H160, value: U256) {
-		let account_id = T::AddressMapping::into_account_id(*address);
-
-		drop(T::Currency::deposit_creating(
-			&account_id,
-			value.low_u128().unique_saturated_into(),
-		));
+	fn correct_and_deposit_fee(
+		who: &H160,
+		corrected_fee: U256,
+		already_withdrawn: Self::LiquidityInfo,
+	) -> Result<(), Error<T>> {
+		EVMCurrencyAdapter::<<T as Config>::Currency, ()>::correct_and_deposit_fee(who, corrected_fee, already_withdrawn)
 	}
 }

--- a/frame/evm/src/runner/mod.rs
+++ b/frame/evm/src/runner/mod.rs
@@ -17,43 +17,43 @@
 
 pub mod stack;
 
-use sp_std::vec::Vec;
-use sp_core::{H160, U256, H256};
-use fp_evm::{CallInfo, CreateInfo};
 use crate::Config;
+use fp_evm::{CallInfo, CreateInfo};
+use sp_core::{H160, H256, U256};
+use sp_std::vec::Vec;
 
 pub trait Runner<T: Config> {
-	type Error: Into<sp_runtime::DispatchError>;
+    type Error: Into<sp_runtime::DispatchError>;
 
-	fn call(
-		source: H160,
-		target: H160,
-		input: Vec<u8>,
-		value: U256,
-		gas_limit: u64,
-		gas_price: Option<U256>,
-		nonce: Option<U256>,
-		config: &evm::Config,
-	) -> Result<CallInfo, Self::Error>;
+    fn call(
+        source: H160,
+        target: H160,
+        input: Vec<u8>,
+        value: U256,
+        gas_limit: u64,
+        gas_price: Option<U256>,
+        nonce: Option<U256>,
+        config: &evm::Config,
+    ) -> Result<CallInfo, Self::Error>;
 
-	fn create(
-		source: H160,
-		init: Vec<u8>,
-		value: U256,
-		gas_limit: u64,
-		gas_price: Option<U256>,
-		nonce: Option<U256>,
-		config: &evm::Config,
-	) -> Result<CreateInfo, Self::Error>;
+    fn create(
+        source: H160,
+        init: Vec<u8>,
+        value: U256,
+        gas_limit: u64,
+        gas_price: Option<U256>,
+        nonce: Option<U256>,
+        config: &evm::Config,
+    ) -> Result<CreateInfo, Self::Error>;
 
-	fn create2(
-		source: H160,
-		init: Vec<u8>,
-		salt: H256,
-		value: U256,
-		gas_limit: u64,
-		gas_price: Option<U256>,
-		nonce: Option<U256>,
-		config: &evm::Config,
-	) -> Result<CreateInfo, Self::Error>;
+    fn create2(
+        source: H160,
+        init: Vec<u8>,
+        salt: H256,
+        value: U256,
+        gas_limit: u64,
+        gas_price: Option<U256>,
+        nonce: Option<U256>,
+        config: &evm::Config,
+    ) -> Result<CreateInfo, Self::Error>;
 }

--- a/frame/evm/src/runner/mod.rs
+++ b/frame/evm/src/runner/mod.rs
@@ -17,43 +17,43 @@
 
 pub mod stack;
 
-use crate::Config;
-use fp_evm::{CallInfo, CreateInfo};
-use sp_core::{H160, H256, U256};
 use sp_std::vec::Vec;
+use sp_core::{H160, U256, H256};
+use fp_evm::{CallInfo, CreateInfo};
+use crate::Config;
 
 pub trait Runner<T: Config> {
-    type Error: Into<sp_runtime::DispatchError>;
+	type Error: Into<sp_runtime::DispatchError>;
 
-    fn call(
-        source: H160,
-        target: H160,
-        input: Vec<u8>,
-        value: U256,
-        gas_limit: u64,
-        gas_price: Option<U256>,
-        nonce: Option<U256>,
-        config: &evm::Config,
-    ) -> Result<CallInfo, Self::Error>;
+	fn call(
+		source: H160,
+		target: H160,
+		input: Vec<u8>,
+		value: U256,
+		gas_limit: u64,
+		gas_price: Option<U256>,
+		nonce: Option<U256>,
+		config: &evm::Config,
+	) -> Result<CallInfo, Self::Error>;
 
-    fn create(
-        source: H160,
-        init: Vec<u8>,
-        value: U256,
-        gas_limit: u64,
-        gas_price: Option<U256>,
-        nonce: Option<U256>,
-        config: &evm::Config,
-    ) -> Result<CreateInfo, Self::Error>;
+	fn create(
+		source: H160,
+		init: Vec<u8>,
+		value: U256,
+		gas_limit: u64,
+		gas_price: Option<U256>,
+		nonce: Option<U256>,
+		config: &evm::Config,
+	) -> Result<CreateInfo, Self::Error>;
 
-    fn create2(
-        source: H160,
-        init: Vec<u8>,
-        salt: H256,
-        value: U256,
-        gas_limit: u64,
-        gas_price: Option<U256>,
-        nonce: Option<U256>,
-        config: &evm::Config,
-    ) -> Result<CreateInfo, Self::Error>;
+	fn create2(
+		source: H160,
+		init: Vec<u8>,
+		salt: H256,
+		value: U256,
+		gas_limit: u64,
+		gas_price: Option<U256>,
+		nonce: Option<U256>,
+		config: &evm::Config,
+	) -> Result<CreateInfo, Self::Error>;
 }

--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -17,500 +17,515 @@
 
 //! EVM stack-based runner.
 
-use sp_std::{marker::PhantomData, vec::Vec, boxed::Box, mem, collections::btree_set::BTreeSet};
-use sp_core::{U256, H256, H160};
-use sp_runtime::traits::UniqueSaturatedInto;
-use frame_support::{
-	debug, ensure, traits::{Get, Currency, ExistenceRequirement},
-	storage::{StorageMap, StorageDoubleMap},
-};
-use sha3::{Keccak256, Digest};
-use fp_evm::{ExecutionInfo, CallInfo, CreateInfo, Log, Vicinity};
-use evm::{ExitReason, ExitError, Transfer};
-use evm::backend::Backend as BackendT;
-use evm::executor::{StackExecutor, StackSubstateMetadata, StackState as StackStateT};
-use crate::{
-	Config, AccountStorages, FeeCalculator, AccountCodes, Module, Event,
-	Error, AddressMapping, PrecompileSet,
-};
 use crate::runner::Runner as RunnerT;
+use crate::{
+    AccountCodes, AccountStorages, AddressMapping, Config, Error, Event, FeeCalculator, Module,
+    OnChargeEVMTransaction, PrecompileSet,
+};
+use evm::backend::Backend as BackendT;
+use evm::executor::{StackExecutor, StackState as StackStateT, StackSubstateMetadata};
+use evm::{ExitError, ExitReason, Transfer};
+use fp_evm::{CallInfo, CreateInfo, ExecutionInfo, Log, Vicinity};
+use frame_support::{
+    debug, ensure,
+    storage::{StorageDoubleMap, StorageMap},
+    traits::{Currency, ExistenceRequirement, Get},
+};
+use sha3::{Digest, Keccak256};
+use sp_core::{H160, H256, U256};
+use sp_runtime::traits::UniqueSaturatedInto;
+use sp_std::{boxed::Box, collections::btree_set::BTreeSet, marker::PhantomData, mem, vec::Vec};
 
 #[derive(Default)]
 pub struct Runner<T: Config> {
-	_marker: PhantomData<T>,
+    _marker: PhantomData<T>,
 }
 
 impl<T: Config> Runner<T> {
-	/// Execute an EVM operation.
-	pub fn execute<'config, F, R>(
-		source: H160,
-		value: U256,
-		gas_limit: u64,
-		gas_price: Option<U256>,
-		nonce: Option<U256>,
-		config: &'config evm::Config,
-		f: F,
-	) -> Result<ExecutionInfo<R>, Error<T>> where
-		F: FnOnce(&mut StackExecutor<'config, SubstrateStackState<'_, 'config, T>>) -> (ExitReason, R),
-	{
-		// Gas price check is skipped when performing a gas estimation.
-		let gas_price = match gas_price {
-			Some(gas_price) => {
-				ensure!(gas_price >= T::FeeCalculator::min_gas_price(), Error::<T>::GasPriceTooLow);
-				gas_price
-			},
-			None => Default::default(),
-		};
+    /// Execute an EVM operation.
+    pub fn execute<'config, F, R>(
+        source: H160,
+        value: U256,
+        gas_limit: u64,
+        gas_price: Option<U256>,
+        nonce: Option<U256>,
+        config: &'config evm::Config,
+        f: F,
+    ) -> Result<ExecutionInfo<R>, Error<T>>
+    where
+        F: FnOnce(
+            &mut StackExecutor<'config, SubstrateStackState<'_, 'config, T>>,
+        ) -> (ExitReason, R),
+    {
+        // Gas price check is skipped when performing a gas estimation.
+        let gas_price = match gas_price {
+            Some(gas_price) => {
+                ensure!(
+                    gas_price >= T::FeeCalculator::min_gas_price(),
+                    Error::<T>::GasPriceTooLow
+                );
+                gas_price
+            }
+            None => Default::default(),
+        };
 
-		let vicinity = Vicinity {
-			gas_price,
-			origin: source,
-		};
+        let vicinity = Vicinity {
+            gas_price,
+            origin: source,
+        };
 
-		let metadata = StackSubstateMetadata::new(gas_limit, &config);
-		let state = SubstrateStackState::new(&vicinity, metadata);
-		let mut executor = StackExecutor::new_with_precompile(
-			state,
-			config,
-			T::Precompiles::execute,
-		);
+        let metadata = StackSubstateMetadata::new(gas_limit, &config);
+        let state = SubstrateStackState::new(&vicinity, metadata);
+        let mut executor =
+            StackExecutor::new_with_precompile(state, config, T::Precompiles::execute);
 
-		let total_fee = gas_price.checked_mul(U256::from(gas_limit))
-			.ok_or(Error::<T>::FeeOverflow)?;
-		let total_payment = value.checked_add(total_fee).ok_or(Error::<T>::PaymentOverflow)?;
-		let source_account = Module::<T>::account_basic(&source);
-		ensure!(source_account.balance >= total_payment, Error::<T>::BalanceLow);
+        let total_fee = gas_price
+            .checked_mul(U256::from(gas_limit))
+            .ok_or(Error::<T>::FeeOverflow)?;
+        let total_payment = value
+            .checked_add(total_fee)
+            .ok_or(Error::<T>::PaymentOverflow)?;
+        let source_account = Module::<T>::account_basic(&source);
+        ensure!(
+            source_account.balance >= total_payment,
+            Error::<T>::BalanceLow
+        );
 
-		Module::<T>::withdraw_fee(&source, total_fee)?;
+        if let Some(nonce) = nonce {
+            ensure!(source_account.nonce == nonce, Error::<T>::InvalidNonce);
+        }
 
-		if let Some(nonce) = nonce {
-			ensure!(source_account.nonce == nonce, Error::<T>::InvalidNonce);
-		}
+        // Deduct fee from the `source` account.
+        let fee = T::OnChargeTransaction::withdraw_fee(&source, total_fee)?;
 
-		let (reason, retv) = f(&mut executor);
+        // Execute the EVM call.
+        let (reason, retv) = f(&mut executor);
 
-		let used_gas = U256::from(executor.used_gas());
-		let actual_fee = executor.fee(gas_price);
-		debug::debug!(
-			target: "evm",
-			"Execution {:?} [source: {:?}, value: {}, gas_limit: {}, actual_fee: {}]",
-			reason,
-			source,
-			value,
-			gas_limit,
-			actual_fee
-		);
+        let used_gas = U256::from(executor.used_gas());
+        let actual_fee = executor.fee(gas_price);
+        debug::debug!(
+            target: "evm",
+            "Execution {:?} [source: {:?}, value: {}, gas_limit: {}, actual_fee: {}]",
+            reason,
+            source,
+            value,
+            gas_limit,
+            actual_fee
+        );
 
-		Module::<T>::deposit_fee(&source, total_fee.saturating_sub(actual_fee));
+        // Refund fees to the `source` account if deducted more before,
+        T::OnChargeTransaction::correct_and_deposit_fee(&source, actual_fee, fee)?;
 
-		let state = executor.into_state();
+        let state = executor.into_state();
 
-		for address in state.substate.deletes {
-			debug::debug!(
-				target: "evm",
-				"Deleting account at {:?}",
-				address
-			);
-			Module::<T>::remove_account(&address)
-		}
+        for address in state.substate.deletes {
+            debug::debug!(
+                target: "evm",
+                "Deleting account at {:?}",
+                address
+            );
+            Module::<T>::remove_account(&address)
+        }
 
-		for log in &state.substate.logs {
-			debug::trace!(
-				target: "evm",
-				"Inserting log for {:?}, topics ({}) {:?}, data ({}): {:?}]",
-				log.address,
-				log.topics.len(),
-				log.topics,
-				log.data.len(),
-				log.data
-			);
-			Module::<T>::deposit_event(Event::<T>::Log(Log {
-				address: log.address,
-				topics: log.topics.clone(),
-				data: log.data.clone(),
-			}));
-		}
+        for log in &state.substate.logs {
+            debug::trace!(
+                target: "evm",
+                "Inserting log for {:?}, topics ({}) {:?}, data ({}): {:?}]",
+                log.address,
+                log.topics.len(),
+                log.topics,
+                log.data.len(),
+                log.data
+            );
+            Module::<T>::deposit_event(Event::<T>::Log(Log {
+                address: log.address,
+                topics: log.topics.clone(),
+                data: log.data.clone(),
+            }));
+        }
 
-		Ok(ExecutionInfo {
-			value: retv,
-			exit_reason: reason,
-			used_gas,
-			logs: state.substate.logs,
-		})
-	}
+        Ok(ExecutionInfo {
+            value: retv,
+            exit_reason: reason,
+            used_gas,
+            logs: state.substate.logs,
+        })
+    }
 }
 
 impl<T: Config> RunnerT<T> for Runner<T> {
-	type Error = Error<T>;
+    type Error = Error<T>;
 
-	fn call(
-		source: H160,
-		target: H160,
-		input: Vec<u8>,
-		value: U256,
-		gas_limit: u64,
-		gas_price: Option<U256>,
-		nonce: Option<U256>,
-		config: &evm::Config,
-	) -> Result<CallInfo, Self::Error> {
-		Self::execute(
-			source,
-			value,
-			gas_limit,
-			gas_price,
-			nonce,
-			config,
-			|executor| executor.transact_call(
-				source,
-				target,
-				value,
-				input,
-				gas_limit,
-			),
-		)
-	}
+    fn call(
+        source: H160,
+        target: H160,
+        input: Vec<u8>,
+        value: U256,
+        gas_limit: u64,
+        gas_price: Option<U256>,
+        nonce: Option<U256>,
+        config: &evm::Config,
+    ) -> Result<CallInfo, Self::Error> {
+        Self::execute(
+            source,
+            value,
+            gas_limit,
+            gas_price,
+            nonce,
+            config,
+            |executor| executor.transact_call(source, target, value, input, gas_limit),
+        )
+    }
 
-	fn create(
-		source: H160,
-		init: Vec<u8>,
-		value: U256,
-		gas_limit: u64,
-		gas_price: Option<U256>,
-		nonce: Option<U256>,
-		config: &evm::Config,
-	) -> Result<CreateInfo, Self::Error> {
-		Self::execute(
-			source,
-			value,
-			gas_limit,
-			gas_price,
-			nonce,
-			config,
-			|executor| {
-				let address = executor.create_address(
-					evm::CreateScheme::Legacy { caller: source },
-				);
-				(executor.transact_create(
-					source,
-					value,
-					init,
-					gas_limit,
-				), address)
-			},
-		)
-	}
+    fn create(
+        source: H160,
+        init: Vec<u8>,
+        value: U256,
+        gas_limit: u64,
+        gas_price: Option<U256>,
+        nonce: Option<U256>,
+        config: &evm::Config,
+    ) -> Result<CreateInfo, Self::Error> {
+        Self::execute(
+            source,
+            value,
+            gas_limit,
+            gas_price,
+            nonce,
+            config,
+            |executor| {
+                let address = executor.create_address(evm::CreateScheme::Legacy { caller: source });
+                (
+                    executor.transact_create(source, value, init, gas_limit),
+                    address,
+                )
+            },
+        )
+    }
 
-	fn create2(
-		source: H160,
-		init: Vec<u8>,
-		salt: H256,
-		value: U256,
-		gas_limit: u64,
-		gas_price: Option<U256>,
-		nonce: Option<U256>,
-		config: &evm::Config,
-	) -> Result<CreateInfo, Self::Error> {
-		let code_hash = H256::from_slice(Keccak256::digest(&init).as_slice());
-		Self::execute(
-			source,
-			value,
-			gas_limit,
-			gas_price,
-			nonce,
-			config,
-			|executor| {
-				let address = executor.create_address(
-					evm::CreateScheme::Create2 { caller: source, code_hash, salt },
-				);
-				(executor.transact_create2(
-					source,
-					value,
-					init,
-					salt,
-					gas_limit,
-				), address)
-			},
-		)
-	}
+    fn create2(
+        source: H160,
+        init: Vec<u8>,
+        salt: H256,
+        value: U256,
+        gas_limit: u64,
+        gas_price: Option<U256>,
+        nonce: Option<U256>,
+        config: &evm::Config,
+    ) -> Result<CreateInfo, Self::Error> {
+        let code_hash = H256::from_slice(Keccak256::digest(&init).as_slice());
+        Self::execute(
+            source,
+            value,
+            gas_limit,
+            gas_price,
+            nonce,
+            config,
+            |executor| {
+                let address = executor.create_address(evm::CreateScheme::Create2 {
+                    caller: source,
+                    code_hash,
+                    salt,
+                });
+                (
+                    executor.transact_create2(source, value, init, salt, gas_limit),
+                    address,
+                )
+            },
+        )
+    }
 }
 
 struct SubstrateStackSubstate<'config> {
-	metadata: StackSubstateMetadata<'config>,
-	deletes: BTreeSet<H160>,
-	logs: Vec<Log>,
-	parent: Option<Box<SubstrateStackSubstate<'config>>>,
+    metadata: StackSubstateMetadata<'config>,
+    deletes: BTreeSet<H160>,
+    logs: Vec<Log>,
+    parent: Option<Box<SubstrateStackSubstate<'config>>>,
 }
 
 impl<'config> SubstrateStackSubstate<'config> {
-	pub fn metadata(&self) -> &StackSubstateMetadata<'config> {
-		&self.metadata
-	}
+    pub fn metadata(&self) -> &StackSubstateMetadata<'config> {
+        &self.metadata
+    }
 
-	pub fn metadata_mut(&mut self) -> &mut StackSubstateMetadata<'config> {
-		&mut self.metadata
-	}
+    pub fn metadata_mut(&mut self) -> &mut StackSubstateMetadata<'config> {
+        &mut self.metadata
+    }
 
-	pub fn enter(&mut self, gas_limit: u64, is_static: bool) {
-		let mut entering = Self {
-			metadata: self.metadata.spit_child(gas_limit, is_static),
-			parent: None,
-			deletes: BTreeSet::new(),
-			logs: Vec::new(),
-		};
-		mem::swap(&mut entering, self);
+    pub fn enter(&mut self, gas_limit: u64, is_static: bool) {
+        let mut entering = Self {
+            metadata: self.metadata.spit_child(gas_limit, is_static),
+            parent: None,
+            deletes: BTreeSet::new(),
+            logs: Vec::new(),
+        };
+        mem::swap(&mut entering, self);
 
-		self.parent = Some(Box::new(entering));
+        self.parent = Some(Box::new(entering));
 
-		sp_io::storage::start_transaction();
-	}
+        sp_io::storage::start_transaction();
+    }
 
-	pub fn exit_commit(&mut self) -> Result<(), ExitError> {
-		let mut exited = *self.parent.take().expect("Cannot commit on root substate");
-		mem::swap(&mut exited, self);
+    pub fn exit_commit(&mut self) -> Result<(), ExitError> {
+        let mut exited = *self.parent.take().expect("Cannot commit on root substate");
+        mem::swap(&mut exited, self);
 
-		self.metadata.swallow_commit(exited.metadata)?;
-		self.logs.append(&mut exited.logs);
-		self.deletes.append(&mut exited.deletes);
+        self.metadata.swallow_commit(exited.metadata)?;
+        self.logs.append(&mut exited.logs);
+        self.deletes.append(&mut exited.deletes);
 
-		sp_io::storage::commit_transaction();
-		Ok(())
-	}
+        sp_io::storage::commit_transaction();
+        Ok(())
+    }
 
-	pub fn exit_revert(&mut self) -> Result<(), ExitError> {
-		let mut exited = *self.parent.take().expect("Cannot discard on root substate");
-		mem::swap(&mut exited, self);
+    pub fn exit_revert(&mut self) -> Result<(), ExitError> {
+        let mut exited = *self.parent.take().expect("Cannot discard on root substate");
+        mem::swap(&mut exited, self);
 
-		self.metadata.swallow_revert(exited.metadata)?;
-		self.logs.append(&mut exited.logs);
+        self.metadata.swallow_revert(exited.metadata)?;
+        self.logs.append(&mut exited.logs);
 
-		sp_io::storage::rollback_transaction();
-		Ok(())
-	}
+        sp_io::storage::rollback_transaction();
+        Ok(())
+    }
 
-	pub fn exit_discard(&mut self) -> Result<(), ExitError> {
-		let mut exited = *self.parent.take().expect("Cannot discard on root substate");
-		mem::swap(&mut exited, self);
+    pub fn exit_discard(&mut self) -> Result<(), ExitError> {
+        let mut exited = *self.parent.take().expect("Cannot discard on root substate");
+        mem::swap(&mut exited, self);
 
-		self.metadata.swallow_discard(exited.metadata)?;
-		self.logs.append(&mut exited.logs);
+        self.metadata.swallow_discard(exited.metadata)?;
+        self.logs.append(&mut exited.logs);
 
-		sp_io::storage::rollback_transaction();
-		Ok(())
-	}
+        sp_io::storage::rollback_transaction();
+        Ok(())
+    }
 
-	pub fn deleted(&self, address: H160) -> bool {
-		if self.deletes.contains(&address) {
-			return true
-		}
+    pub fn deleted(&self, address: H160) -> bool {
+        if self.deletes.contains(&address) {
+            return true;
+        }
 
-		if let Some(parent) = self.parent.as_ref() {
-			return parent.deleted(address)
-		}
+        if let Some(parent) = self.parent.as_ref() {
+            return parent.deleted(address);
+        }
 
-		false
-	}
+        false
+    }
 
-	pub fn set_deleted(&mut self, address: H160) {
-		self.deletes.insert(address);
-	}
+    pub fn set_deleted(&mut self, address: H160) {
+        self.deletes.insert(address);
+    }
 
-	pub fn log(&mut self, address: H160, topics: Vec<H256>, data: Vec<u8>) {
-		self.logs.push(Log {
-			address, topics, data,
-		});
-	}
+    pub fn log(&mut self, address: H160, topics: Vec<H256>, data: Vec<u8>) {
+        self.logs.push(Log {
+            address,
+            topics,
+            data,
+        });
+    }
 }
 
 /// Substrate backend for EVM.
 pub struct SubstrateStackState<'vicinity, 'config, T> {
-	vicinity: &'vicinity Vicinity,
-	substate: SubstrateStackSubstate<'config>,
-	_marker: PhantomData<T>,
+    vicinity: &'vicinity Vicinity,
+    substate: SubstrateStackSubstate<'config>,
+    _marker: PhantomData<T>,
 }
 
 impl<'vicinity, 'config, T: Config> SubstrateStackState<'vicinity, 'config, T> {
-	/// Create a new backend with given vicinity.
-	pub fn new(vicinity: &'vicinity Vicinity, metadata: StackSubstateMetadata<'config>) -> Self {
-		Self { vicinity, substate: SubstrateStackSubstate {
-			metadata,
-			deletes: BTreeSet::new(),
-			logs: Vec::new(),
-			parent: None,
-		}, _marker: PhantomData }
-	}
+    /// Create a new backend with given vicinity.
+    pub fn new(vicinity: &'vicinity Vicinity, metadata: StackSubstateMetadata<'config>) -> Self {
+        Self {
+            vicinity,
+            substate: SubstrateStackSubstate {
+                metadata,
+                deletes: BTreeSet::new(),
+                logs: Vec::new(),
+                parent: None,
+            },
+            _marker: PhantomData,
+        }
+    }
 }
 
 impl<'vicinity, 'config, T: Config> BackendT for SubstrateStackState<'vicinity, 'config, T> {
-	fn gas_price(&self) -> U256 { self.vicinity.gas_price }
-	fn origin(&self) -> H160 { self.vicinity.origin }
+    fn gas_price(&self) -> U256 {
+        self.vicinity.gas_price
+    }
+    fn origin(&self) -> H160 {
+        self.vicinity.origin
+    }
 
-	fn block_hash(&self, number: U256) -> H256 {
-		if number > U256::from(u32::max_value()) {
-			H256::default()
-		} else {
-			let number = T::BlockNumber::from(number.as_u32());
-			H256::from_slice(frame_system::Module::<T>::block_hash(number).as_ref())
-		}
-	}
+    fn block_hash(&self, number: U256) -> H256 {
+        if number > U256::from(u32::max_value()) {
+            H256::default()
+        } else {
+            let number = T::BlockNumber::from(number.as_u32());
+            H256::from_slice(frame_system::Module::<T>::block_hash(number).as_ref())
+        }
+    }
 
-	fn block_number(&self) -> U256 {
-		let number: u128 = frame_system::Module::<T>::block_number().unique_saturated_into();
-		U256::from(number)
-	}
+    fn block_number(&self) -> U256 {
+        let number: u128 = frame_system::Module::<T>::block_number().unique_saturated_into();
+        U256::from(number)
+    }
 
-	fn block_coinbase(&self) -> H160 {
-		H160::default()
-	}
+    fn block_coinbase(&self) -> H160 {
+        H160::default()
+    }
 
-	fn block_timestamp(&self) -> U256 {
-		let now: u128 = pallet_timestamp::Module::<T>::get().unique_saturated_into();
-		U256::from(now / 1000)
-	}
+    fn block_timestamp(&self) -> U256 {
+        let now: u128 = pallet_timestamp::Module::<T>::get().unique_saturated_into();
+        U256::from(now / 1000)
+    }
 
-	fn block_difficulty(&self) -> U256 {
-		U256::zero()
-	}
+    fn block_difficulty(&self) -> U256 {
+        U256::zero()
+    }
 
-	fn block_gas_limit(&self) -> U256 {
-		U256::zero()
-	}
+    fn block_gas_limit(&self) -> U256 {
+        U256::zero()
+    }
 
-	fn chain_id(&self) -> U256 {
-		U256::from(T::ChainId::get())
-	}
+    fn chain_id(&self) -> U256 {
+        U256::from(T::ChainId::get())
+    }
 
-	fn exists(&self, _address: H160) -> bool {
-		true
-	}
+    fn exists(&self, _address: H160) -> bool {
+        true
+    }
 
-	fn basic(&self, address: H160) -> evm::backend::Basic {
-		let account = Module::<T>::account_basic(&address);
+    fn basic(&self, address: H160) -> evm::backend::Basic {
+        let account = Module::<T>::account_basic(&address);
 
-		evm::backend::Basic {
-			balance: account.balance,
-			nonce: account.nonce,
-		}
-	}
+        evm::backend::Basic {
+            balance: account.balance,
+            nonce: account.nonce,
+        }
+    }
 
-	fn code(&self, address: H160) -> Vec<u8> {
-		AccountCodes::get(&address)
-	}
+    fn code(&self, address: H160) -> Vec<u8> {
+        AccountCodes::get(&address)
+    }
 
-	fn storage(&self, address: H160, index: H256) -> H256 {
-		AccountStorages::get(address, index)
-	}
+    fn storage(&self, address: H160, index: H256) -> H256 {
+        AccountStorages::get(address, index)
+    }
 
-	fn original_storage(&self, _address: H160, _index: H256) -> Option<H256> {
-		None
-	}
+    fn original_storage(&self, _address: H160, _index: H256) -> Option<H256> {
+        None
+    }
 }
 
-impl<'vicinity, 'config, T: Config> StackStateT<'config> for SubstrateStackState<'vicinity, 'config, T> {
-	fn metadata(&self) -> &StackSubstateMetadata<'config> {
-		self.substate.metadata()
-	}
+impl<'vicinity, 'config, T: Config> StackStateT<'config>
+    for SubstrateStackState<'vicinity, 'config, T>
+{
+    fn metadata(&self) -> &StackSubstateMetadata<'config> {
+        self.substate.metadata()
+    }
 
-	fn metadata_mut(&mut self) -> &mut StackSubstateMetadata<'config> {
-		self.substate.metadata_mut()
-	}
+    fn metadata_mut(&mut self) -> &mut StackSubstateMetadata<'config> {
+        self.substate.metadata_mut()
+    }
 
-	fn enter(&mut self, gas_limit: u64, is_static: bool) {
-		self.substate.enter(gas_limit, is_static)
-	}
+    fn enter(&mut self, gas_limit: u64, is_static: bool) {
+        self.substate.enter(gas_limit, is_static)
+    }
 
-	fn exit_commit(&mut self) -> Result<(), ExitError> {
-		self.substate.exit_commit()
-	}
+    fn exit_commit(&mut self) -> Result<(), ExitError> {
+        self.substate.exit_commit()
+    }
 
-	fn exit_revert(&mut self) -> Result<(), ExitError> {
-		self.substate.exit_revert()
-	}
+    fn exit_revert(&mut self) -> Result<(), ExitError> {
+        self.substate.exit_revert()
+    }
 
-	fn exit_discard(&mut self) -> Result<(), ExitError> {
-		self.substate.exit_discard()
-	}
+    fn exit_discard(&mut self) -> Result<(), ExitError> {
+        self.substate.exit_discard()
+    }
 
-	fn is_empty(&self, address: H160) -> bool {
-		Module::<T>::is_account_empty(&address)
-	}
+    fn is_empty(&self, address: H160) -> bool {
+        Module::<T>::is_account_empty(&address)
+    }
 
-	fn deleted(&self, address: H160) -> bool {
-		self.substate.deleted(address)
-	}
+    fn deleted(&self, address: H160) -> bool {
+        self.substate.deleted(address)
+    }
 
-	fn inc_nonce(&mut self, address: H160) {
-		let account_id = T::AddressMapping::into_account_id(address);
-		frame_system::Module::<T>::inc_account_nonce(&account_id);
-	}
+    fn inc_nonce(&mut self, address: H160) {
+        let account_id = T::AddressMapping::into_account_id(address);
+        frame_system::Module::<T>::inc_account_nonce(&account_id);
+    }
 
-	fn set_storage(&mut self, address: H160, index: H256, value: H256) {
-		if value == H256::default() {
-			debug::debug!(
-				target: "evm",
-				"Removing storage for {:?} [index: {:?}]",
-				address,
-				index,
-			);
-			AccountStorages::remove(address, index);
-		} else {
-			debug::debug!(
-				target: "evm",
-				"Updating storage for {:?} [index: {:?}, value: {:?}]",
-				address,
-				index,
-				value,
-			);
-			AccountStorages::insert(address, index, value);
-		}
-	}
+    fn set_storage(&mut self, address: H160, index: H256, value: H256) {
+        if value == H256::default() {
+            debug::debug!(
+                target: "evm",
+                "Removing storage for {:?} [index: {:?}]",
+                address,
+                index,
+            );
+            AccountStorages::remove(address, index);
+        } else {
+            debug::debug!(
+                target: "evm",
+                "Updating storage for {:?} [index: {:?}, value: {:?}]",
+                address,
+                index,
+                value,
+            );
+            AccountStorages::insert(address, index, value);
+        }
+    }
 
-	fn reset_storage(&mut self, address: H160) {
-		AccountStorages::remove_prefix(address);
-	}
+    fn reset_storage(&mut self, address: H160) {
+        AccountStorages::remove_prefix(address);
+    }
 
-	fn log(&mut self, address: H160, topics: Vec<H256>, data: Vec<u8>) {
-		self.substate.log(address, topics, data)
-	}
+    fn log(&mut self, address: H160, topics: Vec<H256>, data: Vec<u8>) {
+        self.substate.log(address, topics, data)
+    }
 
-	fn set_deleted(&mut self, address: H160) {
-		self.substate.set_deleted(address)
-	}
+    fn set_deleted(&mut self, address: H160) {
+        self.substate.set_deleted(address)
+    }
 
-	fn set_code(&mut self, address: H160, code: Vec<u8>) {
-		debug::debug!(
-			target: "evm",
-			"Inserting code ({} bytes) at {:?}",
-			code.len(),
-			address
-		);
-		Module::<T>::create_account(address, code);
-	}
+    fn set_code(&mut self, address: H160, code: Vec<u8>) {
+        debug::debug!(
+            target: "evm",
+            "Inserting code ({} bytes) at {:?}",
+            code.len(),
+            address
+        );
+        Module::<T>::create_account(address, code);
+    }
 
-	fn transfer(&mut self, transfer: Transfer) -> Result<(), ExitError> {
-		let source = T::AddressMapping::into_account_id(transfer.source);
-		let target = T::AddressMapping::into_account_id(transfer.target);
+    fn transfer(&mut self, transfer: Transfer) -> Result<(), ExitError> {
+        let source = T::AddressMapping::into_account_id(transfer.source);
+        let target = T::AddressMapping::into_account_id(transfer.target);
 
-		T::Currency::transfer(
-			&source,
-			&target,
-			transfer.value.low_u128().unique_saturated_into(),
-			ExistenceRequirement::AllowDeath,
-		).map_err(|_| ExitError::OutOfFund)
-	}
+        T::Currency::transfer(
+            &source,
+            &target,
+            transfer.value.low_u128().unique_saturated_into(),
+            ExistenceRequirement::AllowDeath,
+        )
+        .map_err(|_| ExitError::OutOfFund)
+    }
 
-	fn reset_balance(&mut self, _address: H160) {
-		// Do nothing on reset balance in Substrate.
-		//
-		// This function exists in EVM because a design issue
-		// (arguably a bug) in SELFDESTRUCT that can cause total
-		// issurance to be reduced. We do not need to replicate this.
-	}
+    fn reset_balance(&mut self, _address: H160) {
+        // Do nothing on reset balance in Substrate.
+        //
+        // This function exists in EVM because a design issue
+        // (arguably a bug) in SELFDESTRUCT that can cause total
+        // issurance to be reduced. We do not need to replicate this.
+    }
 
-	fn touch(&mut self, _address: H160) {
-		// Do nothing on touch in Substrate.
-		//
-		// EVM pallet considers all accounts to exist, and distinguish
-		// only empty and non-empty accounts. This avoids many of the
-		// subtle issues in EIP-161.
-	}
+    fn touch(&mut self, _address: H160) {
+        // Do nothing on touch in Substrate.
+        //
+        // EVM pallet considers all accounts to exist, and distinguish
+        // only empty and non-empty accounts. This avoids many of the
+        // subtle issues in EIP-161.
+    }
 }

--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -17,515 +17,503 @@
 
 //! EVM stack-based runner.
 
-use crate::runner::Runner as RunnerT;
-use crate::{
-    AccountCodes, AccountStorages, AddressMapping, Config, Error, Event, FeeCalculator, Module,
-    OnChargeEVMTransaction, PrecompileSet,
-};
-use evm::backend::Backend as BackendT;
-use evm::executor::{StackExecutor, StackState as StackStateT, StackSubstateMetadata};
-use evm::{ExitError, ExitReason, Transfer};
-use fp_evm::{CallInfo, CreateInfo, ExecutionInfo, Log, Vicinity};
-use frame_support::{
-    debug, ensure,
-    storage::{StorageDoubleMap, StorageMap},
-    traits::{Currency, ExistenceRequirement, Get},
-};
-use sha3::{Digest, Keccak256};
-use sp_core::{H160, H256, U256};
+use sp_std::{marker::PhantomData, vec::Vec, boxed::Box, mem, collections::btree_set::BTreeSet};
+use sp_core::{U256, H256, H160};
 use sp_runtime::traits::UniqueSaturatedInto;
-use sp_std::{boxed::Box, collections::btree_set::BTreeSet, marker::PhantomData, mem, vec::Vec};
+use frame_support::{
+	debug, ensure, traits::{Get, Currency, ExistenceRequirement},
+	storage::{StorageMap, StorageDoubleMap},
+};
+use sha3::{Keccak256, Digest};
+use fp_evm::{ExecutionInfo, CallInfo, CreateInfo, Log, Vicinity};
+use evm::{ExitReason, ExitError, Transfer};
+use evm::backend::Backend as BackendT;
+use evm::executor::{StackExecutor, StackSubstateMetadata, StackState as StackStateT};
+use crate::{
+	Config, AccountStorages, FeeCalculator, AccountCodes, Module, Event,
+	Error, AddressMapping, PrecompileSet, OnChargeEVMTransaction
+};
+use crate::runner::Runner as RunnerT;
 
 #[derive(Default)]
 pub struct Runner<T: Config> {
-    _marker: PhantomData<T>,
+	_marker: PhantomData<T>,
 }
 
 impl<T: Config> Runner<T> {
-    /// Execute an EVM operation.
-    pub fn execute<'config, F, R>(
-        source: H160,
-        value: U256,
-        gas_limit: u64,
-        gas_price: Option<U256>,
-        nonce: Option<U256>,
-        config: &'config evm::Config,
-        f: F,
-    ) -> Result<ExecutionInfo<R>, Error<T>>
-    where
-        F: FnOnce(
-            &mut StackExecutor<'config, SubstrateStackState<'_, 'config, T>>,
-        ) -> (ExitReason, R),
-    {
-        // Gas price check is skipped when performing a gas estimation.
-        let gas_price = match gas_price {
-            Some(gas_price) => {
-                ensure!(
-                    gas_price >= T::FeeCalculator::min_gas_price(),
-                    Error::<T>::GasPriceTooLow
-                );
-                gas_price
-            }
-            None => Default::default(),
-        };
+	/// Execute an EVM operation.
+	pub fn execute<'config, F, R>(
+		source: H160,
+		value: U256,
+		gas_limit: u64,
+		gas_price: Option<U256>,
+		nonce: Option<U256>,
+		config: &'config evm::Config,
+		f: F,
+	) -> Result<ExecutionInfo<R>, Error<T>> where
+		F: FnOnce(&mut StackExecutor<'config, SubstrateStackState<'_, 'config, T>>) -> (ExitReason, R),
+	{
+		// Gas price check is skipped when performing a gas estimation.
+		let gas_price = match gas_price {
+			Some(gas_price) => {
+				ensure!(gas_price >= T::FeeCalculator::min_gas_price(), Error::<T>::GasPriceTooLow);
+				gas_price
+			},
+			None => Default::default(),
+		};
 
-        let vicinity = Vicinity {
-            gas_price,
-            origin: source,
-        };
+		let vicinity = Vicinity {
+			gas_price,
+			origin: source,
+		};
 
-        let metadata = StackSubstateMetadata::new(gas_limit, &config);
-        let state = SubstrateStackState::new(&vicinity, metadata);
-        let mut executor =
-            StackExecutor::new_with_precompile(state, config, T::Precompiles::execute);
+		let metadata = StackSubstateMetadata::new(gas_limit, &config);
+		let state = SubstrateStackState::new(&vicinity, metadata);
+		let mut executor = StackExecutor::new_with_precompile(
+			state,
+			config,
+			T::Precompiles::execute,
+		);
 
-        let total_fee = gas_price
-            .checked_mul(U256::from(gas_limit))
-            .ok_or(Error::<T>::FeeOverflow)?;
-        let total_payment = value
-            .checked_add(total_fee)
-            .ok_or(Error::<T>::PaymentOverflow)?;
-        let source_account = Module::<T>::account_basic(&source);
-        ensure!(
-            source_account.balance >= total_payment,
-            Error::<T>::BalanceLow
-        );
+		let total_fee = gas_price.checked_mul(U256::from(gas_limit))
+			.ok_or(Error::<T>::FeeOverflow)?;
+		let total_payment = value.checked_add(total_fee).ok_or(Error::<T>::PaymentOverflow)?;
+		let source_account = Module::<T>::account_basic(&source);
+		ensure!(source_account.balance >= total_payment, Error::<T>::BalanceLow);
 
-        if let Some(nonce) = nonce {
-            ensure!(source_account.nonce == nonce, Error::<T>::InvalidNonce);
-        }
+		if let Some(nonce) = nonce {
+			ensure!(source_account.nonce == nonce, Error::<T>::InvalidNonce);
+		}
 
-        // Deduct fee from the `source` account.
-        let fee = T::OnChargeTransaction::withdraw_fee(&source, total_fee)?;
+		// Deduct fee from the `source` account.
+		let fee = T::OnChargeTransaction::withdraw_fee(&source, total_fee)?;
 
-        // Execute the EVM call.
-        let (reason, retv) = f(&mut executor);
+		// Execute the EVM call.
+		let (reason, retv) = f(&mut executor);
 
-        let used_gas = U256::from(executor.used_gas());
-        let actual_fee = executor.fee(gas_price);
-        debug::debug!(
-            target: "evm",
-            "Execution {:?} [source: {:?}, value: {}, gas_limit: {}, actual_fee: {}]",
-            reason,
-            source,
-            value,
-            gas_limit,
-            actual_fee
-        );
+		let used_gas = U256::from(executor.used_gas());
+		let actual_fee = executor.fee(gas_price);
+		debug::debug!(
+			target: "evm",
+			"Execution {:?} [source: {:?}, value: {}, gas_limit: {}, actual_fee: {}]",
+			reason,
+			source,
+			value,
+			gas_limit,
+			actual_fee
+		);
 
-        // Refund fees to the `source` account if deducted more before,
-        T::OnChargeTransaction::correct_and_deposit_fee(&source, actual_fee, fee)?;
+		// Refund fees to the `source` account if deducted more before,
+		T::OnChargeTransaction::correct_and_deposit_fee(&source, actual_fee, fee)?;
 
-        let state = executor.into_state();
+		let state = executor.into_state();
 
-        for address in state.substate.deletes {
-            debug::debug!(
-                target: "evm",
-                "Deleting account at {:?}",
-                address
-            );
-            Module::<T>::remove_account(&address)
-        }
+		for address in state.substate.deletes {
+			debug::debug!(
+				target: "evm",
+				"Deleting account at {:?}",
+				address
+			);
+			Module::<T>::remove_account(&address)
+		}
 
-        for log in &state.substate.logs {
-            debug::trace!(
-                target: "evm",
-                "Inserting log for {:?}, topics ({}) {:?}, data ({}): {:?}]",
-                log.address,
-                log.topics.len(),
-                log.topics,
-                log.data.len(),
-                log.data
-            );
-            Module::<T>::deposit_event(Event::<T>::Log(Log {
-                address: log.address,
-                topics: log.topics.clone(),
-                data: log.data.clone(),
-            }));
-        }
+		for log in &state.substate.logs {
+			debug::trace!(
+				target: "evm",
+				"Inserting log for {:?}, topics ({}) {:?}, data ({}): {:?}]",
+				log.address,
+				log.topics.len(),
+				log.topics,
+				log.data.len(),
+				log.data
+			);
+			Module::<T>::deposit_event(Event::<T>::Log(Log {
+				address: log.address,
+				topics: log.topics.clone(),
+				data: log.data.clone(),
+			}));
+		}
 
-        Ok(ExecutionInfo {
-            value: retv,
-            exit_reason: reason,
-            used_gas,
-            logs: state.substate.logs,
-        })
-    }
+		Ok(ExecutionInfo {
+			value: retv,
+			exit_reason: reason,
+			used_gas,
+			logs: state.substate.logs,
+		})
+	}
 }
 
 impl<T: Config> RunnerT<T> for Runner<T> {
-    type Error = Error<T>;
+	type Error = Error<T>;
 
-    fn call(
-        source: H160,
-        target: H160,
-        input: Vec<u8>,
-        value: U256,
-        gas_limit: u64,
-        gas_price: Option<U256>,
-        nonce: Option<U256>,
-        config: &evm::Config,
-    ) -> Result<CallInfo, Self::Error> {
-        Self::execute(
-            source,
-            value,
-            gas_limit,
-            gas_price,
-            nonce,
-            config,
-            |executor| executor.transact_call(source, target, value, input, gas_limit),
-        )
-    }
+	fn call(
+		source: H160,
+		target: H160,
+		input: Vec<u8>,
+		value: U256,
+		gas_limit: u64,
+		gas_price: Option<U256>,
+		nonce: Option<U256>,
+		config: &evm::Config,
+	) -> Result<CallInfo, Self::Error> {
+		Self::execute(
+			source,
+			value,
+			gas_limit,
+			gas_price,
+			nonce,
+			config,
+			|executor| executor.transact_call(
+				source,
+				target,
+				value,
+				input,
+				gas_limit,
+			),
+		)
+	}
 
-    fn create(
-        source: H160,
-        init: Vec<u8>,
-        value: U256,
-        gas_limit: u64,
-        gas_price: Option<U256>,
-        nonce: Option<U256>,
-        config: &evm::Config,
-    ) -> Result<CreateInfo, Self::Error> {
-        Self::execute(
-            source,
-            value,
-            gas_limit,
-            gas_price,
-            nonce,
-            config,
-            |executor| {
-                let address = executor.create_address(evm::CreateScheme::Legacy { caller: source });
-                (
-                    executor.transact_create(source, value, init, gas_limit),
-                    address,
-                )
-            },
-        )
-    }
+	fn create(
+		source: H160,
+		init: Vec<u8>,
+		value: U256,
+		gas_limit: u64,
+		gas_price: Option<U256>,
+		nonce: Option<U256>,
+		config: &evm::Config,
+	) -> Result<CreateInfo, Self::Error> {
+		Self::execute(
+			source,
+			value,
+			gas_limit,
+			gas_price,
+			nonce,
+			config,
+			|executor| {
+				let address = executor.create_address(
+					evm::CreateScheme::Legacy { caller: source },
+				);
+				(executor.transact_create(
+					source,
+					value,
+					init,
+					gas_limit,
+				), address)
+			},
+		)
+	}
 
-    fn create2(
-        source: H160,
-        init: Vec<u8>,
-        salt: H256,
-        value: U256,
-        gas_limit: u64,
-        gas_price: Option<U256>,
-        nonce: Option<U256>,
-        config: &evm::Config,
-    ) -> Result<CreateInfo, Self::Error> {
-        let code_hash = H256::from_slice(Keccak256::digest(&init).as_slice());
-        Self::execute(
-            source,
-            value,
-            gas_limit,
-            gas_price,
-            nonce,
-            config,
-            |executor| {
-                let address = executor.create_address(evm::CreateScheme::Create2 {
-                    caller: source,
-                    code_hash,
-                    salt,
-                });
-                (
-                    executor.transact_create2(source, value, init, salt, gas_limit),
-                    address,
-                )
-            },
-        )
-    }
+	fn create2(
+		source: H160,
+		init: Vec<u8>,
+		salt: H256,
+		value: U256,
+		gas_limit: u64,
+		gas_price: Option<U256>,
+		nonce: Option<U256>,
+		config: &evm::Config,
+	) -> Result<CreateInfo, Self::Error> {
+		let code_hash = H256::from_slice(Keccak256::digest(&init).as_slice());
+		Self::execute(
+			source,
+			value,
+			gas_limit,
+			gas_price,
+			nonce,
+			config,
+			|executor| {
+				let address = executor.create_address(
+					evm::CreateScheme::Create2 { caller: source, code_hash, salt },
+				);
+				(executor.transact_create2(
+					source,
+					value,
+					init,
+					salt,
+					gas_limit,
+				), address)
+			},
+		)
+	}
 }
 
 struct SubstrateStackSubstate<'config> {
-    metadata: StackSubstateMetadata<'config>,
-    deletes: BTreeSet<H160>,
-    logs: Vec<Log>,
-    parent: Option<Box<SubstrateStackSubstate<'config>>>,
+	metadata: StackSubstateMetadata<'config>,
+	deletes: BTreeSet<H160>,
+	logs: Vec<Log>,
+	parent: Option<Box<SubstrateStackSubstate<'config>>>,
 }
 
 impl<'config> SubstrateStackSubstate<'config> {
-    pub fn metadata(&self) -> &StackSubstateMetadata<'config> {
-        &self.metadata
-    }
+	pub fn metadata(&self) -> &StackSubstateMetadata<'config> {
+		&self.metadata
+	}
 
-    pub fn metadata_mut(&mut self) -> &mut StackSubstateMetadata<'config> {
-        &mut self.metadata
-    }
+	pub fn metadata_mut(&mut self) -> &mut StackSubstateMetadata<'config> {
+		&mut self.metadata
+	}
 
-    pub fn enter(&mut self, gas_limit: u64, is_static: bool) {
-        let mut entering = Self {
-            metadata: self.metadata.spit_child(gas_limit, is_static),
-            parent: None,
-            deletes: BTreeSet::new(),
-            logs: Vec::new(),
-        };
-        mem::swap(&mut entering, self);
+	pub fn enter(&mut self, gas_limit: u64, is_static: bool) {
+		let mut entering = Self {
+			metadata: self.metadata.spit_child(gas_limit, is_static),
+			parent: None,
+			deletes: BTreeSet::new(),
+			logs: Vec::new(),
+		};
+		mem::swap(&mut entering, self);
 
-        self.parent = Some(Box::new(entering));
+		self.parent = Some(Box::new(entering));
 
-        sp_io::storage::start_transaction();
-    }
+		sp_io::storage::start_transaction();
+	}
 
-    pub fn exit_commit(&mut self) -> Result<(), ExitError> {
-        let mut exited = *self.parent.take().expect("Cannot commit on root substate");
-        mem::swap(&mut exited, self);
+	pub fn exit_commit(&mut self) -> Result<(), ExitError> {
+		let mut exited = *self.parent.take().expect("Cannot commit on root substate");
+		mem::swap(&mut exited, self);
 
-        self.metadata.swallow_commit(exited.metadata)?;
-        self.logs.append(&mut exited.logs);
-        self.deletes.append(&mut exited.deletes);
+		self.metadata.swallow_commit(exited.metadata)?;
+		self.logs.append(&mut exited.logs);
+		self.deletes.append(&mut exited.deletes);
 
-        sp_io::storage::commit_transaction();
-        Ok(())
-    }
+		sp_io::storage::commit_transaction();
+		Ok(())
+	}
 
-    pub fn exit_revert(&mut self) -> Result<(), ExitError> {
-        let mut exited = *self.parent.take().expect("Cannot discard on root substate");
-        mem::swap(&mut exited, self);
+	pub fn exit_revert(&mut self) -> Result<(), ExitError> {
+		let mut exited = *self.parent.take().expect("Cannot discard on root substate");
+		mem::swap(&mut exited, self);
 
-        self.metadata.swallow_revert(exited.metadata)?;
-        self.logs.append(&mut exited.logs);
+		self.metadata.swallow_revert(exited.metadata)?;
+		self.logs.append(&mut exited.logs);
 
-        sp_io::storage::rollback_transaction();
-        Ok(())
-    }
+		sp_io::storage::rollback_transaction();
+		Ok(())
+	}
 
-    pub fn exit_discard(&mut self) -> Result<(), ExitError> {
-        let mut exited = *self.parent.take().expect("Cannot discard on root substate");
-        mem::swap(&mut exited, self);
+	pub fn exit_discard(&mut self) -> Result<(), ExitError> {
+		let mut exited = *self.parent.take().expect("Cannot discard on root substate");
+		mem::swap(&mut exited, self);
 
-        self.metadata.swallow_discard(exited.metadata)?;
-        self.logs.append(&mut exited.logs);
+		self.metadata.swallow_discard(exited.metadata)?;
+		self.logs.append(&mut exited.logs);
 
-        sp_io::storage::rollback_transaction();
-        Ok(())
-    }
+		sp_io::storage::rollback_transaction();
+		Ok(())
+	}
 
-    pub fn deleted(&self, address: H160) -> bool {
-        if self.deletes.contains(&address) {
-            return true;
-        }
+	pub fn deleted(&self, address: H160) -> bool {
+		if self.deletes.contains(&address) {
+			return true
+		}
 
-        if let Some(parent) = self.parent.as_ref() {
-            return parent.deleted(address);
-        }
+		if let Some(parent) = self.parent.as_ref() {
+			return parent.deleted(address)
+		}
 
-        false
-    }
+		false
+	}
 
-    pub fn set_deleted(&mut self, address: H160) {
-        self.deletes.insert(address);
-    }
+	pub fn set_deleted(&mut self, address: H160) {
+		self.deletes.insert(address);
+	}
 
-    pub fn log(&mut self, address: H160, topics: Vec<H256>, data: Vec<u8>) {
-        self.logs.push(Log {
-            address,
-            topics,
-            data,
-        });
-    }
+	pub fn log(&mut self, address: H160, topics: Vec<H256>, data: Vec<u8>) {
+		self.logs.push(Log {
+			address, topics, data,
+		});
+	}
 }
 
 /// Substrate backend for EVM.
 pub struct SubstrateStackState<'vicinity, 'config, T> {
-    vicinity: &'vicinity Vicinity,
-    substate: SubstrateStackSubstate<'config>,
-    _marker: PhantomData<T>,
+	vicinity: &'vicinity Vicinity,
+	substate: SubstrateStackSubstate<'config>,
+	_marker: PhantomData<T>,
 }
 
 impl<'vicinity, 'config, T: Config> SubstrateStackState<'vicinity, 'config, T> {
-    /// Create a new backend with given vicinity.
-    pub fn new(vicinity: &'vicinity Vicinity, metadata: StackSubstateMetadata<'config>) -> Self {
-        Self {
-            vicinity,
-            substate: SubstrateStackSubstate {
-                metadata,
-                deletes: BTreeSet::new(),
-                logs: Vec::new(),
-                parent: None,
-            },
-            _marker: PhantomData,
-        }
-    }
+	/// Create a new backend with given vicinity.
+	pub fn new(vicinity: &'vicinity Vicinity, metadata: StackSubstateMetadata<'config>) -> Self {
+		Self { vicinity, substate: SubstrateStackSubstate {
+			metadata,
+			deletes: BTreeSet::new(),
+			logs: Vec::new(),
+			parent: None,
+		}, _marker: PhantomData }
+	}
 }
 
 impl<'vicinity, 'config, T: Config> BackendT for SubstrateStackState<'vicinity, 'config, T> {
-    fn gas_price(&self) -> U256 {
-        self.vicinity.gas_price
-    }
-    fn origin(&self) -> H160 {
-        self.vicinity.origin
-    }
+	fn gas_price(&self) -> U256 { self.vicinity.gas_price }
+	fn origin(&self) -> H160 { self.vicinity.origin }
 
-    fn block_hash(&self, number: U256) -> H256 {
-        if number > U256::from(u32::max_value()) {
-            H256::default()
-        } else {
-            let number = T::BlockNumber::from(number.as_u32());
-            H256::from_slice(frame_system::Module::<T>::block_hash(number).as_ref())
-        }
-    }
+	fn block_hash(&self, number: U256) -> H256 {
+		if number > U256::from(u32::max_value()) {
+			H256::default()
+		} else {
+			let number = T::BlockNumber::from(number.as_u32());
+			H256::from_slice(frame_system::Module::<T>::block_hash(number).as_ref())
+		}
+	}
 
-    fn block_number(&self) -> U256 {
-        let number: u128 = frame_system::Module::<T>::block_number().unique_saturated_into();
-        U256::from(number)
-    }
+	fn block_number(&self) -> U256 {
+		let number: u128 = frame_system::Module::<T>::block_number().unique_saturated_into();
+		U256::from(number)
+	}
 
-    fn block_coinbase(&self) -> H160 {
-        H160::default()
-    }
+	fn block_coinbase(&self) -> H160 {
+		H160::default()
+	}
 
-    fn block_timestamp(&self) -> U256 {
-        let now: u128 = pallet_timestamp::Module::<T>::get().unique_saturated_into();
-        U256::from(now / 1000)
-    }
+	fn block_timestamp(&self) -> U256 {
+		let now: u128 = pallet_timestamp::Module::<T>::get().unique_saturated_into();
+		U256::from(now / 1000)
+	}
 
-    fn block_difficulty(&self) -> U256 {
-        U256::zero()
-    }
+	fn block_difficulty(&self) -> U256 {
+		U256::zero()
+	}
 
-    fn block_gas_limit(&self) -> U256 {
-        U256::zero()
-    }
+	fn block_gas_limit(&self) -> U256 {
+		U256::zero()
+	}
 
-    fn chain_id(&self) -> U256 {
-        U256::from(T::ChainId::get())
-    }
+	fn chain_id(&self) -> U256 {
+		U256::from(T::ChainId::get())
+	}
 
-    fn exists(&self, _address: H160) -> bool {
-        true
-    }
+	fn exists(&self, _address: H160) -> bool {
+		true
+	}
 
-    fn basic(&self, address: H160) -> evm::backend::Basic {
-        let account = Module::<T>::account_basic(&address);
+	fn basic(&self, address: H160) -> evm::backend::Basic {
+		let account = Module::<T>::account_basic(&address);
 
-        evm::backend::Basic {
-            balance: account.balance,
-            nonce: account.nonce,
-        }
-    }
+		evm::backend::Basic {
+			balance: account.balance,
+			nonce: account.nonce,
+		}
+	}
 
-    fn code(&self, address: H160) -> Vec<u8> {
-        AccountCodes::get(&address)
-    }
+	fn code(&self, address: H160) -> Vec<u8> {
+		AccountCodes::get(&address)
+	}
 
-    fn storage(&self, address: H160, index: H256) -> H256 {
-        AccountStorages::get(address, index)
-    }
+	fn storage(&self, address: H160, index: H256) -> H256 {
+		AccountStorages::get(address, index)
+	}
 
-    fn original_storage(&self, _address: H160, _index: H256) -> Option<H256> {
-        None
-    }
+	fn original_storage(&self, _address: H160, _index: H256) -> Option<H256> {
+		None
+	}
 }
 
-impl<'vicinity, 'config, T: Config> StackStateT<'config>
-    for SubstrateStackState<'vicinity, 'config, T>
-{
-    fn metadata(&self) -> &StackSubstateMetadata<'config> {
-        self.substate.metadata()
-    }
+impl<'vicinity, 'config, T: Config> StackStateT<'config> for SubstrateStackState<'vicinity, 'config, T> {
+	fn metadata(&self) -> &StackSubstateMetadata<'config> {
+		self.substate.metadata()
+	}
 
-    fn metadata_mut(&mut self) -> &mut StackSubstateMetadata<'config> {
-        self.substate.metadata_mut()
-    }
+	fn metadata_mut(&mut self) -> &mut StackSubstateMetadata<'config> {
+		self.substate.metadata_mut()
+	}
 
-    fn enter(&mut self, gas_limit: u64, is_static: bool) {
-        self.substate.enter(gas_limit, is_static)
-    }
+	fn enter(&mut self, gas_limit: u64, is_static: bool) {
+		self.substate.enter(gas_limit, is_static)
+	}
 
-    fn exit_commit(&mut self) -> Result<(), ExitError> {
-        self.substate.exit_commit()
-    }
+	fn exit_commit(&mut self) -> Result<(), ExitError> {
+		self.substate.exit_commit()
+	}
 
-    fn exit_revert(&mut self) -> Result<(), ExitError> {
-        self.substate.exit_revert()
-    }
+	fn exit_revert(&mut self) -> Result<(), ExitError> {
+		self.substate.exit_revert()
+	}
 
-    fn exit_discard(&mut self) -> Result<(), ExitError> {
-        self.substate.exit_discard()
-    }
+	fn exit_discard(&mut self) -> Result<(), ExitError> {
+		self.substate.exit_discard()
+	}
 
-    fn is_empty(&self, address: H160) -> bool {
-        Module::<T>::is_account_empty(&address)
-    }
+	fn is_empty(&self, address: H160) -> bool {
+		Module::<T>::is_account_empty(&address)
+	}
 
-    fn deleted(&self, address: H160) -> bool {
-        self.substate.deleted(address)
-    }
+	fn deleted(&self, address: H160) -> bool {
+		self.substate.deleted(address)
+	}
 
-    fn inc_nonce(&mut self, address: H160) {
-        let account_id = T::AddressMapping::into_account_id(address);
-        frame_system::Module::<T>::inc_account_nonce(&account_id);
-    }
+	fn inc_nonce(&mut self, address: H160) {
+		let account_id = T::AddressMapping::into_account_id(address);
+		frame_system::Module::<T>::inc_account_nonce(&account_id);
+	}
 
-    fn set_storage(&mut self, address: H160, index: H256, value: H256) {
-        if value == H256::default() {
-            debug::debug!(
-                target: "evm",
-                "Removing storage for {:?} [index: {:?}]",
-                address,
-                index,
-            );
-            AccountStorages::remove(address, index);
-        } else {
-            debug::debug!(
-                target: "evm",
-                "Updating storage for {:?} [index: {:?}, value: {:?}]",
-                address,
-                index,
-                value,
-            );
-            AccountStorages::insert(address, index, value);
-        }
-    }
+	fn set_storage(&mut self, address: H160, index: H256, value: H256) {
+		if value == H256::default() {
+			debug::debug!(
+				target: "evm",
+				"Removing storage for {:?} [index: {:?}]",
+				address,
+				index,
+			);
+			AccountStorages::remove(address, index);
+		} else {
+			debug::debug!(
+				target: "evm",
+				"Updating storage for {:?} [index: {:?}, value: {:?}]",
+				address,
+				index,
+				value,
+			);
+			AccountStorages::insert(address, index, value);
+		}
+	}
 
-    fn reset_storage(&mut self, address: H160) {
-        AccountStorages::remove_prefix(address);
-    }
+	fn reset_storage(&mut self, address: H160) {
+		AccountStorages::remove_prefix(address);
+	}
 
-    fn log(&mut self, address: H160, topics: Vec<H256>, data: Vec<u8>) {
-        self.substate.log(address, topics, data)
-    }
+	fn log(&mut self, address: H160, topics: Vec<H256>, data: Vec<u8>) {
+		self.substate.log(address, topics, data)
+	}
 
-    fn set_deleted(&mut self, address: H160) {
-        self.substate.set_deleted(address)
-    }
+	fn set_deleted(&mut self, address: H160) {
+		self.substate.set_deleted(address)
+	}
 
-    fn set_code(&mut self, address: H160, code: Vec<u8>) {
-        debug::debug!(
-            target: "evm",
-            "Inserting code ({} bytes) at {:?}",
-            code.len(),
-            address
-        );
-        Module::<T>::create_account(address, code);
-    }
+	fn set_code(&mut self, address: H160, code: Vec<u8>) {
+		debug::debug!(
+			target: "evm",
+			"Inserting code ({} bytes) at {:?}",
+			code.len(),
+			address
+		);
+		Module::<T>::create_account(address, code);
+	}
 
-    fn transfer(&mut self, transfer: Transfer) -> Result<(), ExitError> {
-        let source = T::AddressMapping::into_account_id(transfer.source);
-        let target = T::AddressMapping::into_account_id(transfer.target);
+	fn transfer(&mut self, transfer: Transfer) -> Result<(), ExitError> {
+		let source = T::AddressMapping::into_account_id(transfer.source);
+		let target = T::AddressMapping::into_account_id(transfer.target);
 
-        T::Currency::transfer(
-            &source,
-            &target,
-            transfer.value.low_u128().unique_saturated_into(),
-            ExistenceRequirement::AllowDeath,
-        )
-        .map_err(|_| ExitError::OutOfFund)
-    }
+		T::Currency::transfer(
+			&source,
+			&target,
+			transfer.value.low_u128().unique_saturated_into(),
+			ExistenceRequirement::AllowDeath,
+		).map_err(|_| ExitError::OutOfFund)
+	}
 
-    fn reset_balance(&mut self, _address: H160) {
-        // Do nothing on reset balance in Substrate.
-        //
-        // This function exists in EVM because a design issue
-        // (arguably a bug) in SELFDESTRUCT that can cause total
-        // issurance to be reduced. We do not need to replicate this.
-    }
+	fn reset_balance(&mut self, _address: H160) {
+		// Do nothing on reset balance in Substrate.
+		//
+		// This function exists in EVM because a design issue
+		// (arguably a bug) in SELFDESTRUCT that can cause total
+		// issurance to be reduced. We do not need to replicate this.
+	}
 
-    fn touch(&mut self, _address: H160) {
-        // Do nothing on touch in Substrate.
-        //
-        // EVM pallet considers all accounts to exist, and distinguish
-        // only empty and non-empty accounts. This avoids many of the
-        // subtle issues in EIP-161.
-    }
+	fn touch(&mut self, _address: H160) {
+		// Do nothing on touch in Substrate.
+		//
+		// EVM pallet considers all accounts to exist, and distinguish
+		// only empty and non-empty accounts. This avoids many of the
+		// subtle issues in EIP-161.
+	}
 }

--- a/frame/evm/src/tests.rs
+++ b/frame/evm/src/tests.rs
@@ -19,104 +19,103 @@
 
 use super::*;
 
-use std::{str::FromStr, collections::BTreeMap};
-use frame_support::{
-	assert_ok, impl_outer_origin, parameter_types, impl_outer_dispatch,
-};
+use frame_support::{assert_ok, impl_outer_dispatch, impl_outer_origin, parameter_types};
 use sp_core::{Blake2Hasher, H256};
 use sp_runtime::{
-	testing::Header,
-	traits::{BlakeTwo256, IdentityLookup},
+    testing::Header,
+    traits::{BlakeTwo256, IdentityLookup},
 };
+use std::{collections::BTreeMap, str::FromStr};
 
 impl_outer_origin! {
-	pub enum Origin for Test where system = frame_system {}
+    pub enum Origin for Test where system = frame_system {}
 }
 
 impl_outer_dispatch! {
-	pub enum OuterCall for Test where origin: Origin {
-		self::EVM,
-	}
+    pub enum OuterCall for Test where origin: Origin {
+        self::EVM,
+    }
 }
 
 #[derive(Clone, Eq, PartialEq)]
 pub struct Test;
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
-	pub BlockWeights: frame_system::limits::BlockWeights =
-		frame_system::limits::BlockWeights::simple_max(1024);
+    pub const BlockHashCount: u64 = 250;
+    pub BlockWeights: frame_system::limits::BlockWeights =
+        frame_system::limits::BlockWeights::simple_max(1024);
 }
 impl frame_system::Config for Test {
-	type BaseCallFilter = ();
-	type BlockWeights = ();
-	type BlockLength = ();
-	type DbWeight = ();
-	type Origin = Origin;
-	type Index = u64;
-	type BlockNumber = u64;
-	type Hash = H256;
-	type Call = OuterCall;
-	type Hashing = BlakeTwo256;
-	type AccountId = AccountId32;
-	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
-	type Event = ();
-	type BlockHashCount = BlockHashCount;
-	type Version = ();
-	type PalletInfo = ();
-	type AccountData = pallet_balances::AccountData<u64>;
-	type OnNewAccount = ();
-	type OnKilledAccount = ();
-	type SystemWeightInfo = ();
-	type SS58Prefix = ();
+    type BaseCallFilter = ();
+    type BlockWeights = ();
+    type BlockLength = ();
+    type DbWeight = ();
+    type Origin = Origin;
+    type Index = u64;
+    type BlockNumber = u64;
+    type Hash = H256;
+    type Call = OuterCall;
+    type Hashing = BlakeTwo256;
+    type AccountId = AccountId32;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = ();
+    type BlockHashCount = BlockHashCount;
+    type Version = ();
+    type PalletInfo = ();
+    type AccountData = pallet_balances::AccountData<u64>;
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type SystemWeightInfo = ();
+    type SS58Prefix = ();
 }
 
 parameter_types! {
-	pub const ExistentialDeposit: u64 = 1;
+    pub const ExistentialDeposit: u64 = 1;
 }
 impl pallet_balances::Config for Test {
-	type MaxLocks = ();
-	type Balance = u64;
-	type DustRemoval = ();
-	type Event = ();
-	type ExistentialDeposit = ExistentialDeposit;
-	type AccountStore = System;
-	type WeightInfo = ();
+    type MaxLocks = ();
+    type Balance = u64;
+    type DustRemoval = ();
+    type Event = ();
+    type ExistentialDeposit = ExistentialDeposit;
+    type AccountStore = System;
+    type WeightInfo = ();
 }
 
 parameter_types! {
-	pub const MinimumPeriod: u64 = 1000;
+    pub const MinimumPeriod: u64 = 1000;
 }
 impl pallet_timestamp::Config for Test {
-	type Moment = u64;
-	type OnTimestampSet = ();
-	type MinimumPeriod = MinimumPeriod;
-	type WeightInfo = ();
+    type Moment = u64;
+    type OnTimestampSet = ();
+    type MinimumPeriod = MinimumPeriod;
+    type WeightInfo = ();
 }
 
 /// Fixed gas price of `0`.
 pub struct FixedGasPrice;
 impl FeeCalculator for FixedGasPrice {
-	fn min_gas_price() -> U256 {
-		// Gas price is always one token per gas.
-		0.into()
-	}
+    fn min_gas_price() -> U256 {
+        // Gas price is always one token per gas.
+        0.into()
+    }
 }
 
 impl Config for Test {
-	type FeeCalculator = FixedGasPrice;
-	type GasWeightMapping = ();
+    type FeeCalculator = FixedGasPrice;
+    type GasWeightMapping = ();
 
-	type CallOrigin = EnsureAddressRoot<Self::AccountId>;
-	type WithdrawOrigin = EnsureAddressNever<Self::AccountId>;
+    type CallOrigin = EnsureAddressRoot<Self::AccountId>;
+    type WithdrawOrigin = EnsureAddressNever<Self::AccountId>;
 
-	type AddressMapping = HashedAddressMapping<Blake2Hasher>;
-	type Currency = Balances;
-	type Runner = crate::runner::stack::Runner<Self>;
+    type AddressMapping = HashedAddressMapping<Blake2Hasher>;
+    type Currency = Balances;
+    type Runner = crate::runner::stack::Runner<Self>;
 
-	type Event = Event<Test>;
-	type Precompiles = ();
-	type ChainId = ();
+    type Event = Event<Test>;
+    type Precompiles = ();
+    type ChainId = ();
+    type OnChargeTransaction = ();
 }
 
 type System = frame_system::Module<Test>;
@@ -124,60 +123,87 @@ type Balances = pallet_balances::Module<Test>;
 type EVM = Module<Test>;
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+    let mut t = frame_system::GenesisConfig::default()
+        .build_storage::<Test>()
+        .unwrap();
 
-	let mut accounts = BTreeMap::new();
-	accounts.insert(
-		H160::from_str("1000000000000000000000000000000000000001").unwrap(),
-		GenesisAccount {
-			nonce: U256::from(1),
-			balance: U256::from(1000000),
-			storage: Default::default(),
-			code: vec![
-				0x00, // STOP
-			],
-		}
-	);
-	accounts.insert(
-		H160::from_str("1000000000000000000000000000000000000002").unwrap(),
-		GenesisAccount {
-			nonce: U256::from(1),
-			balance: U256::from(1000000),
-			storage: Default::default(),
-			code: vec![
-				0xff, // INVALID
-			],
-		}
-	);
+    let mut accounts = BTreeMap::new();
+    accounts.insert(
+        H160::from_str("1000000000000000000000000000000000000001").unwrap(),
+        GenesisAccount {
+            nonce: U256::from(1),
+            balance: U256::from(1000000),
+            storage: Default::default(),
+            code: vec![
+                0x00, // STOP
+            ],
+        },
+    );
+    accounts.insert(
+        H160::from_str("1000000000000000000000000000000000000002").unwrap(),
+        GenesisAccount {
+            nonce: U256::from(1),
+            balance: U256::from(1000000),
+            storage: Default::default(),
+            code: vec![
+                0xff, // INVALID
+            ],
+        },
+    );
 
-	pallet_balances::GenesisConfig::<Test>::default().assimilate_storage(&mut t).unwrap();
-	GenesisConfig { accounts }.assimilate_storage::<Test>(&mut t).unwrap();
-	t.into()
+    pallet_balances::GenesisConfig::<Test>::default()
+        .assimilate_storage(&mut t)
+        .unwrap();
+    GenesisConfig { accounts }
+        .assimilate_storage::<Test>(&mut t)
+        .unwrap();
+    t.into()
 }
 
 #[test]
 fn fail_call_return_ok() {
-	new_test_ext().execute_with(|| {
-		assert_ok!(EVM::call(
-			Origin::root(),
-			H160::default(),
-			H160::from_str("1000000000000000000000000000000000000001").unwrap(),
-			Vec::new(),
-			U256::default(),
-			1000000,
-			U256::default(),
-			None,
-		));
+    new_test_ext().execute_with(|| {
+        assert_ok!(EVM::call(
+            Origin::root(),
+            H160::default(),
+            H160::from_str("1000000000000000000000000000000000000001").unwrap(),
+            Vec::new(),
+            U256::default(),
+            1000000,
+            U256::default(),
+            None,
+        ));
 
-		assert_ok!(EVM::call(
-			Origin::root(),
-			H160::default(),
-			H160::from_str("1000000000000000000000000000000000000002").unwrap(),
-			Vec::new(),
-			U256::default(),
-			1000000,
-			U256::default(),
-			None,
-		));
+        assert_ok!(EVM::call(
+            Origin::root(),
+            H160::default(),
+            H160::from_str("1000000000000000000000000000000000000002").unwrap(),
+            Vec::new(),
+            U256::default(),
+            1000000,
+            U256::default(),
+            None,
+        ));
+    });
+}
+
+#[test]
+fn fee_deduction() {
+    new_test_ext().execute_with(|| {
+		// Create an EVM address and the corresponding Substrate address that will be charged fees and refunded
+		let evm_addr = H160::from_str("1000000000000000000000000000000000000003").unwrap();
+		let substrate_addr = <Test as Config>::AddressMapping::into_account_id(evm_addr);
+
+		// Seed account
+		let _ = <Test as Config>::Currency::deposit_creating(&substrate_addr, 100);
+		assert_eq!(Balances::free_balance(&substrate_addr), 100);
+
+		// Deduct fees as 10 units
+		let imbalance = <<Test as Config>::OnChargeTransaction as OnChargeEVMTransaction<Test>>::withdraw_fee(&evm_addr, U256::from(10)).unwrap();
+		assert_eq!(Balances::free_balance(&substrate_addr), 90);
+
+		// Refund fees as 5 units
+		<<Test as Config>::OnChargeTransaction as OnChargeEVMTransaction<Test>>::correct_and_deposit_fee(&evm_addr, U256::from(5), imbalance).unwrap();
+		assert_eq!(Balances::free_balance(&substrate_addr), 95);
 	});
 }

--- a/frame/evm/src/tests.rs
+++ b/frame/evm/src/tests.rs
@@ -19,103 +19,105 @@
 
 use super::*;
 
-use frame_support::{assert_ok, impl_outer_dispatch, impl_outer_origin, parameter_types};
+use std::{str::FromStr, collections::BTreeMap};
+use frame_support::{
+	assert_ok, impl_outer_origin, parameter_types, impl_outer_dispatch,
+};
 use sp_core::{Blake2Hasher, H256};
 use sp_runtime::{
-    testing::Header,
-    traits::{BlakeTwo256, IdentityLookup},
+	testing::Header,
+	traits::{BlakeTwo256, IdentityLookup},
 };
-use std::{collections::BTreeMap, str::FromStr};
 
 impl_outer_origin! {
-    pub enum Origin for Test where system = frame_system {}
+	pub enum Origin for Test where system = frame_system {}
 }
 
 impl_outer_dispatch! {
-    pub enum OuterCall for Test where origin: Origin {
-        self::EVM,
-    }
+	pub enum OuterCall for Test where origin: Origin {
+		self::EVM,
+	}
 }
 
 #[derive(Clone, Eq, PartialEq)]
 pub struct Test;
 parameter_types! {
-    pub const BlockHashCount: u64 = 250;
-    pub BlockWeights: frame_system::limits::BlockWeights =
-        frame_system::limits::BlockWeights::simple_max(1024);
+	pub const BlockHashCount: u64 = 250;
+	pub BlockWeights: frame_system::limits::BlockWeights =
+		frame_system::limits::BlockWeights::simple_max(1024);
 }
 impl frame_system::Config for Test {
-    type BaseCallFilter = ();
-    type BlockWeights = ();
-    type BlockLength = ();
-    type DbWeight = ();
-    type Origin = Origin;
-    type Index = u64;
-    type BlockNumber = u64;
-    type Hash = H256;
-    type Call = OuterCall;
-    type Hashing = BlakeTwo256;
-    type AccountId = AccountId32;
-    type Lookup = IdentityLookup<Self::AccountId>;
-    type Header = Header;
-    type Event = ();
-    type BlockHashCount = BlockHashCount;
-    type Version = ();
-    type PalletInfo = ();
-    type AccountData = pallet_balances::AccountData<u64>;
-    type OnNewAccount = ();
-    type OnKilledAccount = ();
-    type SystemWeightInfo = ();
-    type SS58Prefix = ();
+	type BaseCallFilter = ();
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type Origin = Origin;
+	type Index = u64;
+	type BlockNumber = u64;
+	type Hash = H256;
+	type Call = OuterCall;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId32;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type Event = ();
+	type BlockHashCount = BlockHashCount;
+	type Version = ();
+	type PalletInfo = ();
+	type AccountData = pallet_balances::AccountData<u64>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 
 parameter_types! {
-    pub const ExistentialDeposit: u64 = 1;
+	pub const ExistentialDeposit: u64 = 1;
 }
 impl pallet_balances::Config for Test {
-    type MaxLocks = ();
-    type Balance = u64;
-    type DustRemoval = ();
-    type Event = ();
-    type ExistentialDeposit = ExistentialDeposit;
-    type AccountStore = System;
-    type WeightInfo = ();
+	type MaxLocks = ();
+	type Balance = u64;
+	type DustRemoval = ();
+	type Event = ();
+	type ExistentialDeposit = ExistentialDeposit;
+	type AccountStore = System;
+	type WeightInfo = ();
 }
 
 parameter_types! {
-    pub const MinimumPeriod: u64 = 1000;
+	pub const MinimumPeriod: u64 = 1000;
 }
 impl pallet_timestamp::Config for Test {
-    type Moment = u64;
-    type OnTimestampSet = ();
-    type MinimumPeriod = MinimumPeriod;
-    type WeightInfo = ();
+	type Moment = u64;
+	type OnTimestampSet = ();
+	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
 }
 
 /// Fixed gas price of `0`.
 pub struct FixedGasPrice;
 impl FeeCalculator for FixedGasPrice {
-    fn min_gas_price() -> U256 {
-        // Gas price is always one token per gas.
-        0.into()
-    }
+	fn min_gas_price() -> U256 {
+		// Gas price is always one token per gas.
+		0.into()
+	}
 }
 
 impl Config for Test {
-    type FeeCalculator = FixedGasPrice;
-    type GasWeightMapping = ();
+	type FeeCalculator = FixedGasPrice;
+	type GasWeightMapping = ();
 
-    type CallOrigin = EnsureAddressRoot<Self::AccountId>;
-    type WithdrawOrigin = EnsureAddressNever<Self::AccountId>;
+	type CallOrigin = EnsureAddressRoot<Self::AccountId>;
+	type WithdrawOrigin = EnsureAddressNever<Self::AccountId>;
 
-    type AddressMapping = HashedAddressMapping<Blake2Hasher>;
-    type Currency = Balances;
-    type Runner = crate::runner::stack::Runner<Self>;
+	type AddressMapping = HashedAddressMapping<Blake2Hasher>;
+	type Currency = Balances;
+	type Runner = crate::runner::stack::Runner<Self>;
 
-    type Event = Event<Test>;
-    type Precompiles = ();
-    type ChainId = ();
-    type OnChargeTransaction = ();
+	type Event = Event<Test>;
+	type Precompiles = ();
+	type ChainId = ();
+	type OnChargeTransaction = ();
 }
 
 type System = frame_system::Module<Test>;
@@ -123,73 +125,67 @@ type Balances = pallet_balances::Module<Test>;
 type EVM = Module<Test>;
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
-    let mut t = frame_system::GenesisConfig::default()
-        .build_storage::<Test>()
-        .unwrap();
+	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
 
-    let mut accounts = BTreeMap::new();
-    accounts.insert(
-        H160::from_str("1000000000000000000000000000000000000001").unwrap(),
-        GenesisAccount {
-            nonce: U256::from(1),
-            balance: U256::from(1000000),
-            storage: Default::default(),
-            code: vec![
-                0x00, // STOP
-            ],
-        },
-    );
-    accounts.insert(
-        H160::from_str("1000000000000000000000000000000000000002").unwrap(),
-        GenesisAccount {
-            nonce: U256::from(1),
-            balance: U256::from(1000000),
-            storage: Default::default(),
-            code: vec![
-                0xff, // INVALID
-            ],
-        },
-    );
+	let mut accounts = BTreeMap::new();
+	accounts.insert(
+		H160::from_str("1000000000000000000000000000000000000001").unwrap(),
+		GenesisAccount {
+			nonce: U256::from(1),
+			balance: U256::from(1000000),
+			storage: Default::default(),
+			code: vec![
+				0x00, // STOP
+			],
+		}
+	);
+	accounts.insert(
+		H160::from_str("1000000000000000000000000000000000000002").unwrap(),
+		GenesisAccount {
+			nonce: U256::from(1),
+			balance: U256::from(1000000),
+			storage: Default::default(),
+			code: vec![
+				0xff, // INVALID
+			],
+		}
+	);
 
-    pallet_balances::GenesisConfig::<Test>::default()
-        .assimilate_storage(&mut t)
-        .unwrap();
-    GenesisConfig { accounts }
-        .assimilate_storage::<Test>(&mut t)
-        .unwrap();
-    t.into()
+	pallet_balances::GenesisConfig::<Test>::default().assimilate_storage(&mut t).unwrap();
+	GenesisConfig { accounts }.assimilate_storage::<Test>(&mut t).unwrap();
+	t.into()
 }
 
 #[test]
 fn fail_call_return_ok() {
-    new_test_ext().execute_with(|| {
-        assert_ok!(EVM::call(
-            Origin::root(),
-            H160::default(),
-            H160::from_str("1000000000000000000000000000000000000001").unwrap(),
-            Vec::new(),
-            U256::default(),
-            1000000,
-            U256::default(),
-            None,
-        ));
+	new_test_ext().execute_with(|| {
+		assert_ok!(EVM::call(
+			Origin::root(),
+			H160::default(),
+			H160::from_str("1000000000000000000000000000000000000001").unwrap(),
+			Vec::new(),
+			U256::default(),
+			1000000,
+			U256::default(),
+			None,
+		));
 
-        assert_ok!(EVM::call(
-            Origin::root(),
-            H160::default(),
-            H160::from_str("1000000000000000000000000000000000000002").unwrap(),
-            Vec::new(),
-            U256::default(),
-            1000000,
-            U256::default(),
-            None,
-        ));
-    });
+		assert_ok!(EVM::call(
+			Origin::root(),
+			H160::default(),
+			H160::from_str("1000000000000000000000000000000000000002").unwrap(),
+			Vec::new(),
+			U256::default(),
+			1000000,
+			U256::default(),
+			None,
+		));
+	});
 }
 
 #[test]
 fn fee_deduction() {
-    new_test_ext().execute_with(|| {
+	new_test_ext().execute_with(|| {
 		// Create an EVM address and the corresponding Substrate address that will be charged fees and refunded
 		let evm_addr = H160::from_str("1000000000000000000000000000000000000003").unwrap();
 		let substrate_addr = <Test as Config>::AddressMapping::into_account_id(evm_addr);

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -291,6 +291,7 @@ impl pallet_evm::Config for Runtime {
 		pallet_evm_precompile_simple::Identity,
 	);
 	type ChainId = ChainId;
+	type OnChargeTransaction = ();
 }
 
 pub struct EthereumFindAuthor<F>(PhantomData<F>);


### PR DESCRIPTION
Projects using `pallet_ethereum` need a way to know about fee deducted
by EVM to take appropriate action on the fee like giving it to the
miner. This adds a type `OnChargeTransaction` to pallet's `Config` trait
similar to `OnChargeTransaction` of `pallet_transaction_payment`

Signed-off-by: lovesh <lovesh.bond@gmail.com>