### PR TITLE
Mapping sync worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,6 +1576,7 @@ version = "2.0.0-dev"
 dependencies = [
  "fc-consensus",
  "fc-db",
+ "fc-mapping-sync",
  "fc-rpc",
  "fc-rpc-core",
  "fp-consensus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,6 +1265,7 @@ dependencies = [
  "fc-consensus",
  "fc-db",
  "fp-consensus",
+ "sc-client-api",
  "sp-blockchain",
  "sp-runtime",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,6 +1265,8 @@ dependencies = [
  "fc-consensus",
  "fc-db",
  "fp-consensus",
+ "futures 0.3.12",
+ "futures-timer 3.0.2",
  "sc-client-api",
  "sp-blockchain",
  "sp-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,9 +1265,12 @@ dependencies = [
  "fc-consensus",
  "fc-db",
  "fp-consensus",
+ "fp-rpc",
  "futures 0.3.12",
  "futures-timer 3.0.2",
+ "log",
  "sc-client-api",
+ "sp-api",
  "sp-blockchain",
  "sp-runtime",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,6 +1259,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fc-mapping-sync"
+version = "0.1.0"
+dependencies = [
+ "fc-consensus",
+ "fc-db",
+ "fp-consensus",
+ "sp-blockchain",
+ "sp-runtime",
+]
+
+[[package]]
 name = "fc-rpc"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
 	"client/rpc-core",
 	"client/rpc",
 	"client/db",
+	"client/mapping-sync",
 	"primitives/consensus",
 	"primitives/evm",
 	"primitives/rpc",

--- a/client/consensus/src/lib.rs
+++ b/client/consensus/src/lib.rs
@@ -120,17 +120,9 @@ impl<B, I, C> BlockImport<B> for FrontierBlockImport<B, I, C> where
 
 	fn import_block(
 		&mut self,
-		mut block: BlockImportParams<B, Self::Transaction>,
+		block: BlockImportParams<B, Self::Transaction>,
 		new_cache: HashMap<CacheKeyId, Vec<u8>>,
 	) -> Result<ImportResult, Self::Error> {
-		macro_rules! insert_closure {
-			() => (
-				|insert| block.auxiliary.extend(
-					insert.iter().map(|(k, v)| (k.to_vec(), Some(v.to_vec())))
-				)
-			)
-		}
-
 		let client = self.client.clone();
 
 		if self.enabled {
@@ -172,7 +164,7 @@ impl<B, I, C> BlockImport<B> for FrontierBlockImport<B, I, C> where
 	}
 }
 
-fn find_frontier_log<B: BlockT>(
+pub fn find_frontier_log<B: BlockT>(
 	header: &B::Header,
 ) -> Result<ConsensusLog, Error> {
 	let mut frontier_log: Option<_> = None;

--- a/client/consensus/src/lib.rs
+++ b/client/consensus/src/lib.rs
@@ -139,7 +139,7 @@ impl<B, I, C> BlockImport<B> for FrontierBlockImport<B, I, C> where
 				ethereum_block_hash: post_hashes.block_hash,
 				ethereum_transaction_hashes: post_hashes.transaction_hashes,
 			};
-			let res = self.backend.mapping_db().write_hashes(mapping_commitment);
+			let res = self.backend.mapping().write_hashes(mapping_commitment);
 			if res.is_err() { trace!(target: "frontier-consensus", "{:?}", res); }
 
 			// On importing block 1 we also map the genesis block in the auxiliary.
@@ -154,7 +154,7 @@ impl<B, I, C> BlockImport<B> for FrontierBlockImport<B, I, C> where
 						ethereum_block_hash: block_hash,
 						ethereum_transaction_hashes: Vec::new(),
 					};
-					let res = self.backend.mapping_db().write_hashes(mapping_commitment);
+					let res = self.backend.mapping().write_hashes(mapping_commitment);
 					if res.is_err() { trace!(target: "frontier-consensus", "{:?}", res); }
 				}
 			}

--- a/client/consensus/src/lib.rs
+++ b/client/consensus/src/lib.rs
@@ -25,8 +25,8 @@ use sc_client_api::{BlockOf, backend::AuxStore};
 use sp_blockchain::{HeaderBackend, ProvideCache, well_known_cache_keys::Id as CacheKeyId};
 use sp_block_builder::BlockBuilder as BlockBuilderApi;
 use sp_runtime::generic::OpaqueDigestItemId;
-use sp_runtime::traits::{Block as BlockT, Header as HeaderT, One, Zero};
-use sp_api::{ProvideRuntimeApi, BlockId};
+use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
+use sp_api::ProvideRuntimeApi;
 use sp_consensus::{
 	BlockImportParams, Error as ConsensusError, BlockImport,
 	BlockCheckParams, ImportResult,
@@ -123,41 +123,11 @@ impl<B, I, C> BlockImport<B> for FrontierBlockImport<B, I, C> where
 		block: BlockImportParams<B, Self::Transaction>,
 		new_cache: HashMap<CacheKeyId, Vec<u8>>,
 	) -> Result<ImportResult, Self::Error> {
-		let client = self.client.clone();
-
 		if self.enabled {
-			let log = find_frontier_log::<B>(&block.header)?;
-			let hash = block.post_hash();
-			let post_hashes = match log {
-				ConsensusLog::PostHashes(post_hashes) => post_hashes,
-				ConsensusLog::PreBlock(block) => fp_consensus::PostHashes::from_block(block),
-				ConsensusLog::PostBlock(block) => fp_consensus::PostHashes::from_block(block),
-			};
-
-			let mapping_commitment = fc_db::MappingCommitment {
-				block_hash: hash,
-				ethereum_block_hash: post_hashes.block_hash,
-				ethereum_transaction_hashes: post_hashes.transaction_hashes,
-			};
-			let res = self.backend.mapping().write_hashes(mapping_commitment);
-			if res.is_err() { trace!(target: "frontier-consensus", "{:?}", res); }
-
-			// On importing block 1 we also map the genesis block in the auxiliary.
-			if block.header.number().clone() == One::one() {
-				let id = BlockId::Number(Zero::zero());
-				if let Ok(Some(header)) = client.header(id) {
-					let block = self.client.runtime_api().current_block(&id)
-						.map_err(|_| Error::RuntimeApiCallFailed)?;
-					let block_hash = block.unwrap().header.hash(); // TODO: shouldn't use unwrap
-					let mapping_commitment = fc_db::MappingCommitment::<B> {
-						block_hash: header.hash(),
-						ethereum_block_hash: block_hash,
-						ethereum_transaction_hashes: Vec::new(),
-					};
-					let res = self.backend.mapping().write_hashes(mapping_commitment);
-					if res.is_err() { trace!(target: "frontier-consensus", "{:?}", res); }
-				}
-			}
+			// We validate that there are only one frontier log. No other
+			// actions are needed and mapping syncing is delegated to a separate
+			// worker.
+			let _ = find_frontier_log::<B>(&block.header)?;
 		}
 
 		self.inner.import_block(block, new_cache).map_err(Into::into)

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -65,8 +65,13 @@ pub(crate) mod columns {
 	pub const TRANSACTION_MAPPING: u32 = 2;
 }
 
+pub(crate) mod static_keys {
+	pub const CURRENT_SYNCING_TIPS: &[u8] = b"CURRENT_SYNCING_TIPS";
+}
+
 pub struct Backend<Block: BlockT> {
-	mapping_db: Arc<MappingDb<Block>>,
+	meta: Arc<MetaDb<Block>>,
+	mapping: Arc<MappingDb<Block>>,
 }
 
 impl<Block: BlockT> Backend<Block> {
@@ -74,16 +79,24 @@ impl<Block: BlockT> Backend<Block> {
 		let db = utils::open_database(config)?;
 
 		Ok(Self {
-			mapping_db: Arc::new(MappingDb {
+			mapping: Arc::new(MappingDb {
 				db: db.clone(),
 				write_lock: Arc::new(Mutex::new(())),
 				_marker: PhantomData,
-			})
+			}),
+			meta: Arc::new(MetaDb {
+				db: db.clone(),
+				_marker: PhantomData,
+			}),
 		})
 	}
 
-	pub fn mapping_db(&self) -> &Arc<MappingDb<Block>> {
-		&self.mapping_db
+	pub fn mapping(&self) -> &Arc<MappingDb<Block>> {
+		&self.mapping
+	}
+
+	pub fn meta(&self) -> &Arc<MetaDb<Block>> {
+		&self.meta
 	}
 }
 
@@ -93,7 +106,26 @@ pub struct MetaDb<Block: BlockT> {
 }
 
 impl<Block: BlockT> MetaDb<Block> {
+	pub fn current_syncing_tips(&self) -> Result<Vec<Block::Hash>, String> {
+		match self.db.get(crate::columns::META, &crate::static_keys::CURRENT_SYNCING_TIPS) {
+			Some(raw) => Ok(Vec::<Block::Hash>::decode(&mut &raw[..]).map_err(|e| format!("{:?}", e))?),
+			None => Ok(Vec::new()),
+		}
+	}
 
+	pub fn write_current_syncing_tips(&self, tips: Vec<Block::Hash>) -> Result<(), String> {
+		let mut transaction = sp_database::Transaction::new();
+
+		transaction.set(
+			crate::columns::META,
+			crate::static_keys::CURRENT_SYNCING_TIPS,
+			&tips.encode(),
+		);
+
+		self.db.commit(transaction).map_err(|e| format!("{:?}", e))?;
+
+		Ok(())
+	}
 }
 
 pub struct MappingCommitment<Block: BlockT> {

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -87,6 +87,15 @@ impl<Block: BlockT> Backend<Block> {
 	}
 }
 
+pub struct MetaDb<Block: BlockT> {
+	db: Arc<dyn Database<DbHash>>,
+	_marker: PhantomData<Block>,
+}
+
+impl<Block: BlockT> MetaDb<Block> {
+
+}
+
 pub struct MappingCommitment<Block: BlockT> {
 	pub block_hash: Block::Hash,
 	pub ethereum_block_hash: H256,

--- a/client/mapping-sync/Cargo.toml
+++ b/client/mapping-sync/Cargo.toml
@@ -13,3 +13,5 @@ sc-client-api = { version = "2.0.0", git = "https://github.com/paritytech/substr
 fp-consensus = { path = "../../primitives/consensus" }
 fc-consensus = { path = "../consensus" }
 fc-db = { path = "../db" }
+futures = { version = "0.3.1", features = ["compat"] }
+futures-timer = "3.0.1"

--- a/client/mapping-sync/Cargo.toml
+++ b/client/mapping-sync/Cargo.toml
@@ -9,6 +9,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 [dependencies]
 sp-runtime = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-blockchain = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sc-client-api = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-consensus = { path = "../../primitives/consensus" }
 fc-consensus = { path = "../consensus" }
 fc-db = { path = "../db" }

--- a/client/mapping-sync/Cargo.toml
+++ b/client/mapping-sync/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "fc-mapping-sync"
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
+description = "Mapping sync logic for Frontier."
+license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+
+[dependencies]
+sp-runtime = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-blockchain = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+fp-consensus = { path = "../../primitives/consensus" }
+fc-consensus = { path = "../consensus" }
+fc-db = { path = "../db" }

--- a/client/mapping-sync/Cargo.toml
+++ b/client/mapping-sync/Cargo.toml
@@ -10,8 +10,11 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 sp-runtime = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-blockchain = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sc-client-api = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-api = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-consensus = { path = "../../primitives/consensus" }
 fc-consensus = { path = "../consensus" }
 fc-db = { path = "../db" }
+fp-rpc = { path = "../../primitives/rpc" }
 futures = { version = "0.3.1", features = ["compat"] }
 futures-timer = "3.0.1"
+log = "0.4.8"

--- a/client/mapping-sync/src/lib.rs
+++ b/client/mapping-sync/src/lib.rs
@@ -41,7 +41,7 @@ pub fn sync_block<Block: BlockT, C>(
 		ethereum_block_hash: post_hashes.block_hash,
 		ethereum_transaction_hashes: post_hashes.transaction_hashes,
 	};
-	backend.mapping_db().write_hashes(mapping_commitment)?;
+	backend.mapping().write_hashes(mapping_commitment)?;
 
 	Ok(())
 }

--- a/client/mapping-sync/src/lib.rs
+++ b/client/mapping-sync/src/lib.rs
@@ -21,7 +21,11 @@ mod worker;
 pub use worker::MappingSyncWorker;
 
 use sp_runtime::{generic::BlockId, traits::{Block as BlockT, Header as HeaderT, Zero}};
+use sp_api::ProvideRuntimeApi;
+use sc_client_api::BlockOf;
+use sp_blockchain::HeaderBackend;
 use fp_consensus::ConsensusLog;
+use fp_rpc::EthereumRuntimeRPCApi;
 
 pub fn sync_block<Block: BlockT>(
 	backend: &fc_db::Backend<Block>,
@@ -44,10 +48,36 @@ pub fn sync_block<Block: BlockT>(
 	Ok(())
 }
 
-pub fn sync_one_block<Block: BlockT, B>(
+pub fn sync_genesis_block<Block: BlockT, C>(
+	client: &C,
+	backend: &fc_db::Backend<Block>,
+	header: &Block::Header,
+) -> Result<(), String> where
+	C: ProvideRuntimeApi<Block> + Send + Sync + HeaderBackend<Block> + BlockOf,
+	C::Api: EthereumRuntimeRPCApi<Block>,
+{
+	let id = BlockId::Hash(header.hash());
+
+	let block = client.runtime_api().current_block(&id)
+		.map_err(|e| format!("{:?}", e))?;
+	let block_hash = block.ok_or("Ethereum genesis block not found".to_string())?.header.hash();
+	let mapping_commitment = fc_db::MappingCommitment::<Block> {
+		block_hash: header.hash(),
+		ethereum_block_hash: block_hash,
+		ethereum_transaction_hashes: Vec::new(),
+	};
+	backend.mapping().write_hashes(mapping_commitment)?;
+
+	Ok(())
+}
+
+pub fn sync_one_block<Block: BlockT, C, B>(
+	client: &C,
 	substrate_backend: &B,
 	frontier_backend: &fc_db::Backend<Block>,
 ) -> Result<bool, String> where
+	C: ProvideRuntimeApi<Block> + Send + Sync + HeaderBackend<Block> + BlockOf,
+	C::Api: EthereumRuntimeRPCApi<Block>,
 	B: sp_blockchain::HeaderBackend<Block> + sp_blockchain::Backend<Block>,
 {
 	let mut current_syncing_tips = frontier_backend.meta().current_syncing_tips()?;
@@ -58,7 +88,7 @@ pub fn sync_one_block<Block: BlockT, B>(
 		let header = substrate_backend.header(BlockId::Number(Zero::zero()))
 			.map_err(|e| format!("{:?}", e))?
 			.ok_or("Genesis header not found".to_string())?;
-		sync_block(frontier_backend, &header)?;
+		sync_genesis_block(client, frontier_backend, &header)?;
 
 		current_syncing_tips.push(header.hash());
 		frontier_backend.meta().write_current_syncing_tips(current_syncing_tips)?;
@@ -97,17 +127,20 @@ pub fn sync_one_block<Block: BlockT, B>(
 	}
 }
 
-pub fn sync_blocks<Block: BlockT, B>(
+pub fn sync_blocks<Block: BlockT, C, B>(
+	client: &C,
 	substrate_backend: &B,
 	frontier_backend: &fc_db::Backend<Block>,
 	limit: usize,
 ) -> Result<bool, String> where
+	C: ProvideRuntimeApi<Block> + Send + Sync + HeaderBackend<Block> + BlockOf,
+	C::Api: EthereumRuntimeRPCApi<Block>,
 	B: sp_blockchain::HeaderBackend<Block> + sp_blockchain::Backend<Block>,
 {
 	let mut synced_any = false;
 
 	for _ in 0..limit {
-		synced_any = synced_any || sync_one_block(substrate_backend, frontier_backend)?;
+		synced_any = synced_any || sync_one_block(client, substrate_backend, frontier_backend)?;
 	}
 
 	Ok(synced_any)

--- a/client/mapping-sync/src/lib.rs
+++ b/client/mapping-sync/src/lib.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+// This file is part of Frontier.
+//
+// Copyright (c) 2020 Parity Technologies (UK) Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use sp_runtime::{generic::BlockId, traits::Block as BlockT};
+use sp_blockchain::HeaderBackend;
+use fp_consensus::ConsensusLog;
+
+pub fn sync_block<Block: BlockT, C>(
+	client: &C,
+	backend: &fc_db::Backend<Block>,
+	hash: Block::Hash,
+) -> Result<(), String> where
+	C: HeaderBackend<Block>,
+{
+	let header = client.header(BlockId::Hash(hash)).map_err(|e| format!("{:?}", e))?
+		.ok_or("Header not found".to_string())?;
+	let log = fc_consensus::find_frontier_log::<Block>(&header)?;
+	let post_hashes = match log {
+		ConsensusLog::PostHashes(post_hashes) => post_hashes,
+		ConsensusLog::PreBlock(block) => fp_consensus::PostHashes::from_block(block),
+		ConsensusLog::PostBlock(block) => fp_consensus::PostHashes::from_block(block),
+	};
+
+	let mapping_commitment = fc_db::MappingCommitment {
+		block_hash: hash,
+		ethereum_block_hash: post_hashes.block_hash,
+		ethereum_transaction_hashes: post_hashes.transaction_hashes,
+	};
+	backend.mapping_db().write_hashes(mapping_commitment)?;
+
+	Ok(())
+}

--- a/client/mapping-sync/src/lib.rs
+++ b/client/mapping-sync/src/lib.rs
@@ -92,3 +92,19 @@ pub fn sync_one_block<Block: BlockT, B>(
 		}
 	}
 }
+
+pub fn sync_blocks<Block: BlockT, B>(
+	substrate_backend: &B,
+	frontier_backend: &fc_db::Backend<Block>,
+	limit: usize,
+) -> Result<bool, String> where
+	B: sp_blockchain::HeaderBackend<Block> + sp_blockchain::Backend<Block>,
+{
+	let mut synced_any = false;
+
+	for _ in 0..limit {
+		synced_any = synced_any || sync_one_block(substrate_backend, frontier_backend)?;
+	}
+
+	Ok(synced_any)
+}

--- a/client/mapping-sync/src/lib.rs
+++ b/client/mapping-sync/src/lib.rs
@@ -16,6 +16,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+mod worker;
+
+pub use worker::MappingSyncWorker;
+
 use sp_runtime::{generic::BlockId, traits::{Block as BlockT, Header as HeaderT, Zero}};
 use fp_consensus::ConsensusLog;
 

--- a/client/mapping-sync/src/worker.rs
+++ b/client/mapping-sync/src/worker.rs
@@ -37,6 +37,26 @@ pub struct MappingSyncWorker<Block: BlockT, B> {
 	have_next: bool,
 }
 
+impl<Block: BlockT, B> MappingSyncWorker<Block, B> {
+	pub fn new(
+		import_notifications: ImportNotifications<Block>,
+		timeout: Duration,
+		substrate_backend: Arc<B>,
+		frontier_backend: Arc<fc_db::Backend<Block>>,
+	) -> Self {
+		Self {
+			import_notifications,
+			timeout,
+			inner_delay: None,
+
+			substrate_backend,
+			frontier_backend,
+
+			have_next: true,
+		}
+	}
+}
+
 impl<Block: BlockT, B> Stream for MappingSyncWorker<Block, B> where
 	B: sc_client_api::Backend<Block>,
 {

--- a/client/mapping-sync/src/worker.rs
+++ b/client/mapping-sync/src/worker.rs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+// This file is part of Frontier.
+//
+// Copyright (c) 2020 Parity Technologies (UK) Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::time::Duration;
+use std::pin::Pin;
+use std::sync::Arc;
+use futures::{prelude::*, task::{Context, Poll}};
+use sp_runtime::traits::Block as BlockT;
+use sc_client_api::ImportNotifications;
+use futures_timer::Delay;
+
+const LIMIT: usize = 8;
+
+pub struct MappingSyncWorker<Block: BlockT, B> {
+	import_notifications: ImportNotifications<Block>,
+	timeout: Duration,
+	inner_delay: Option<Delay>,
+
+	substrate_backend: Arc<B>,
+	frontier_backend: Arc<fc_db::Backend<Block>>,
+
+	have_next: bool,
+}
+
+impl<Block: BlockT, B> Stream for MappingSyncWorker<Block, B> where
+	B: sc_client_api::Backend<Block>,
+{
+	type Item = ();
+
+	fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<()>> {
+		let mut fire = false;
+
+		loop {
+			match Stream::poll_next(Pin::new(&mut self.import_notifications), cx) {
+				Poll::Pending => break,
+				Poll::Ready(Some(_)) => {
+					fire = true;
+				},
+				Poll::Ready(None) => return Poll::Ready(None),
+			}
+		}
+
+		let timeout = self.timeout.clone();
+		let inner_delay = self.inner_delay.get_or_insert_with(|| Delay::new(timeout));
+
+		match Future::poll(Pin::new(inner_delay), cx) {
+			Poll::Pending => (),
+			Poll::Ready(()) => {
+				fire = true;
+			},
+		}
+
+		if self.have_next {
+			fire = true;
+		}
+
+		if fire {
+			self.inner_delay = None;
+
+			match crate::sync_blocks(
+				self.substrate_backend.blockchain(),
+				&self.frontier_backend,
+				LIMIT,
+			) {
+				Ok(have_next) => {
+					self.have_next = have_next;
+					Poll::Ready(Some(()))
+				},
+				Err(_) => Poll::Ready(None),
+			}
+		} else {
+			Poll::Pending
+		}
+	}
+}

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -301,7 +301,7 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApi<B, C, P, CT, BE, H> where
 
 	// Asumes there is only one mapped canonical block in the AuxStore, otherwise something is wrong
 	fn load_hash(&self, hash: H256) -> Result<Option<BlockId<B>>> {
-		let hashes = self.backend.mapping_db().block_hashes(&hash)
+		let hashes = self.backend.mapping().block_hashes(&hash)
 			.map_err(|err| internal_err(format!("fetch aux store failed: {:?}", err)))?;
 		let out: Vec<H256> = hashes.into_iter()
 			.filter_map(|h| {
@@ -330,7 +330,7 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApi<B, C, P, CT, BE, H> where
 	}
 
 	fn load_transactions(&self, transaction_hash: H256) -> Result<Option<(H256, u32)>> {
-		let transaction_metadata = self.backend.mapping_db().transaction_metadata(&transaction_hash)
+		let transaction_metadata = self.backend.mapping().transaction_metadata(&transaction_hash)
 			.map_err(|err| internal_err(format!("fetch aux store failed: {:?}", err)))?;
 
 		if transaction_metadata.len() == 1 {

--- a/template/node/Cargo.toml
+++ b/template/node/Cargo.toml
@@ -56,6 +56,7 @@ fc-rpc = { path = "../../client/rpc" }
 fp-rpc = { path = "../../primitives/rpc" }
 fc-rpc-core = { path = "../../client/rpc-core" }
 fc-db = { path = "../../client/db" }
+fc-mapping-sync = { path = "../../client/mapping-sync" }
 
 [build-dependencies]
 substrate-build-script-utils = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -5,6 +5,7 @@ use fc_rpc_core::types::{FilterPool, PendingTransactions};
 use sc_client_api::{ExecutorProvider, RemoteBackend, BlockchainEvents};
 use sc_consensus_manual_seal::{self as manual_seal};
 use fc_consensus::FrontierBlockImport;
+use fc_mapping_sync::MappingSyncWorker;
 use frontier_template_runtime::{self, opaque::Block, RuntimeApi, SLOT_DURATION};
 use sc_service::{error::Error as ServiceError, Configuration, TaskManager, BasePath};
 use sp_inherents::{InherentDataProviders, ProvideInherentData, InherentIdentifier, InherentData};
@@ -15,6 +16,7 @@ use sc_finality_grandpa::SharedVoterState;
 use sp_timestamp::InherentError;
 use sc_telemetry::TelemetrySpan;
 use sc_cli::SubstrateCli;
+use futures::StreamExt;
 use crate::cli::Sealing;
 
 // Our native executor instance.
@@ -226,6 +228,8 @@ pub fn new_full(
 		let network = network.clone();
 		let pending = pending_transactions.clone();
 		let filter_pool = filter_pool.clone();
+		let frontier_backend = frontier_backend.clone();
+
 		Box::new(move |deny_unsafe, _| {
 			let deps = crate::rpc::FullDeps {
 				client: client.clone(),
@@ -246,6 +250,16 @@ pub fn new_full(
 		})
 	};
 
+	task_manager.spawn_essential_handle().spawn(
+		"frontier-mapping-sync-worker",
+		MappingSyncWorker::new(
+			client.import_notification_stream(),
+			Duration::new(6, 0),
+			backend.clone(),
+			frontier_backend.clone(),
+		).for_each(|()| futures::future::ready(()))
+	);
+
 	let (_rpc_handlers, telemetry_connection_notifier) = sc_service::spawn_tasks(sc_service::SpawnTasksParams {
 		network: network.clone(),
 		client: client.clone(),
@@ -260,7 +274,6 @@ pub fn new_full(
 
 	// Spawn Frontier EthFilterApi maintenance task.
 	if filter_pool.is_some() {
-		use futures::StreamExt;
 		// Each filter is allowed to stay in the pool for 100 blocks.
 		const FILTER_RETAIN_THRESHOLD: u64 = 100;
 		task_manager.spawn_essential_handle().spawn(
@@ -282,7 +295,6 @@ pub fn new_full(
 
 	// Spawn Frontier pending transactions maintenance task (as essential, otherwise we leak).
 	if pending_transactions.is_some() {
-		use futures::StreamExt;
 		use fp_consensus::{FRONTIER_ENGINE_ID, ConsensusLog};
 		use sp_runtime::generic::OpaqueDigestItemId;
 

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -255,6 +255,7 @@ pub fn new_full(
 		MappingSyncWorker::new(
 			client.import_notification_stream(),
 			Duration::new(6, 0),
+			client.clone(),
 			backend.clone(),
 			frontier_backend.clone(),
 		).for_each(|()| futures::future::ready(()))


### PR DESCRIPTION
This moves all Ethereum block mapping sync logics away from consensus layer.

* It allows chains to plug in Frontier mid-flight, while not requiring any mandatory node upgrade, as one do not need to modify the consensus layer.
* This separates consensus/runtime logic away from the more complicated RPC logic, which makes consensus/runtime interface (relatively) stable and suitable for audit.