### PR TITLE
Separate PreLog and PostLog

### DIFF
--- a/client/mapping-sync/src/lib.rs
+++ b/client/mapping-sync/src/lib.rs
@@ -24,19 +24,14 @@ use sp_runtime::{generic::BlockId, traits::{Block as BlockT, Header as HeaderT, 
 use sp_api::ProvideRuntimeApi;
 use sc_client_api::BlockOf;
 use sp_blockchain::HeaderBackend;
-use fp_consensus::ConsensusLog;
 use fp_rpc::EthereumRuntimeRPCApi;
 
 pub fn sync_block<Block: BlockT>(
 	backend: &fc_db::Backend<Block>,
 	header: &Block::Header,
 ) -> Result<(), String> {
-	let log = fc_consensus::find_frontier_log::<Block>(&header)?;
-	let post_hashes = match log {
-		ConsensusLog::PostHashes(post_hashes) => post_hashes,
-		ConsensusLog::PreBlock(block) => fp_consensus::PostHashes::from_block(block),
-		ConsensusLog::PostBlock(block) => fp_consensus::PostHashes::from_block(block),
-	};
+	let log = fp_consensus::find_log::<Block>(&header).map_err(|e| format!("{:?}", e))?;
+	let post_hashes = log.into_hashes();
 
 	let mapping_commitment = fc_db::MappingCommitment {
 		block_hash: header.hash(),

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -42,7 +42,7 @@ use fp_evm::CallOrCreateInfo;
 use pallet_evm::{Runner, GasWeightMapping, FeeCalculator};
 use sha3::{Digest, Keccak256};
 use codec::{Encode, Decode};
-use fp_consensus::{FRONTIER_ENGINE_ID, ConsensusLog};
+use fp_consensus::{FRONTIER_ENGINE_ID, PostLog};
 
 pub use fp_rpc::TransactionStatus;
 pub use ethereum::{Transaction, Log, Block, Receipt, TransactionAction, TransactionMessage};
@@ -333,7 +333,7 @@ impl<T: Config> Module<T> {
 
 		let digest = DigestItem::<T::Hash>::Consensus(
 			FRONTIER_ENGINE_ID,
-			ConsensusLog::PostHashes(fp_consensus::PostHashes::from_block(block)).encode(),
+			PostLog::Hashes(fp_consensus::Hashes::from_block(block)).encode(),
 		);
 		frame_system::Module::<T>::deposit_log(digest.into());
 	}

--- a/primitives/consensus/src/lib.rs
+++ b/primitives/consensus/src/lib.rs
@@ -20,30 +20,53 @@
 use codec::{Encode, Decode};
 use sp_std::vec::Vec;
 use sp_core::H256;
-use sp_runtime::ConsensusEngineId;
+use sp_runtime::{
+	ConsensusEngineId, generic::OpaqueDigestItemId,
+	traits::{Block as BlockT, Header as HeaderT},
+};
 use sha3::{Digest, Keccak256};
 
 pub const FRONTIER_ENGINE_ID: ConsensusEngineId = [b'f', b'r', b'o', b'n'];
 
-#[derive(Decode, Encode, Clone, PartialEq, Eq)]
-pub enum ConsensusLog {
-	#[codec(index = "1")]
-	PostHashes(PostHashes),
-	#[codec(index = "2")]
-	PostBlock(ethereum::Block),
-	#[codec(index = "3")]
-	PreBlock(ethereum::Block),
+#[derive(Clone, PartialEq, Eq)]
+pub enum Log {
+	Pre(PreLog),
+	Post(PostLog),
+}
+
+impl Log {
+	pub fn into_hashes(self) -> Hashes {
+		match self {
+			Log::Post(PostLog::Hashes(post_hashes)) => post_hashes,
+			Log::Post(PostLog::Block(block)) => Hashes::from_block(block),
+			Log::Pre(PreLog::Block(block)) => Hashes::from_block(block),
+		}
+	}
 }
 
 #[derive(Decode, Encode, Clone, PartialEq, Eq)]
-pub struct PostHashes {
+pub enum PreLog {
+	#[codec(index = "3")]
+	Block(ethereum::Block),
+}
+
+#[derive(Decode, Encode, Clone, PartialEq, Eq)]
+pub enum PostLog {
+	#[codec(index = "1")]
+	Hashes(Hashes),
+	#[codec(index = "2")]
+	Block(ethereum::Block),
+}
+
+#[derive(Decode, Encode, Clone, PartialEq, Eq)]
+pub struct Hashes {
 	/// Ethereum block hash.
 	pub block_hash: H256,
 	/// Transaction hashes of the Ethereum block.
 	pub transaction_hashes: Vec<H256>,
 }
 
-impl PostHashes {
+impl Hashes {
 	pub fn from_block(block: ethereum::Block) -> Self {
 		let mut transaction_hashes = Vec::new();
 
@@ -56,6 +79,98 @@ impl PostHashes {
 
 		let block_hash = block.header.hash();
 
-		PostHashes { transaction_hashes, block_hash }
+		Hashes { transaction_hashes, block_hash }
+	}
+}
+
+#[derive(Clone, Debug)]
+pub enum FindLogError {
+	NotFound,
+	MultipleLogs,
+}
+
+pub fn find_pre_log<Block: BlockT>(
+	header: &Block::Header,
+) -> Result<PreLog, FindLogError> {
+	let mut found = None;
+
+	for log in header.digest().logs() {
+		let log = log.try_to::<PreLog>(OpaqueDigestItemId::PreRuntime(&FRONTIER_ENGINE_ID));
+		match (log, found.is_some()) {
+			(Some(_), true) => return Err(FindLogError::MultipleLogs),
+			(Some(log), false) => found = Some(log),
+			(None, _) => (),
+		}
+	}
+
+	found.ok_or(FindLogError::NotFound)
+}
+
+pub fn find_post_log<Block: BlockT>(
+	header: &Block::Header,
+) -> Result<PostLog, FindLogError> {
+	let mut found = None;
+
+	for log in header.digest().logs() {
+		let log = log.try_to::<PostLog>(OpaqueDigestItemId::Consensus(&FRONTIER_ENGINE_ID));
+		match (log, found.is_some()) {
+			(Some(_), true) => return Err(FindLogError::MultipleLogs),
+			(Some(log), false) => found = Some(log),
+			(None, _) => (),
+		}
+	}
+
+	found.ok_or(FindLogError::NotFound)
+}
+
+pub fn find_log<Block: BlockT>(
+	header: &Block::Header,
+) -> Result<Log, FindLogError> {
+	let mut found = None;
+
+	for log in header.digest().logs() {
+		let pre_log = log.try_to::<PreLog>(OpaqueDigestItemId::PreRuntime(&FRONTIER_ENGINE_ID));
+		match (pre_log, found.is_some()) {
+			(Some(_), true) => return Err(FindLogError::MultipleLogs),
+			(Some(pre_log), false) => found = Some(Log::Pre(pre_log)),
+			(None, _) => (),
+		}
+
+		let post_log = log.try_to::<PostLog>(OpaqueDigestItemId::Consensus(&FRONTIER_ENGINE_ID));
+		match (post_log, found.is_some()) {
+			(Some(_), true) => return Err(FindLogError::MultipleLogs),
+			(Some(post_log), false) => found = Some(Log::Post(post_log)),
+			(None, _) => (),
+		}
+	}
+
+	found.ok_or(FindLogError::NotFound)
+}
+
+pub fn ensure_log<Block: BlockT>(
+	header: &Block::Header,
+) -> Result<(), FindLogError> {
+	let mut found = false;
+
+	for log in header.digest().logs() {
+		let pre_log = log.try_to::<PreLog>(OpaqueDigestItemId::PreRuntime(&FRONTIER_ENGINE_ID));
+		match (pre_log, found) {
+			(Some(_), true) => return Err(FindLogError::MultipleLogs),
+			(Some(_), false) => found = true,
+			(None, _) => (),
+		}
+
+		let post_log = log.try_to::<PostLog>(OpaqueDigestItemId::Consensus(&FRONTIER_ENGINE_ID));
+		match (post_log, found) {
+			(Some(_), true) => return Err(FindLogError::MultipleLogs),
+			(Some(_), false) => found = true,
+			(None, _) => (),
+		}
+	}
+
+	if found {
+		Ok(())
+	} else {
+		Err(FindLogError::NotFound)
 	}
 }


### PR DESCRIPTION
`PreLog` uses `OpaqueDigestItemId::PreRuntime`, and `PostLog` uses `OpaqueDigestItemId::Consensus`. Therefore they should be separated.