### PR TITLE
Add support for PreLog in pallet-ethereum

### DIFF
--- a/client/consensus/src/lib.rs
+++ b/client/consensus/src/lib.rs
@@ -24,7 +24,7 @@ use fp_rpc::EthereumRuntimeRPCApi;
 use sc_client_api::{BlockOf, backend::AuxStore};
 use sp_blockchain::{HeaderBackend, ProvideCache, well_known_cache_keys::Id as CacheKeyId};
 use sp_block_builder::BlockBuilder as BlockBuilderApi;
-use sp_runtime::traits::Block as BlockT;
+use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
 use sp_api::ProvideRuntimeApi;
 use sp_consensus::{
 	BlockImportParams, Error as ConsensusError, BlockImport,
@@ -129,7 +129,7 @@ impl<B, I, C> BlockImport<B> for FrontierBlockImport<B, I, C> where
 		// We validate that there are only one frontier log. No other
 		// actions are needed and mapping syncing is delegated to a separate
 		// worker.
-		ensure_log::<B>(&block.header).map_err(|e| Error::from(e))?;
+		ensure_log(&block.header.digest()).map_err(|e| Error::from(e))?;
 
 		self.inner.import_block(block, new_cache).map_err(Into::into)
 	}

--- a/client/mapping-sync/src/lib.rs
+++ b/client/mapping-sync/src/lib.rs
@@ -30,7 +30,7 @@ pub fn sync_block<Block: BlockT>(
 	backend: &fc_db::Backend<Block>,
 	header: &Block::Header,
 ) -> Result<(), String> {
-	let log = fp_consensus::find_log::<Block>(&header).map_err(|e| format!("{:?}", e))?;
+	let log = fp_consensus::find_log(header.digest()).map_err(|e| format!("{:?}", e))?;
 	let post_hashes = log.into_hashes();
 
 	let mapping_commitment = fc_db::MappingCommitment {

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -301,7 +301,7 @@ pub fn new_full(
 				if let Ok(locked) = &mut pending_transactions.clone().unwrap().lock() {
 					// As pending transactions have a finite lifespan anyway
 					// we can ignore MultiplePostRuntimeLogs error checks.
-					let log = fp_consensus::find_log::<Block>(&notification.header).ok();
+					let log = fp_consensus::find_log(&notification.header.digest).ok();
 					let post_hashes = log.map(|log| log.into_hashes());
 
 					if let Some(post_hashes) = post_hashes {


### PR DESCRIPTION
This adds support for pallet-ethereum to process an existing Ethereum block, encoded as a `PreLog`. If this is the case, then `transact` function is disabled.