### PR TITLE
Update Substrate to v3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,19 +1156,6 @@ dependencies = [
 
 [[package]]
 name = "ethbloom"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a621dcebea74f2a6f2002d0a885c81ccf6cbdf86760183316a7722b5707ca4"
-dependencies = [
- "crunchy",
- "fixed-hash",
- "impl-codec 0.4.2",
- "impl-rlp",
- "tiny-keccak",
-]
-
-[[package]]
-name = "ethbloom"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "779864b9c7f7ead1f092972c3257496c6a84b46dba2ce131dd8a282cb2cc5972"
@@ -1183,28 +1170,11 @@ dependencies = [
 
 [[package]]
 name = "ethereum"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8603f637f22e3ab9aff8466b37850cd7ea2ae52034b07e41fdc82f1f68dfa2c"
-dependencies = [
- "ethereum-types 0.10.0",
- "hash-db",
- "hash256-std-hasher",
- "parity-scale-codec 1.3.7",
- "rlp",
- "rlp-derive",
- "serde",
- "sha3 0.9.1",
- "triehash",
-]
-
-[[package]]
-name = "ethereum"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567ce064a8232c16e2b2c2173a936b91fbe35c2f2c5278871f5a1a31688b42e9"
 dependencies = [
- "ethereum-types 0.11.0",
+ "ethereum-types",
  "funty",
  "hash-db",
  "hash256-std-hasher",
@@ -1218,25 +1188,11 @@ dependencies = [
 
 [[package]]
 name = "ethereum-types"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05dc5f0df4915fa6dff7f975a8366ecfaaa8959c74235469495153e7bb1b280e"
-dependencies = [
- "ethbloom 0.10.0",
- "fixed-hash",
- "impl-codec 0.4.2",
- "impl-rlp",
- "primitive-types 0.8.0",
- "uint",
-]
-
-[[package]]
-name = "ethereum-types"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64b5df66a228d85e4b17e5d6c6aa43b0310898ffe8a85988c4c032357aaabfd"
 dependencies = [
- "ethbloom 0.11.0",
+ "ethbloom",
  "fixed-hash",
  "impl-codec 0.5.0",
  "impl-rlp",
@@ -1257,7 +1213,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0467250a12bb144ad7b2f41e03e8675e38b971ab73f6d42ede6b78af07657e7b"
 dependencies = [
- "ethereum 0.7.1",
+ "ethereum",
  "evm-core 0.24.0",
  "evm-gasometer 0.24.0",
  "evm-runtime 0.24.0",
@@ -1422,8 +1378,8 @@ dependencies = [
 name = "fc-rpc"
 version = "0.1.0"
 dependencies = [
- "ethereum 0.6.0",
- "ethereum-types 0.11.0",
+ "ethereum",
+ "ethereum-types",
  "fc-consensus",
  "fc-db",
  "fc-rpc-core",
@@ -1458,7 +1414,7 @@ dependencies = [
 name = "fc-rpc-core"
 version = "0.1.0"
 dependencies = [
- "ethereum-types 0.11.0",
+ "ethereum-types",
  "jsonrpc-core 15.1.0",
  "jsonrpc-core-client 14.2.0",
  "jsonrpc-derive 14.2.2",
@@ -1551,7 +1507,7 @@ dependencies = [
 name = "fp-consensus"
 version = "0.1.0"
 dependencies = [
- "ethereum 0.7.1",
+ "ethereum",
  "parity-scale-codec 2.0.1",
  "rlp",
  "sha3 0.8.2",
@@ -1576,8 +1532,8 @@ dependencies = [
 name = "fp-rpc"
 version = "0.1.0"
 dependencies = [
- "ethereum 0.7.1",
- "ethereum-types 0.11.0",
+ "ethereum",
+ "ethereum-types",
  "fp-evm",
  "parity-scale-codec 2.0.1",
  "sp-api",
@@ -3943,8 +3899,8 @@ dependencies = [
 name = "pallet-ethereum"
 version = "0.1.0"
 dependencies = [
- "ethereum 0.7.1",
- "ethereum-types 0.11.0",
+ "ethereum",
+ "ethereum-types",
  "evm",
  "fp-consensus",
  "fp-evm",
@@ -4642,7 +4598,6 @@ checksum = "b3824ae2c5e27160113b9e029a10ec9e3f0237bad8029f69c7724393c9fdefd8"
 dependencies = [
  "fixed-hash",
  "impl-codec 0.4.2",
- "impl-rlp",
  "uint",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,6 +373,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-x"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
+
+[[package]]
 name = "base58"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,7 +433,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41262f11d771fd4a61aa3ce019fca363b4b6c282fca9da2a31186d3965a47a5c"
 dependencies = [
  "either",
- "radium",
+ "radium 0.3.0",
+]
+
+[[package]]
+name = "bitvec"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f682656975d3a682daff957be4ddeb65d6ad656737cd821f2d00685ae466af1"
+dependencies = [
+ "funty",
+ "radium 0.6.2",
+ "tap",
+ "wyz",
 ]
 
 [[package]]
@@ -460,6 +478,32 @@ dependencies = [
  "arrayref",
  "arrayvec 0.5.2",
  "constant_time_eq",
+]
+
+[[package]]
+name = "blake2s_simd"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e461a7034e85b211a4acb57ee2e6730b32912b06c08cc242243c39fc21ae6a2"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.5.2",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "blake3"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9ff35b701f3914bdb8fad3368d822c766ef2858b2583198e41639b936f09d3f"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.5.2",
+ "cc",
+ "cfg-if 0.1.10",
+ "constant_time_eq",
+ "crypto-mac 0.8.0",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -557,6 +601,12 @@ name = "byte-slice-cast"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c1bf4a04a88c54f589125563643d773f3254b5c38571395e2b591c693bbc81"
 
 [[package]]
 name = "byte-tools"
@@ -685,6 +735,17 @@ dependencies = [
  "num-traits",
  "time",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "cid"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff0e3bc0b6446b3f9663c1a6aba6ef06c5aeaa1bc92bd18077be337198ab9768"
+dependencies = [
+ "multibase",
+ "multihash",
+ "unsigned-varint 0.5.1",
 ]
 
 [[package]]
@@ -931,6 +992,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
+name = "data-encoding-macro"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a94feec3d2ba66c0b6621bca8bc6f68415b1e5c69af3586fdd0af9fd9f29b17"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f83e699727abca3c56e187945f303389590305ab2f0185ea445aa66e8d5f2a"
+dependencies = [
+ "data-encoding",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1081,7 +1162,21 @@ checksum = "22a621dcebea74f2a6f2002d0a885c81ccf6cbdf86760183316a7722b5707ca4"
 dependencies = [
  "crunchy",
  "fixed-hash",
- "impl-codec",
+ "impl-codec 0.4.2",
+ "impl-rlp",
+ "impl-serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethbloom"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779864b9c7f7ead1f092972c3257496c6a84b46dba2ce131dd8a282cb2cc5972"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-codec 0.5.0",
  "impl-rlp",
  "impl-serde",
  "tiny-keccak",
@@ -1093,10 +1188,28 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8603f637f22e3ab9aff8466b37850cd7ea2ae52034b07e41fdc82f1f68dfa2c"
 dependencies = [
- "ethereum-types",
+ "ethereum-types 0.10.0",
  "hash-db",
  "hash256-std-hasher",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.7",
+ "rlp",
+ "rlp-derive",
+ "serde",
+ "sha3 0.9.1",
+ "triehash",
+]
+
+[[package]]
+name = "ethereum"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567ce064a8232c16e2b2c2173a936b91fbe35c2f2c5278871f5a1a31688b42e9"
+dependencies = [
+ "ethereum-types 0.11.0",
+ "funty",
+ "hash-db",
+ "hash256-std-hasher",
+ "parity-scale-codec 2.0.1",
  "rlp",
  "rlp-derive",
  "serde",
@@ -1110,12 +1223,27 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05dc5f0df4915fa6dff7f975a8366ecfaaa8959c74235469495153e7bb1b280e"
 dependencies = [
- "ethbloom",
+ "ethbloom 0.10.0",
  "fixed-hash",
- "impl-codec",
+ "impl-codec 0.4.2",
  "impl-rlp",
  "impl-serde",
- "primitive-types",
+ "primitive-types 0.8.0",
+ "uint",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64b5df66a228d85e4b17e5d6c6aa43b0310898ffe8a85988c4c032357aaabfd"
+dependencies = [
+ "ethbloom 0.11.0",
+ "fixed-hash",
+ "impl-codec 0.5.0",
+ "impl-rlp",
+ "impl-serde",
+ "primitive-types 0.9.0",
  "uint",
 ]
 
@@ -1127,17 +1255,17 @@ checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 
 [[package]]
 name = "evm"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b46f945d7548bea2affc1a48168f6d7e832bae914e0d90627a2ea2a7ba63001"
+checksum = "0467250a12bb144ad7b2f41e03e8675e38b971ab73f6d42ede6b78af07657e7b"
 dependencies = [
- "ethereum",
- "evm-core",
- "evm-gasometer",
- "evm-runtime",
+ "ethereum 0.7.1",
+ "evm-core 0.24.0",
+ "evm-gasometer 0.24.0",
+ "evm-runtime 0.24.0",
  "log",
- "parity-scale-codec",
- "primitive-types",
+ "parity-scale-codec 2.0.1",
+ "primitive-types 0.9.0",
  "rlp",
  "serde",
  "sha3 0.8.2",
@@ -1149,8 +1277,20 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc372feb219651f8ae872e6ec0f84b346053c058bd0e8408b1f44a2a796bfecd"
 dependencies = [
- "parity-scale-codec",
- "primitive-types",
+ "parity-scale-codec 1.3.7",
+ "primitive-types 0.8.0",
+ "serde",
+]
+
+[[package]]
+name = "evm-core"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0db0394d7b497bf97be3d9ece9c828f8b7670a065fc9f3106c9598cce6556d"
+dependencies = [
+ "funty",
+ "parity-scale-codec 2.0.1",
+ "primitive-types 0.9.0",
  "serde",
 ]
 
@@ -1160,9 +1300,20 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5737059b7a570b3e28a0126b02e0e36e218cc828b29dddbbae73d0b97fce1e0a"
 dependencies = [
- "evm-core",
- "evm-runtime",
- "primitive-types",
+ "evm-core 0.23.0",
+ "evm-runtime 0.23.0",
+ "primitive-types 0.8.0",
+]
+
+[[package]]
+name = "evm-gasometer"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c617616408f87be6826bda72cee7625aa8cbc09b759f05b1dccd329fb61b2077"
+dependencies = [
+ "evm-core 0.24.0",
+ "evm-runtime 0.24.0",
+ "primitive-types 0.9.0",
 ]
 
 [[package]]
@@ -1171,8 +1322,19 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95726118dbc5f76ed1ee300e685950e58e52a1c4db454a7635aba636c7002186"
 dependencies = [
- "evm-core",
- "primitive-types",
+ "evm-core 0.23.0",
+ "primitive-types 0.8.0",
+ "sha3 0.8.2",
+]
+
+[[package]]
+name = "evm-runtime"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8447504daa86bc5a7ae982b9b5c53225aa0ebcfba636b785cf0f53406eaa4d87"
+dependencies = [
+ "evm-core 0.24.0",
+ "primitive-types 0.9.0",
  "sha3 0.8.2",
 ]
 
@@ -1232,7 +1394,7 @@ dependencies = [
  "fp-rpc",
  "futures 0.3.12",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "sc-client-api",
  "sp-api",
  "sp-block-builder",
@@ -1251,7 +1413,7 @@ version = "0.1.0"
 dependencies = [
  "kvdb",
  "kvdb-rocksdb",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "parking_lot 0.11.1",
  "sp-core",
  "sp-database",
@@ -1262,8 +1424,8 @@ dependencies = [
 name = "fc-rpc"
 version = "0.1.0"
 dependencies = [
- "ethereum",
- "ethereum-types",
+ "ethereum 0.6.0",
+ "ethereum-types 0.10.0",
  "fc-consensus",
  "fc-db",
  "fc-rpc-core",
@@ -1277,7 +1439,7 @@ dependencies = [
  "log",
  "pallet-ethereum",
  "pallet-evm",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "rand 0.7.3",
  "rlp",
  "rustc-hex",
@@ -1298,7 +1460,7 @@ dependencies = [
 name = "fc-rpc-core"
 version = "0.1.0"
 dependencies = [
- "ethereum-types",
+ "ethereum-types 0.10.0",
  "jsonrpc-core 15.1.0",
  "jsonrpc-core-client 14.2.0",
  "jsonrpc-derive 14.2.2",
@@ -1319,17 +1481,17 @@ dependencies = [
 
 [[package]]
 name = "finality-grandpa"
-version = "0.12.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8feb87a63249689640ac9c011742c33139204e3c134293d3054022276869133b"
+checksum = "c6447e2f8178843749e8c8003206def83ec124a7859475395777a28b5338647c"
 dependencies = [
  "either",
  "futures 0.3.12",
- "futures-timer 2.0.2",
+ "futures-timer 3.0.2",
  "log",
  "num-traits",
- "parity-scale-codec",
- "parking_lot 0.9.0",
+ "parity-scale-codec 2.0.1",
+ "parking_lot 0.11.1",
 ]
 
 [[package]]
@@ -1371,10 +1533,10 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fork-tree"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
 ]
 
 [[package]]
@@ -1391,8 +1553,8 @@ dependencies = [
 name = "fp-consensus"
 version = "0.1.0"
 dependencies = [
- "ethereum",
- "parity-scale-codec",
+ "ethereum 0.7.1",
+ "parity-scale-codec 2.0.1",
  "rlp",
  "sha3 0.8.2",
  "sp-core",
@@ -1406,7 +1568,7 @@ version = "0.8.0"
 dependencies = [
  "evm",
  "impl-trait-for-tuples 0.1.3",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "serde",
  "sp-core",
  "sp-std",
@@ -1416,10 +1578,10 @@ dependencies = [
 name = "fp-rpc"
 version = "0.1.0"
 dependencies = [
- "ethereum",
- "ethereum-types",
+ "ethereum 0.7.1",
+ "ethereum-types 0.10.0",
  "fp-evm",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "sp-api",
  "sp-core",
  "sp-io",
@@ -1429,14 +1591,14 @@ dependencies = [
 
 [[package]]
 name = "frame-benchmarking"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-support",
  "frame-system",
  "linregress",
- "parity-scale-codec",
- "paste",
+ "parity-scale-codec 2.0.1",
+ "paste 1.0.4",
  "sp-api",
  "sp-io",
  "sp-runtime",
@@ -1447,12 +1609,12 @@ dependencies = [
 
 [[package]]
 name = "frame-executive"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-support",
  "frame-system",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "serde",
  "sp-core",
  "sp-io",
@@ -1463,10 +1625,10 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata"
-version = "12.0.1"
+version = "13.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "serde",
  "sp-core",
  "sp-std",
@@ -1474,17 +1636,17 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "bitflags",
  "frame-metadata",
  "frame-support-procedural",
- "impl-trait-for-tuples 0.2.0",
+ "impl-trait-for-tuples 0.2.1",
  "log",
  "once_cell",
- "parity-scale-codec",
- "paste",
+ "parity-scale-codec 2.0.1",
+ "paste 1.0.4",
  "serde",
  "smallvec 1.6.1",
  "sp-arithmetic",
@@ -1492,6 +1654,7 @@ dependencies = [
  "sp-inherents",
  "sp-io",
  "sp-runtime",
+ "sp-staking",
  "sp-state-machine",
  "sp-std",
  "sp-tracing",
@@ -1499,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "Inflector",
@@ -1511,7 +1674,7 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural-tools"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-support-procedural-tools-derive",
@@ -1523,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "proc-macro2",
@@ -1533,12 +1696,12 @@ dependencies = [
 
 [[package]]
 name = "frame-system"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-support",
- "impl-trait-for-tuples 0.2.0",
- "parity-scale-codec",
+ "impl-trait-for-tuples 0.2.1",
+ "parity-scale-codec 2.0.1",
  "serde",
  "sp-core",
  "sp-io",
@@ -1549,16 +1712,16 @@ dependencies = [
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "sp-api",
 ]
 
 [[package]]
 name = "frontier-template-node"
-version = "2.0.0-dev"
+version = "3.0.0-dev"
 dependencies = [
  "fc-consensus",
  "fc-db",
@@ -1606,7 +1769,7 @@ dependencies = [
 
 [[package]]
 name = "frontier-template-runtime"
-version = "2.0.0-dev"
+version = "3.0.0-dev"
 dependencies = [
  "fp-rpc",
  "frame-executive",
@@ -1624,7 +1787,7 @@ dependencies = [
  "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "serde",
  "sp-api",
  "sp-block-builder",
@@ -1646,7 +1809,7 @@ name = "frontier-template-test-client"
 version = "0.1.0"
 dependencies = [
  "frontier-template-runtime",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "sc-client-api",
  "sc-consensus",
  "sc-executor",
@@ -1665,6 +1828,16 @@ dependencies = [
  "lazy_static",
  "libc",
  "libloading",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
  "winapi 0.3.9",
 ]
 
@@ -1689,6 +1862,12 @@ name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+
+[[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
@@ -2280,7 +2459,16 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1be51a921b067b0eaca2fad532d9400041561aa922221cc65f95a85641c6bf53"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 1.3.7",
+]
+
+[[package]]
+name = "impl-codec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df170efa359aebdd5cb7fe78edcc67107748e4737bdca8a8fb40d15ea7a877ed"
+dependencies = [
+ "parity-scale-codec 2.0.1",
 ]
 
 [[package]]
@@ -2314,9 +2502,9 @@ dependencies = [
 
 [[package]]
 name = "impl-trait-for-tuples"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f65a8ecf74feeacdab8d38cb129e550ca871cccaa7d1921d8636ecd75534903"
+checksum = "d5dacb10c5b3bb92d46ba347505a9041e676bb20ad220101326bffb0c93031ee"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2627,9 +2815,9 @@ dependencies = [
 
 [[package]]
 name = "kvdb"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92312348daade49976a6dc59263ad39ed54f840aacb5664874f7c9aa16e5f848"
+checksum = "8891bd853eff90e33024195d79d578dc984c82f9e0715fcd2b525a0c19d52811"
 dependencies = [
  "parity-util-mem",
  "smallvec 1.6.1",
@@ -2637,9 +2825,9 @@ dependencies = [
 
 [[package]]
 name = "kvdb-memorydb"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "986052a8d16c692eaebe775391f9a3ac26714f3907132658500b601dec94c8c2"
+checksum = "30a0da8e08caf08d384a620ec19bb6c9b85c84137248e202617fb91881f25912"
 dependencies = [
  "kvdb",
  "parity-util-mem",
@@ -2648,9 +2836,9 @@ dependencies = [
 
 [[package]]
 name = "kvdb-rocksdb"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d92c36be64baba5ea549116ff0d7ffd445456a7be8aaee21ec05882b980cd11"
+checksum = "34446c373ccc494c2124439281c198c7636ccdc2752c06722bbffd56d459c1e4"
 dependencies = [
  "fs-swap",
  "kvdb",
@@ -3246,13 +3434,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
-name = "memmap"
-version = "0.7.0"
+name = "memmap2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+checksum = "04e3e85b970d650e2ae6d70592474087051c11c54da7f7b4949725c5735fbcc6"
 dependencies = [
  "libc",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3266,9 +3453,9 @@ dependencies = [
 
 [[package]]
 name = "memory-db"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cbd2a22f201c03cc1706a727842490abfea17b7b53260358239828208daba3c"
+checksum = "814bbecfc0451fc314eeea34f05bbcd5b98a7ad7af37faee088b86a1e633f1d4"
 dependencies = [
  "hash-db",
  "hashbrown",
@@ -3400,15 +3587,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "multibase"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b78c60039650ff12e140ae867ef5299a58e19dded4d334c849dc7177083667e2"
+dependencies = [
+ "base-x",
+ "data-encoding",
+ "data-encoding-macro",
+]
+
+[[package]]
 name = "multihash"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dac63698b887d2d929306ea48b63760431ff8a24fac40ddb22f9c7f49fb7cab"
 dependencies = [
+ "blake2b_simd",
+ "blake2s_simd",
+ "blake3",
  "digest 0.9.0",
  "generic-array 0.14.4",
  "multihash-derive",
  "sha2 0.9.3",
+ "sha3 0.9.1",
  "unsigned-varint 0.5.1",
 ]
 
@@ -3680,18 +3882,17 @@ dependencies = [
 
 [[package]]
 name = "pallet-aura"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-support",
  "frame-system",
  "pallet-session",
  "pallet-timestamp",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "serde",
  "sp-application-crypto",
  "sp-consensus-aura",
- "sp-inherents",
  "sp-runtime",
  "sp-std",
  "sp-timestamp",
@@ -3699,13 +3900,13 @@ dependencies = [
 
 [[package]]
 name = "pallet-authorship"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-support",
  "frame-system",
- "impl-trait-for-tuples 0.2.0",
- "parity-scale-codec",
+ "impl-trait-for-tuples 0.2.1",
+ "parity-scale-codec 2.0.1",
  "sp-authorship",
  "sp-inherents",
  "sp-runtime",
@@ -3714,13 +3915,13 @@ dependencies = [
 
 [[package]]
 name = "pallet-balances"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "serde",
  "sp-runtime",
  "sp-std",
@@ -3732,7 +3933,7 @@ version = "0.1.0"
 dependencies = [
  "frame-support",
  "frame-system",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "serde",
  "sp-core",
  "sp-inherents",
@@ -3744,8 +3945,8 @@ dependencies = [
 name = "pallet-ethereum"
 version = "0.1.0"
 dependencies = [
- "ethereum",
- "ethereum-types",
+ "ethereum 0.7.1",
+ "ethereum-types 0.10.0",
  "evm",
  "fp-consensus",
  "fp-evm",
@@ -3756,7 +3957,7 @@ dependencies = [
  "pallet-balances",
  "pallet-evm",
  "pallet-timestamp",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "rlp",
  "rustc-hex",
  "serde",
@@ -3769,18 +3970,18 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "evm",
- "evm-gasometer",
- "evm-runtime",
+ "evm-gasometer 0.23.0",
+ "evm-runtime 0.23.0",
  "fp-evm",
  "frame-support",
  "frame-system",
  "pallet-balances",
  "pallet-timestamp",
- "parity-scale-codec",
- "primitive-types",
+ "parity-scale-codec 2.0.1",
+ "primitive-types 0.8.0",
  "rlp",
  "serde",
  "sha3 0.8.2",
@@ -3792,7 +3993,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-precompile-blake2"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "evm",
  "fp-evm",
@@ -3802,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-precompile-bn128"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "evm",
  "fp-evm",
@@ -3813,20 +4014,20 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-precompile-dispatch"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "evm",
  "fp-evm",
  "frame-support",
  "pallet-evm",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "sp-core",
  "sp-io",
 ]
 
 [[package]]
 name = "pallet-evm-precompile-ed25519"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "ed25519-dalek",
  "evm",
@@ -3837,7 +4038,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-precompile-modexp"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "evm",
  "fp-evm",
@@ -3849,7 +4050,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-precompile-simple"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "evm",
  "fp-evm",
@@ -3860,7 +4061,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-grandpa"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-benchmarking",
@@ -3868,7 +4069,7 @@ dependencies = [
  "frame-system",
  "pallet-authorship",
  "pallet-session",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "serde",
  "sp-application-crypto",
  "sp-core",
@@ -3881,12 +4082,12 @@ dependencies = [
 
 [[package]]
 name = "pallet-randomness-collective-flip"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-support",
  "frame-system",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "safe-mix",
  "sp-runtime",
  "sp-std",
@@ -3894,14 +4095,14 @@ dependencies = [
 
 [[package]]
 name = "pallet-session"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-support",
  "frame-system",
- "impl-trait-for-tuples 0.1.3",
+ "impl-trait-for-tuples 0.2.1",
  "pallet-timestamp",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "serde",
  "sp-core",
  "sp-io",
@@ -3914,12 +4115,12 @@ dependencies = [
 
 [[package]]
 name = "pallet-sudo"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-support",
  "frame-system",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "serde",
  "sp-io",
  "sp-runtime",
@@ -3928,14 +4129,14 @@ dependencies = [
 
 [[package]]
 name = "pallet-timestamp"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "impl-trait-for-tuples 0.2.0",
- "parity-scale-codec",
+ "impl-trait-for-tuples 0.2.1",
+ "parity-scale-codec 2.0.1",
  "serde",
  "sp-inherents",
  "sp-runtime",
@@ -3945,12 +4146,12 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-support",
  "frame-system",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "serde",
  "smallvec 1.6.1",
  "sp-core",
@@ -3961,14 +4162,14 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "jsonrpc-core 15.1.0",
  "jsonrpc-core-client 15.1.0",
  "jsonrpc-derive 15.1.0",
  "pallet-transaction-payment-rpc-runtime-api",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "sp-api",
  "sp-blockchain",
  "sp-core",
@@ -3978,27 +4179,30 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "pallet-transaction-payment",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "sp-api",
  "sp-runtime",
 ]
 
 [[package]]
 name = "parity-db"
-version = "0.1.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00d595e372d119261593297debbe4193811a4dc811d2a1ccbb8caaa6666ad7ab"
+checksum = "495197c078e54b8735181aa35c00a327f7f3a3cc00a1ee8c95926dd010f0ec6b"
 dependencies = [
  "blake2-rfc",
  "crc32fast",
+ "fs2",
+ "hex",
  "libc",
  "log",
- "memmap",
- "parking_lot 0.10.2",
+ "memmap2",
+ "parking_lot 0.11.1",
+ "rand 0.8.3",
 ]
 
 [[package]]
@@ -4021,22 +4225,47 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "1.3.6"
+version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79602888a81ace83e3d1d4b2873286c1f5f906c84db667594e8db8da3506c383"
+checksum = "a4b26b16c7687c3075982af47719e481815df30bc544f7a6690763a25ca16e9d"
 dependencies = [
  "arrayvec 0.5.2",
- "bitvec",
- "byte-slice-cast",
- "parity-scale-codec-derive",
+ "bitvec 0.17.4",
+ "byte-slice-cast 0.3.5",
+ "parity-scale-codec-derive 1.2.3",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cd3dab59b5cf4bc81069ade0fc470341a1ef3ad5fa73e5a8943bed2ec12b2e8"
+dependencies = [
+ "arrayvec 0.5.2",
+ "bitvec 0.20.2",
+ "byte-slice-cast 1.0.0",
+ "parity-scale-codec-derive 2.0.1",
  "serde",
 ]
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198db82bb1c18fc00176004462dd809b2a6d851669550aa17af6dacd21ae0c14"
+checksum = "c41512944b1faff334a5f1b9447611bf4ef40638ccb6328173dacefb338e878c"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa04976a81fde04924b40cc4036c4d12841e8bb04325a5cf2ada75731a150a7d"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4071,16 +4300,16 @@ dependencies = [
 
 [[package]]
 name = "parity-util-mem"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f17f15cb05897127bf36a240085a1f0bbef7bce3024849eccf7f93f6171bc27"
+checksum = "664a8c6b8e62d8f9f2f937e391982eb433ab285b4cd9545b342441e04a906e42"
 dependencies = [
  "cfg-if 1.0.0",
  "hashbrown",
- "impl-trait-for-tuples 0.2.0",
+ "impl-trait-for-tuples 0.2.1",
  "parity-util-mem-derive",
  "parking_lot 0.11.1",
- "primitive-types",
+ "primitive-types 0.9.0",
  "smallvec 1.6.1",
  "winapi 0.3.9",
 ]
@@ -4221,6 +4450,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d65c4d95931acda4498f675e332fcbdc9a06705cd07086c510e9b6009cd1c1"
+
+[[package]]
 name = "paste-impl"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4357,9 +4592,9 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "platforms"
-version = "0.2.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb3b2b1033b8a60b4da6ee470325f887758c95d5320f52f9ce0df055a55940e"
+checksum = "989d43012e2ca1c4a02507c67282691a0a3207f9dc67cec596b43fe925b3d325"
 
 [[package]]
 name = "polling"
@@ -4408,7 +4643,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3824ae2c5e27160113b9e029a10ec9e3f0237bad8029f69c7724393c9fdefd8"
 dependencies = [
  "fixed-hash",
- "impl-codec",
+ "impl-codec 0.4.2",
+ "impl-rlp",
+ "impl-serde",
+ "uint",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2415937401cb030a2a0a4d922483f945fa068f52a7dbb22ce0fe5f2b6f6adace"
+dependencies = [
+ "fixed-hash",
+ "impl-codec 0.5.0",
  "impl-rlp",
  "impl-serde",
  "uint",
@@ -4470,11 +4718,11 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d70cf4412832bcac9cffe27906f4a66e450d323525e977168c70d1b36120ae"
+checksum = "c8425533e7122f0c3cc7a37e6244b16ad3a2cc32ae7ac6276e2a75da0d9c200d"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "fnv",
  "lazy_static",
  "parking_lot 0.11.1",
@@ -4564,6 +4812,12 @@ name = "radium"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
+
+[[package]]
+name = "radium"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
@@ -5006,13 +5260,13 @@ dependencies = [
 
 [[package]]
 name = "sc-basic-authorship"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "futures 0.3.12",
  "futures-timer 3.0.2",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "sc-block-builder",
  "sc-client-api",
  "sc-proposer-metrics",
@@ -5029,10 +5283,10 @@ dependencies = [
 
 [[package]]
 name = "sc-block-builder"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "sc-client-api",
  "sp-api",
  "sp-block-builder",
@@ -5046,11 +5300,11 @@ dependencies = [
 
 [[package]]
 name = "sc-chain-spec"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
- "impl-trait-for-tuples 0.2.0",
- "parity-scale-codec",
+ "impl-trait-for-tuples 0.2.1",
+ "parity-scale-codec 2.0.1",
  "sc-chain-spec-derive",
  "sc-consensus-babe",
  "sc-consensus-epochs",
@@ -5067,7 +5321,7 @@ dependencies = [
 
 [[package]]
 name = "sc-chain-spec-derive"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "proc-macro-crate",
@@ -5078,7 +5332,7 @@ dependencies = [
 
 [[package]]
 name = "sc-cli"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "chrono",
@@ -5088,7 +5342,7 @@ dependencies = [
  "libp2p",
  "log",
  "names",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "rand 0.7.3",
  "regex",
  "rpassword",
@@ -5116,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "sc-client-api"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "derive_more",
@@ -5126,7 +5380,7 @@ dependencies = [
  "kvdb",
  "lazy_static",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "parking_lot 0.11.1",
  "sc-executor",
  "sp-api",
@@ -5150,7 +5404,7 @@ dependencies = [
 
 [[package]]
 name = "sc-client-db"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "blake2-rfc",
@@ -5161,7 +5415,7 @@ dependencies = [
  "linked-hash-map",
  "log",
  "parity-db",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "parity-util-mem",
  "parking_lot 0.11.1",
  "sc-client-api",
@@ -5180,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "sc-client-api",
@@ -5191,14 +5445,14 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-aura"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "derive_more",
  "futures 0.3.12",
  "futures-timer 3.0.2",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "parking_lot 0.11.1",
  "sc-block-builder",
  "sc-client-api",
@@ -5210,6 +5464,7 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-aura",
+ "sp-consensus-slots",
  "sp-core",
  "sp-inherents",
  "sp-io",
@@ -5222,7 +5477,7 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-babe"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "derive_more",
@@ -5234,7 +5489,7 @@ dependencies = [
  "num-bigint 0.2.6",
  "num-rational 0.2.4",
  "num-traits",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "parking_lot 0.11.1",
  "pdqselect",
  "rand 0.7.3",
@@ -5253,6 +5508,7 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
+ "sp-consensus-slots",
  "sp-consensus-vrf",
  "sp-core",
  "sp-inherents",
@@ -5267,11 +5523,11 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-epochs"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "fork-tree",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "parking_lot 0.11.1",
  "sc-client-api",
  "sp-blockchain",
@@ -5280,7 +5536,7 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-manual-seal"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "assert_matches",
@@ -5290,7 +5546,7 @@ dependencies = [
  "jsonrpc-core-client 15.1.0",
  "jsonrpc-derive 15.1.0",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "parking_lot 0.11.1",
  "sc-client-api",
  "sc-consensus-babe",
@@ -5301,6 +5557,7 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
+ "sp-consensus-slots",
  "sp-core",
  "sp-inherents",
  "sp-keyring",
@@ -5313,13 +5570,13 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "futures 0.3.12",
  "futures-timer 3.0.2",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "parking_lot 0.11.1",
  "sc-client-api",
  "sc-telemetry",
@@ -5339,7 +5596,7 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-uncles"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "log",
@@ -5353,14 +5610,14 @@ dependencies = [
 
 [[package]]
 name = "sc-executor"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "derive_more",
  "lazy_static",
  "libsecp256k1",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "parity-wasm 0.41.0",
  "parking_lot 0.11.1",
  "sc-executor-common",
@@ -5381,11 +5638,11 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-common"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "derive_more",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "parity-wasm 0.41.0",
  "sp-allocator",
  "sp-core",
@@ -5397,11 +5654,11 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-wasmi"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "sc-executor-common",
  "sp-allocator",
  "sp-core",
@@ -5412,19 +5669,20 @@ dependencies = [
 
 [[package]]
 name = "sc-finality-grandpa"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "derive_more",
+ "dyn-clone",
  "finality-grandpa",
  "fork-tree",
  "futures 0.3.12",
  "futures-timer 3.0.2",
  "linked-hash-map",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "parking_lot 0.11.1",
- "pin-project 0.4.27",
+ "pin-project 1.0.5",
  "rand 0.7.3",
  "sc-block-builder",
  "sc-client-api",
@@ -5450,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "sc-informant"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "ansi_term 0.12.1",
@@ -5468,7 +5726,7 @@ dependencies = [
 
 [[package]]
 name = "sc-keystore"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "async-trait",
@@ -5488,12 +5746,12 @@ dependencies = [
 
 [[package]]
 name = "sc-light"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "hash-db",
  "lazy_static",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "parking_lot 0.11.1",
  "sc-client-api",
  "sc-executor",
@@ -5507,7 +5765,7 @@ dependencies = [
 
 [[package]]
 name = "sc-network"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "async-std",
@@ -5516,6 +5774,7 @@ dependencies = [
  "bitflags",
  "bs58",
  "bytes 1.0.1",
+ "cid",
  "derive_more",
  "either",
  "erased-serde",
@@ -5531,9 +5790,9 @@ dependencies = [
  "log",
  "lru",
  "nohash-hasher",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "parking_lot 0.11.1",
- "pin-project 0.4.27",
+ "pin-project 1.0.5",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -5559,7 +5818,7 @@ dependencies = [
 
 [[package]]
 name = "sc-network-gossip"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "futures 0.3.12",
@@ -5575,7 +5834,7 @@ dependencies = [
 
 [[package]]
 name = "sc-offchain"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "bytes 0.5.6",
@@ -5586,7 +5845,7 @@ dependencies = [
  "hyper-rustls",
  "log",
  "num_cpus",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "parking_lot 0.11.1",
  "rand 0.7.3",
  "sc-client-api",
@@ -5602,7 +5861,7 @@ dependencies = [
 
 [[package]]
 name = "sc-peerset"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "futures 0.3.12",
@@ -5615,7 +5874,7 @@ dependencies = [
 
 [[package]]
 name = "sc-proposer-metrics"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "log",
@@ -5624,7 +5883,7 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "futures 0.3.12",
@@ -5632,7 +5891,7 @@ dependencies = [
  "jsonrpc-core 15.1.0",
  "jsonrpc-pubsub 15.1.0",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "parking_lot 0.11.1",
  "sc-block-builder",
  "sc-client-api",
@@ -5658,7 +5917,7 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "derive_more",
@@ -5668,7 +5927,7 @@ dependencies = [
  "jsonrpc-derive 15.1.0",
  "jsonrpc-pubsub 15.1.0",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "parking_lot 0.11.1",
  "serde",
  "serde_json",
@@ -5682,7 +5941,7 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-server"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "futures 0.1.30",
@@ -5700,7 +5959,7 @@ dependencies = [
 
 [[package]]
 name = "sc-service"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "directories",
@@ -5713,10 +5972,10 @@ dependencies = [
  "jsonrpc-pubsub 15.1.0",
  "lazy_static",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "parity-util-mem",
  "parking_lot 0.11.1",
- "pin-project 0.4.27",
+ "pin-project 1.0.5",
  "rand 0.7.3",
  "sc-block-builder",
  "sc-chain-spec",
@@ -5763,11 +6022,11 @@ dependencies = [
 
 [[package]]
 name = "sc-state-db"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "parity-util-mem",
  "parity-util-mem-derive",
  "parking_lot 0.11.1",
@@ -5778,7 +6037,7 @@ dependencies = [
 
 [[package]]
 name = "sc-telemetry"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "chrono",
@@ -5786,7 +6045,7 @@ dependencies = [
  "libp2p",
  "log",
  "parking_lot 0.11.1",
- "pin-project 0.4.27",
+ "pin-project 1.0.5",
  "rand 0.7.3",
  "serde",
  "serde_json",
@@ -5800,7 +6059,7 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "ansi_term 0.12.1",
@@ -5828,7 +6087,7 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing-proc-macro"
-version = "2.0.0"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "proc-macro-crate",
@@ -5839,7 +6098,7 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-graph"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "derive_more",
@@ -5861,14 +6120,14 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "futures 0.3.12",
  "futures-diagnose",
  "intervalier",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "parity-util-mem",
  "parking_lot 0.11.1",
  "sc-client-api",
@@ -6160,7 +6419,7 @@ dependencies = [
  "approx",
  "num-complex 0.2.4",
  "num-traits",
- "paste",
+ "paste 0.1.18",
 ]
 
 [[package]]
@@ -6231,7 +6490,7 @@ dependencies = [
 
 [[package]]
 name = "sp-allocator"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "log",
@@ -6243,11 +6502,11 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "hash-db",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "sp-api-proc-macro",
  "sp-core",
  "sp-runtime",
@@ -6259,7 +6518,7 @@ dependencies = [
 
 [[package]]
 name = "sp-api-proc-macro"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "blake2-rfc",
@@ -6271,10 +6530,10 @@ dependencies = [
 
 [[package]]
 name = "sp-application-crypto"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "serde",
  "sp-core",
  "sp-io",
@@ -6283,12 +6542,12 @@ dependencies = [
 
 [[package]]
 name = "sp-arithmetic"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "integer-sqrt",
  "num-traits",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "serde",
  "sp-debug-derive",
  "sp-std",
@@ -6296,10 +6555,10 @@ dependencies = [
 
 [[package]]
 name = "sp-authorship"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "sp-inherents",
  "sp-runtime",
  "sp-std",
@@ -6307,10 +6566,10 @@ dependencies = [
 
 [[package]]
 name = "sp-block-builder"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "sp-api",
  "sp-inherents",
  "sp-runtime",
@@ -6319,13 +6578,13 @@ dependencies = [
 
 [[package]]
 name = "sp-blockchain"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "futures 0.3.12",
  "log",
  "lru",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "parking_lot 0.11.1",
  "sp-api",
  "sp-consensus",
@@ -6337,7 +6596,7 @@ dependencies = [
 
 [[package]]
 name = "sp-chain-spec"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "serde",
@@ -6346,14 +6605,14 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "futures 0.3.12",
  "futures-timer 3.0.2",
  "libp2p",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "parking_lot 0.11.1",
  "serde",
  "sp-api",
@@ -6372,12 +6631,13 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-aura"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "sp-api",
  "sp-application-crypto",
+ "sp-consensus-slots",
  "sp-inherents",
  "sp-runtime",
  "sp-std",
@@ -6386,11 +6646,11 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-babe"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "merlin",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "sp-api",
  "sp-application-crypto",
  "sp-consensus",
@@ -6406,19 +6666,20 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-slots"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
+ "sp-arithmetic",
  "sp-runtime",
 ]
 
 [[package]]
 name = "sp-consensus-vrf"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "schnorrkel",
  "sp-core",
  "sp-runtime",
@@ -6427,7 +6688,7 @@ dependencies = [
 
 [[package]]
 name = "sp-core"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "base58",
@@ -6445,10 +6706,10 @@ dependencies = [
  "log",
  "merlin",
  "num-traits",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "parity-util-mem",
  "parking_lot 0.11.1",
- "primitive-types",
+ "primitive-types 0.9.0",
  "rand 0.7.3",
  "regex",
  "schnorrkel",
@@ -6471,7 +6732,7 @@ dependencies = [
 
 [[package]]
 name = "sp-database"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "kvdb",
@@ -6480,7 +6741,7 @@ dependencies = [
 
 [[package]]
 name = "sp-debug-derive"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "proc-macro2",
@@ -6490,23 +6751,23 @@ dependencies = [
 
 [[package]]
 name = "sp-externalities"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "environmental",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "sp-std",
  "sp-storage",
 ]
 
 [[package]]
 name = "sp-finality-grandpa"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "finality-grandpa",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "serde",
  "sp-api",
  "sp-application-crypto",
@@ -6518,10 +6779,10 @@ dependencies = [
 
 [[package]]
 name = "sp-inherents"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "parking_lot 0.11.1",
  "sp-core",
  "sp-std",
@@ -6530,14 +6791,14 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "futures 0.3.12",
  "hash-db",
  "libsecp256k1",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "parking_lot 0.11.1",
  "sp-core",
  "sp-externalities",
@@ -6554,7 +6815,7 @@ dependencies = [
 
 [[package]]
 name = "sp-keyring"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "lazy_static",
@@ -6565,14 +6826,14 @@ dependencies = [
 
 [[package]]
 name = "sp-keystore"
-version = "0.8.0"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "async-trait",
  "derive_more",
  "futures 0.3.12",
  "merlin",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "parking_lot 0.11.1",
  "schnorrkel",
  "serde",
@@ -6582,7 +6843,7 @@ dependencies = [
 
 [[package]]
 name = "sp-offchain"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "sp-api",
@@ -6592,7 +6853,7 @@ dependencies = [
 
 [[package]]
 name = "sp-panic-handler"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "backtrace",
@@ -6600,7 +6861,7 @@ dependencies = [
 
 [[package]]
 name = "sp-rpc"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "serde",
@@ -6609,16 +6870,16 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "either",
  "hash256-std-hasher",
- "impl-trait-for-tuples 0.2.0",
+ "impl-trait-for-tuples 0.2.1",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "parity-util-mem",
- "paste",
+ "paste 1.0.4",
  "rand 0.7.3",
  "serde",
  "sp-application-crypto",
@@ -6630,12 +6891,12 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
- "impl-trait-for-tuples 0.2.0",
- "parity-scale-codec",
- "primitive-types",
+ "impl-trait-for-tuples 0.2.1",
+ "parity-scale-codec 2.0.1",
+ "primitive-types 0.9.0",
  "sp-externalities",
  "sp-runtime-interface-proc-macro",
  "sp-std",
@@ -6647,7 +6908,7 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "Inflector",
@@ -6659,7 +6920,7 @@ dependencies = [
 
 [[package]]
 name = "sp-serializer"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "serde",
@@ -6668,10 +6929,10 @@ dependencies = [
 
 [[package]]
 name = "sp-session"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "sp-api",
  "sp-core",
  "sp-runtime",
@@ -6681,23 +6942,23 @@ dependencies = [
 
 [[package]]
 name = "sp-staking"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "sp-runtime",
  "sp-std",
 ]
 
 [[package]]
 name = "sp-state-machine"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "hash-db",
  "log",
  "num-traits",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "parking_lot 0.11.1",
  "rand 0.7.3",
  "smallvec 1.6.1",
@@ -6713,16 +6974,16 @@ dependencies = [
 
 [[package]]
 name = "sp-std"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 
 [[package]]
 name = "sp-storage"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "impl-serde",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "ref-cast",
  "serde",
  "sp-debug-derive",
@@ -6731,7 +6992,7 @@ dependencies = [
 
 [[package]]
 name = "sp-tasks"
-version = "2.0.0"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "log",
@@ -6744,11 +7005,11 @@ dependencies = [
 
 [[package]]
 name = "sp-timestamp"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
- "impl-trait-for-tuples 0.2.0",
- "parity-scale-codec",
+ "impl-trait-for-tuples 0.2.1",
+ "parity-scale-codec 2.0.1",
  "sp-api",
  "sp-inherents",
  "sp-runtime",
@@ -6758,11 +7019,11 @@ dependencies = [
 
 [[package]]
 name = "sp-tracing"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "sp-std",
  "tracing",
  "tracing-core",
@@ -6771,13 +7032,13 @@ dependencies = [
 
 [[package]]
 name = "sp-transaction-pool"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "derive_more",
  "futures 0.3.12",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "serde",
  "sp-api",
  "sp-blockchain",
@@ -6787,12 +7048,12 @@ dependencies = [
 
 [[package]]
 name = "sp-trie"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "hash-db",
  "memory-db",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "sp-core",
  "sp-std",
  "trie-db",
@@ -6801,7 +7062,7 @@ dependencies = [
 
 [[package]]
 name = "sp-utils"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "futures 0.3.12",
@@ -6813,11 +7074,11 @@ dependencies = [
 
 [[package]]
 name = "sp-version"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "impl-serde",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "serde",
  "sp-runtime",
  "sp-std",
@@ -6825,11 +7086,11 @@ dependencies = [
 
 [[package]]
 name = "sp-wasm-interface"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
- "impl-trait-for-tuples 0.2.0",
- "parity-scale-codec",
+ "impl-trait-for-tuples 0.2.1",
+ "parity-scale-codec 2.0.1",
  "sp-std",
  "wasmi",
 ]
@@ -6912,18 +7173,18 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.16.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6138f8f88a16d90134763314e3fc76fa3ed6a7db4725d6acf9a3ef95a3188d22"
+checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.16.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0054a7df764039a6cd8592b9de84be4bec368ff081d203a7d5371cbfa8e65c81"
+checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -6959,7 +7220,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-build-script-utils"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "platforms",
@@ -6967,7 +7228,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-frame-rpc-system"
-version = "2.0.1"
+version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-system-rpc-runtime-api",
@@ -6976,7 +7237,7 @@ dependencies = [
  "jsonrpc-core-client 15.1.0",
  "jsonrpc-derive 15.1.0",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "sc-client-api",
  "sc-rpc-api",
  "serde",
@@ -6990,7 +7251,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-prometheus-endpoint"
-version = "0.8.1"
+version = "0.9.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "async-std",
@@ -7011,7 +7272,7 @@ dependencies = [
  "futures 0.3.12",
  "hash-db",
  "hex",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.1",
  "sc-client-api",
  "sc-client-db",
  "sc-consensus",
@@ -7031,7 +7292,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "3.0.0"
+version = "4.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "ansi_term 0.12.1",
@@ -7084,6 +7345,12 @@ name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -8060,6 +8327,12 @@ dependencies = [
  "winapi 0.2.8",
  "winapi-build",
 ]
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "x25519-dalek"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1164,7 +1164,6 @@ dependencies = [
  "fixed-hash",
  "impl-codec 0.4.2",
  "impl-rlp",
- "impl-serde",
  "tiny-keccak",
 ]
 
@@ -1227,7 +1226,6 @@ dependencies = [
  "fixed-hash",
  "impl-codec 0.4.2",
  "impl-rlp",
- "impl-serde",
  "primitive-types 0.8.0",
  "uint",
 ]
@@ -1425,7 +1423,7 @@ name = "fc-rpc"
 version = "0.1.0"
 dependencies = [
  "ethereum 0.6.0",
- "ethereum-types 0.10.0",
+ "ethereum-types 0.11.0",
  "fc-consensus",
  "fc-db",
  "fc-rpc-core",
@@ -1460,7 +1458,7 @@ dependencies = [
 name = "fc-rpc-core"
 version = "0.1.0"
 dependencies = [
- "ethereum-types 0.10.0",
+ "ethereum-types 0.11.0",
  "jsonrpc-core 15.1.0",
  "jsonrpc-core-client 14.2.0",
  "jsonrpc-derive 14.2.2",
@@ -1579,7 +1577,7 @@ name = "fp-rpc"
 version = "0.1.0"
 dependencies = [
  "ethereum 0.7.1",
- "ethereum-types 0.10.0",
+ "ethereum-types 0.11.0",
  "fp-evm",
  "parity-scale-codec 2.0.1",
  "sp-api",
@@ -3946,7 +3944,7 @@ name = "pallet-ethereum"
 version = "0.1.0"
 dependencies = [
  "ethereum 0.7.1",
- "ethereum-types 0.10.0",
+ "ethereum-types 0.11.0",
  "evm",
  "fp-consensus",
  "fp-evm",
@@ -3981,7 +3979,7 @@ dependencies = [
  "pallet-balances",
  "pallet-timestamp",
  "parity-scale-codec 2.0.1",
- "primitive-types 0.8.0",
+ "primitive-types 0.9.0",
  "rlp",
  "serde",
  "sha3 0.8.2",
@@ -4645,7 +4643,6 @@ dependencies = [
  "fixed-hash",
  "impl-codec 0.4.2",
  "impl-rlp",
- "impl-serde",
  "uint",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1372,7 +1372,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1430,7 +1430,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1448,7 +1448,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1464,7 +1464,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "12.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1475,7 +1475,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -1500,7 +1500,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -1512,7 +1512,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1524,7 +1524,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1534,7 +1534,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples 0.2.0",
@@ -1550,7 +1550,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3681,7 +3681,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3700,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3715,7 +3715,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3861,7 +3861,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3882,7 +3882,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3915,7 +3915,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3929,7 +3929,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3946,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3962,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "jsonrpc-core 15.1.0",
  "jsonrpc-core-client 15.1.0",
@@ -3979,7 +3979,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -5007,7 +5007,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "futures 0.3.12",
  "futures-timer 3.0.2",
@@ -5030,7 +5030,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5047,7 +5047,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "impl-trait-for-tuples 0.2.0",
  "parity-scale-codec",
@@ -5068,7 +5068,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5079,7 +5079,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "chrono",
  "fdlimit",
@@ -5117,7 +5117,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "derive_more",
  "fnv",
@@ -5151,7 +5151,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -5181,7 +5181,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -5192,7 +5192,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "derive_more",
  "futures 0.3.12",
@@ -5223,7 +5223,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "derive_more",
  "fork-tree",
@@ -5268,7 +5268,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -5281,7 +5281,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "assert_matches",
  "derive_more",
@@ -5314,7 +5314,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "futures 0.3.12",
  "futures-timer 3.0.2",
@@ -5340,7 +5340,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "log",
  "sc-client-api",
@@ -5354,7 +5354,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -5382,7 +5382,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -5398,7 +5398,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5413,7 +5413,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "derive_more",
  "finality-grandpa",
@@ -5451,7 +5451,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.12",
@@ -5469,7 +5469,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -5489,7 +5489,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -5508,7 +5508,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "async-std",
  "async-trait",
@@ -5560,7 +5560,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "futures 0.3.12",
  "futures-timer 3.0.2",
@@ -5576,7 +5576,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -5603,7 +5603,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "futures 0.3.12",
  "libp2p",
@@ -5616,7 +5616,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -5625,7 +5625,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "futures 0.3.12",
  "hash-db",
@@ -5659,7 +5659,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "derive_more",
  "futures 0.3.12",
@@ -5683,7 +5683,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "futures 0.1.30",
  "jsonrpc-core 15.1.0",
@@ -5701,7 +5701,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "directories",
  "exit-future",
@@ -5764,7 +5764,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5779,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "chrono",
  "futures 0.3.12",
@@ -5801,7 +5801,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -5829,7 +5829,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5840,7 +5840,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "derive_more",
  "futures 0.3.12",
@@ -5862,7 +5862,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "futures 0.3.12",
  "futures-diagnose",
@@ -6232,7 +6232,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "log",
  "sp-core",
@@ -6244,7 +6244,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -6260,7 +6260,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -6272,7 +6272,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6284,7 +6284,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -6297,7 +6297,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6308,7 +6308,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6320,7 +6320,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "futures 0.3.12",
  "log",
@@ -6338,7 +6338,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "serde",
  "serde_json",
@@ -6347,7 +6347,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "futures 0.3.12",
  "futures-timer 3.0.2",
@@ -6373,7 +6373,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6387,7 +6387,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -6407,7 +6407,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -6416,7 +6416,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -6428,7 +6428,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -6472,7 +6472,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "kvdb",
  "parking_lot 0.11.1",
@@ -6481,7 +6481,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6491,7 +6491,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6502,7 +6502,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -6519,7 +6519,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.11.1",
@@ -6531,7 +6531,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "futures 0.3.12",
  "hash-db",
@@ -6555,7 +6555,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -6566,7 +6566,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -6583,7 +6583,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6593,7 +6593,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "backtrace",
 ]
@@ -6601,7 +6601,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "serde",
  "sp-core",
@@ -6610,7 +6610,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -6631,7 +6631,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "impl-trait-for-tuples 0.2.0",
  "parity-scale-codec",
@@ -6648,7 +6648,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -6660,7 +6660,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "serde",
  "serde_json",
@@ -6669,7 +6669,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6682,7 +6682,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -6692,7 +6692,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "hash-db",
  "log",
@@ -6714,12 +6714,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -6732,7 +6732,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "log",
  "sp-core",
@@ -6745,7 +6745,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "impl-trait-for-tuples 0.2.0",
  "parity-scale-codec",
@@ -6759,7 +6759,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6772,7 +6772,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "derive_more",
  "futures 0.3.12",
@@ -6788,7 +6788,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -6802,7 +6802,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "futures 0.3.12",
  "futures-core",
@@ -6814,7 +6814,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -6826,7 +6826,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "impl-trait-for-tuples 0.2.0",
  "parity-scale-codec",
@@ -6960,7 +6960,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "platforms",
 ]
@@ -6968,7 +6968,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.12",
@@ -6991,7 +6991,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "async-std",
  "derive_more",
@@ -7005,7 +7005,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "futures 0.1.30",
  "futures 0.3.12",
@@ -7032,7 +7032,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=frontier#4888ac68c8f451b5843ff17135a34ae0f137dabc"
+source = "git+https://github.com/paritytech/substrate.git?branch=frontier#ca63242fc848b9bff739c246e07310dd15ec25eb"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",

--- a/client/consensus/Cargo.toml
+++ b/client/consensus/Cargo.toml
@@ -19,7 +19,7 @@ sp-inherents = { version = "3.0.0", git = "https://github.com/paritytech/substra
 fp-consensus = { version = "0.1.0", path = "../../primitives/consensus" }
 fp-rpc = { path = "../../primitives/rpc" }
 fc-db = { path = "../db" }
-sp-consensus = { version = "0.8.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-consensus = { version = "0.9.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 log = "0.4.8"
 futures = { version = "0.3.1", features = ["compat"] }
 sp-timestamp = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }

--- a/client/consensus/Cargo.toml
+++ b/client/consensus/Cargo.toml
@@ -9,19 +9,19 @@ repository = "https://github.com/paritytech/frontier/"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.4", features = ["derive"] }
-sp-core = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-blockchain = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-runtime = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-api = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sc-client-api = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-block-builder = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-inherents = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-core = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-blockchain = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-runtime = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-api = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sc-client-api = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-block-builder = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-inherents = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-consensus = { version = "0.1.0", path = "../../primitives/consensus" }
 fp-rpc = { path = "../../primitives/rpc" }
 fc-db = { path = "../db" }
 sp-consensus = { version = "0.8.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 log = "0.4.8"
 futures = { version = "0.3.1", features = ["compat"] }
-sp-timestamp = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-timestamp = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 derive_more = "0.99.2"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/substrate.git", branch = "frontier"}

--- a/client/consensus/Cargo.toml
+++ b/client/consensus/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 repository = "https://github.com/paritytech/frontier/"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.3.4", features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "2.0.0", features = ["derive"] }
 sp-core = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-blockchain = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-runtime = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }

--- a/client/consensus/src/lib.rs
+++ b/client/consensus/src/lib.rs
@@ -82,7 +82,7 @@ impl<B, I, C> FrontierBlockImport<B, I, C> where
 	I::Error: Into<ConsensusError>,
 	C: ProvideRuntimeApi<B> + Send + Sync + HeaderBackend<B> + AuxStore + ProvideCache<B> + BlockOf,
 	C::Api: EthereumRuntimeRPCApi<B>,
-	C::Api: BlockBuilderApi<B, Error = sp_blockchain::Error>,
+	C::Api: BlockBuilderApi<B>,
 {
 	pub fn new(
 		inner: I,
@@ -106,7 +106,7 @@ impl<B, I, C> BlockImport<B> for FrontierBlockImport<B, I, C> where
 	I::Error: Into<ConsensusError>,
 	C: ProvideRuntimeApi<B> + Send + Sync + HeaderBackend<B> + AuxStore + ProvideCache<B> + BlockOf,
 	C::Api: EthereumRuntimeRPCApi<B>,
-	C::Api: BlockBuilderApi<B, Error = sp_blockchain::Error>,
+	C::Api: BlockBuilderApi<B>,
 {
 	type Error = ConsensusError;
 	type Transaction = sp_api::TransactionFor<C, B>;

--- a/client/db/Cargo.toml
+++ b/client/db/Cargo.toml
@@ -13,5 +13,5 @@ sp-database = { version = "3.0.0", git = "https://github.com/paritytech/substrat
 sp-runtime = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 kvdb = "0.8.0"
 kvdb-rocksdb = "0.10.0"
-codec = { package = "parity-scale-codec", version = "1.3.6", features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "2.0.0", features = ["derive"] }
 parking_lot = "0.11.1"

--- a/client/db/Cargo.toml
+++ b/client/db/Cargo.toml
@@ -8,9 +8,9 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 repository = "https://github.com/paritytech/frontier/"
 
 [dependencies]
-sp-core = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-database = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-runtime = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-core = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-database = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-runtime = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 kvdb = "0.8.0"
 kvdb-rocksdb = "0.10.0"
 codec = { package = "parity-scale-codec", version = "1.3.6", features = ["derive"] }

--- a/client/db/Cargo.toml
+++ b/client/db/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/paritytech/frontier/"
 sp-core = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-database = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-runtime = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-kvdb = "0.8.0"
-kvdb-rocksdb = "0.10.0"
+kvdb = "0.9.0"
+kvdb-rocksdb = "0.11.0"
 codec = { package = "parity-scale-codec", version = "2.0.0", features = ["derive"] }
 parking_lot = "0.11.1"

--- a/client/mapping-sync/Cargo.toml
+++ b/client/mapping-sync/Cargo.toml
@@ -7,10 +7,10 @@ description = "Mapping sync logic for Frontier."
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
-sp-runtime = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-blockchain = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sc-client-api = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-api = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-runtime = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-blockchain = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sc-client-api = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-api = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-consensus = { path = "../../primitives/consensus" }
 fc-consensus = { path = "../consensus" }
 fc-db = { path = "../db" }

--- a/client/rpc-core/Cargo.toml
+++ b/client/rpc-core/Cargo.toml
@@ -12,6 +12,6 @@ jsonrpc-core-client = "14.0.3"
 jsonrpc-derive = "14.0.3"
 jsonrpc-pubsub = "15.0.0"
 rustc-hex = "2.1.0"
-ethereum-types = "0.10.0"
+ethereum-types = "0.11.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -30,7 +30,7 @@ sc-network = { git = "https://github.com/paritytech/substrate.git", branch = "fr
 pallet-evm = { path = "../../frame/evm" }
 pallet-ethereum = { path = "../../frame/ethereum" }
 ethereum = { version = "0.6", features = ["with-codec"] }
-codec = { package = "parity-scale-codec", version = "1.0.0" }
+codec = { package = "parity-scale-codec", version = "2.0.0" }
 rlp = "0.5"
 futures = { version = "0.3.1", features = ["compat"] }
 sha3 = "0.8"

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -29,7 +29,7 @@ sc-rpc = { git = "https://github.com/paritytech/substrate.git", branch = "fronti
 sc-network = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 pallet-evm = { path = "../../frame/evm" }
 pallet-ethereum = { path = "../../frame/ethereum" }
-ethereum = { version = "0.6", features = ["with-codec"] }
+ethereum = { version = "0.7.1", features = ["with-codec"] }
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 rlp = "0.5"
 futures = { version = "0.3.1", features = ["compat"] }

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -12,7 +12,7 @@ jsonrpc-derive = "14.0.3"
 jsonrpc-core-client = "14.0.3"
 jsonrpc-pubsub = "15.0.0"
 log = "0.4.8"
-ethereum-types = "0.10.0"
+ethereum-types = "0.11.0"
 fc-consensus = { path = "../consensus" }
 fc-db = { path = "../db" }
 fc-rpc-core = { path = "../rpc-core" }

--- a/frame/dynamic-fee/Cargo.toml
+++ b/frame/dynamic-fee/Cargo.toml
@@ -7,7 +7,7 @@ description = "Dynamic fee handling for EVM."
 license = "Apache-2.0"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 serde = { version = "1.0.101", optional = true }
 sp-std = { version = "3.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-core = { version = "3.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }

--- a/frame/dynamic-fee/Cargo.toml
+++ b/frame/dynamic-fee/Cargo.toml
@@ -9,12 +9,12 @@ license = "Apache-2.0"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
 serde = { version = "1.0.101", optional = true }
-sp-std = { version = "2.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-core = { version = "2.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-runtime = { version = "2.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-inherents = { version = "2.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-frame-system = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-frame-support = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-std = { version = "3.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-core = { version = "3.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-runtime = { version = "3.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-inherents = { version = "3.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+frame-system = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+frame-support = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 
 [features]
 default = ["std"]

--- a/frame/ethereum/Cargo.toml
+++ b/frame/ethereum/Cargo.toml
@@ -21,7 +21,7 @@ sp-io = { version = "3.0.0-dev", default-features = false, git = "https://github
 fp-evm = { version = "0.8.0", default-features = false, path = "../../primitives/evm" }
 evm = { version = "0.24.0", features = ["with-codec"], default-features = false }
 ethereum = { version = "0.7.1", default-features = false, features = ["with-codec"] }
-ethereum-types = { version = "0.10", default-features = false }
+ethereum-types = { version = "0.11", default-features = false }
 rlp = { version = "0.5", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 libsecp256k1 = { version = "0.3", default-features = false }

--- a/frame/ethereum/Cargo.toml
+++ b/frame/ethereum/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 [dependencies]
 rustc-hex = { version = "2.1.0", default-features = false }
 serde = { version = "1.0.101", optional = true }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 frame-support = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 frame-system = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 pallet-balances = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }

--- a/frame/ethereum/Cargo.toml
+++ b/frame/ethereum/Cargo.toml
@@ -10,14 +10,14 @@ license = "Apache-2.0"
 rustc-hex = { version = "2.1.0", default-features = false }
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
-frame-support = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-frame-system = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-pallet-balances = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-pallet-timestamp = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-pallet-evm = { version = "2.0.0-dev", default-features = false, path = "../evm" }
-sp-runtime = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-std = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-io = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+frame-support = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+frame-system = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+pallet-balances = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+pallet-timestamp = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+pallet-evm = { version = "3.0.0-dev", default-features = false, path = "../evm" }
+sp-runtime = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-std = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-io = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-evm = { version = "0.8.0", default-features = false, path = "../../primitives/evm" }
 evm = { version = "0.23.0", features = ["with-codec"], default-features = false }
 ethereum = { version = "0.6", default-features = false, features = ["with-codec"] }
@@ -29,7 +29,7 @@ fp-consensus = { path = "../../primitives/consensus", default-features = false }
 fp-rpc = { path = "../../primitives/rpc", default-features = false }
 
 [dev-dependencies]
-sp-core = { version = "2.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-core = { version = "3.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 
 [features]
 default = ["std"]

--- a/frame/ethereum/Cargo.toml
+++ b/frame/ethereum/Cargo.toml
@@ -20,7 +20,7 @@ sp-std = { version = "3.0.0-dev", default-features = false, git = "https://githu
 sp-io = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-evm = { version = "0.8.0", default-features = false, path = "../../primitives/evm" }
 evm = { version = "0.23.0", features = ["with-codec"], default-features = false }
-ethereum = { version = "0.6", default-features = false, features = ["with-codec"] }
+ethereum = { version = "0.7.1", default-features = false, features = ["with-codec"] }
 ethereum-types = { version = "0.10", default-features = false }
 rlp = { version = "0.5", default-features = false }
 sha3 = { version = "0.8", default-features = false }

--- a/frame/ethereum/Cargo.toml
+++ b/frame/ethereum/Cargo.toml
@@ -19,7 +19,7 @@ sp-runtime = { version = "3.0.0-dev", default-features = false, git = "https://g
 sp-std = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-evm = { version = "0.8.0", default-features = false, path = "../../primitives/evm" }
-evm = { version = "0.23.0", features = ["with-codec"], default-features = false }
+evm = { version = "0.24.0", features = ["with-codec"], default-features = false }
 ethereum = { version = "0.7.1", default-features = false, features = ["with-codec"] }
 ethereum-types = { version = "0.10", default-features = false }
 rlp = { version = "0.5", default-features = false }

--- a/frame/ethereum/src/mock.rs
+++ b/frame/ethereum/src/mock.rs
@@ -37,6 +37,18 @@ impl_outer_origin! {
 	pub enum Origin for Test where system = frame_system {}
 }
 
+pub struct PalletInfo;
+
+impl frame_support::traits::PalletInfo for PalletInfo {
+	fn index<P: 'static>() -> Option<usize> {
+		return Some(0)
+	}
+
+	fn name<P: 'static>() -> Option<&'static str> {
+		return Some("TestName")
+	}
+}
+
 // For testing the pallet, we construct most of a mock runtime. This means
 // first constructing a configuration type (`Test`) which `impl`s each of the
 // configuration traits of pallets we want to use.
@@ -64,7 +76,7 @@ impl frame_system::Config for Test {
 	type Event = ();
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
-	type PalletInfo = ();
+	type PalletInfo = PalletInfo;
 	type AccountData = pallet_balances::AccountData<u64>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();

--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -24,7 +24,7 @@ sp-runtime = { version = "3.0.0", default-features = false, git = "https://githu
 sp-std = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-evm = { version = "0.8.0", default-features = false, path = "../../primitives/evm" }
-primitive-types = { version = "0.8.0", default-features = false, features = ["rlp", "byteorder"] }
+primitive-types = { version = "0.9.0", default-features = false, features = ["rlp", "byteorder"] }
 rlp = { version = "0.5", default-features = false }
 evm = { version = "0.24.0", default-features = false, features = ["with-codec"] }
 evm-runtime = { version = "0.23.0", default-features = false }

--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "1.3.4", default-features = false }
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 frame-support = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 frame-system = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 pallet-timestamp = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }

--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-evm"
-version = "2.0.0"
+version = "3.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -15,14 +15,14 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "1.3.4", default-features = false }
-frame-support = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-frame-system = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-pallet-timestamp = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-pallet-balances = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-core = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-runtime = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-std = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-io = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+frame-support = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+frame-system = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+pallet-timestamp = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+pallet-balances = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-runtime = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-std = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-evm = { version = "0.8.0", default-features = false, path = "../../primitives/evm" }
 primitive-types = { version = "0.8.0", default-features = false, features = ["rlp", "byteorder"] }
 rlp = { version = "0.5", default-features = false }

--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -26,7 +26,7 @@ sp-io = { version = "3.0.0", default-features = false, git = "https://github.com
 fp-evm = { version = "0.8.0", default-features = false, path = "../../primitives/evm" }
 primitive-types = { version = "0.8.0", default-features = false, features = ["rlp", "byteorder"] }
 rlp = { version = "0.5", default-features = false }
-evm = { version = "0.23.0", default-features = false, features = ["with-codec"] }
+evm = { version = "0.24.0", default-features = false, features = ["with-codec"] }
 evm-runtime = { version = "0.23.0", default-features = false }
 evm-gasometer = { version = "0.23.0", default-features = false }
 sha3 = { version = "0.8", default-features = false }

--- a/frame/evm/precompile/blake2/Cargo.toml
+++ b/frame/evm/precompile/blake2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-evm-precompile-blake2"
-version = "2.0.0"
+version = "3.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -9,8 +9,8 @@ repository = "https://github.com/paritytech/substrate/"
 description = "BLAKE2 precompiles for EVM pallet."
 
 [dependencies]
-sp-core = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-io = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-evm = { version = "0.8.0", default-features = false, path = "../../../../primitives/evm" }
 evm = { version = "0.23.0", default-features = false, features = ["with-codec"] }
 

--- a/frame/evm/precompile/blake2/Cargo.toml
+++ b/frame/evm/precompile/blake2/Cargo.toml
@@ -12,7 +12,7 @@ description = "BLAKE2 precompiles for EVM pallet."
 sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-evm = { version = "0.8.0", default-features = false, path = "../../../../primitives/evm" }
-evm = { version = "0.23.0", default-features = false, features = ["with-codec"] }
+evm = { version = "0.24.0", default-features = false, features = ["with-codec"] }
 
 [features]
 default = ["std"]

--- a/frame/evm/precompile/bn128/Cargo.toml
+++ b/frame/evm/precompile/bn128/Cargo.toml
@@ -12,7 +12,7 @@ description = "BN128 precompiles for EVM pallet."
 sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-evm = { version = "0.8.0", default-features = false, path = "../../../../primitives/evm" }
-evm = { version = "0.23.0", default-features = false, features = ["with-codec"] }
+evm = { version = "0.24.0", default-features = false, features = ["with-codec"] }
 bn = { package = "substrate-bn", version = "0.5", default-features = false }
 
 [features]

--- a/frame/evm/precompile/bn128/Cargo.toml
+++ b/frame/evm/precompile/bn128/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-evm-precompile-bn128"
-version = "2.0.0"
+version = "3.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -9,8 +9,8 @@ repository = "https://github.com/paritytech/substrate/"
 description = "BN128 precompiles for EVM pallet."
 
 [dependencies]
-sp-core = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-io = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-evm = { version = "0.8.0", default-features = false, path = "../../../../primitives/evm" }
 evm = { version = "0.23.0", default-features = false, features = ["with-codec"] }
 bn = { package = "substrate-bn", version = "0.5", default-features = false }

--- a/frame/evm/precompile/dispatch/Cargo.toml
+++ b/frame/evm/precompile/dispatch/Cargo.toml
@@ -15,7 +15,7 @@ frame-support = { version = "3.0.0", default-features = false, git = "https://gi
 pallet-evm = { version = "3.0.0", default-features = false, path = "../.." }
 fp-evm = { version = "0.8.0", default-features = false, path = "../../../../primitives/evm" }
 evm = { version = "0.23.0", default-features = false, features = ["with-codec"] }
-codec = { package = "parity-scale-codec", version = "1.3.5", default-features = false }
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 
 [features]
 default = ["std"]

--- a/frame/evm/precompile/dispatch/Cargo.toml
+++ b/frame/evm/precompile/dispatch/Cargo.toml
@@ -14,7 +14,7 @@ sp-io = { version = "3.0.0", default-features = false, git = "https://github.com
 frame-support = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 pallet-evm = { version = "3.0.0", default-features = false, path = "../.." }
 fp-evm = { version = "0.8.0", default-features = false, path = "../../../../primitives/evm" }
-evm = { version = "0.23.0", default-features = false, features = ["with-codec"] }
+evm = { version = "0.24.0", default-features = false, features = ["with-codec"] }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 
 [features]

--- a/frame/evm/precompile/dispatch/Cargo.toml
+++ b/frame/evm/precompile/dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-evm-precompile-dispatch"
-version = "2.0.0"
+version = "3.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -9,10 +9,10 @@ repository = "https://github.com/paritytech/substrate/"
 description = "DISPATCH precompiles for EVM pallet."
 
 [dependencies]
-sp-core = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-io = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-frame-support = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-pallet-evm = { version = "2.0.0", default-features = false, path = "../.." }
+sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+frame-support = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+pallet-evm = { version = "3.0.0", default-features = false, path = "../.." }
 fp-evm = { version = "0.8.0", default-features = false, path = "../../../../primitives/evm" }
 evm = { version = "0.23.0", default-features = false, features = ["with-codec"] }
 codec = { package = "parity-scale-codec", version = "1.3.5", default-features = false }

--- a/frame/evm/precompile/ed25519/Cargo.toml
+++ b/frame/evm/precompile/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-evm-precompile-ed25519"
-version = "2.0.0"
+version = "3.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -9,8 +9,8 @@ repository = "https://github.com/paritytech/substrate/"
 description = "ED25519 precompiles for EVM pallet."
 
 [dependencies]
-sp-core = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-io = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-evm = { version = "0.8.0", default-features = false, path = "../../../../primitives/evm" }
 evm = { version = "0.23.0", default-features = false, features = ["with-codec"] }
 ed25519-dalek = { version = "1.0.0", features = ["alloc", "u64_backend"], default-features = false }

--- a/frame/evm/precompile/ed25519/Cargo.toml
+++ b/frame/evm/precompile/ed25519/Cargo.toml
@@ -12,7 +12,7 @@ description = "ED25519 precompiles for EVM pallet."
 sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-evm = { version = "0.8.0", default-features = false, path = "../../../../primitives/evm" }
-evm = { version = "0.23.0", default-features = false, features = ["with-codec"] }
+evm = { version = "0.24.0", default-features = false, features = ["with-codec"] }
 ed25519-dalek = { version = "1.0.0", features = ["alloc", "u64_backend"], default-features = false }
 
 [features]

--- a/frame/evm/precompile/modexp/Cargo.toml
+++ b/frame/evm/precompile/modexp/Cargo.toml
@@ -12,7 +12,7 @@ description = "MODEXP precompiles for EVM pallet."
 sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-evm = { version = "0.8.0", default-features = false, path = "../../../../primitives/evm" }
-evm = { version = "0.23.0", default-features = false, features = ["with-codec"] }
+evm = { version = "0.24.0", default-features = false, features = ["with-codec"] }
 num = { version = "0.3", features = ["alloc"], default-features = false }
 
 [dev-dependencies]

--- a/frame/evm/precompile/modexp/Cargo.toml
+++ b/frame/evm/precompile/modexp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-evm-precompile-modexp"
-version = "2.0.0"
+version = "3.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -9,8 +9,8 @@ repository = "https://github.com/paritytech/substrate/"
 description = "MODEXP precompiles for EVM pallet."
 
 [dependencies]
-sp-core = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-io = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-evm = { version = "0.8.0", default-features = false, path = "../../../../primitives/evm" }
 evm = { version = "0.23.0", default-features = false, features = ["with-codec"] }
 num = { version = "0.3", features = ["alloc"], default-features = false }

--- a/frame/evm/precompile/simple/Cargo.toml
+++ b/frame/evm/precompile/simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-evm-precompile-simple"
-version = "2.0.0"
+version = "3.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -9,8 +9,8 @@ repository = "https://github.com/paritytech/substrate/"
 description = "Simple precompiles for EVM pallet."
 
 [dependencies]
-sp-core = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-io = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-evm = { version = "0.8.0", default-features = false, path = "../../../../primitives/evm" }
 evm = { version = "0.23.0", default-features = false, features = ["with-codec"] }
 ripemd160 = { version = "0.9", default-features = false }

--- a/frame/evm/precompile/simple/Cargo.toml
+++ b/frame/evm/precompile/simple/Cargo.toml
@@ -12,7 +12,7 @@ description = "Simple precompiles for EVM pallet."
 sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-evm = { version = "0.8.0", default-features = false, path = "../../../../primitives/evm" }
-evm = { version = "0.23.0", default-features = false, features = ["with-codec"] }
+evm = { version = "0.24.0", default-features = false, features = ["with-codec"] }
 ripemd160 = { version = "0.9", default-features = false }
 
 [features]

--- a/frame/evm/src/tests.rs
+++ b/frame/evm/src/tests.rs
@@ -39,6 +39,18 @@ impl_outer_dispatch! {
 	}
 }
 
+pub struct PalletInfo;
+
+impl frame_support::traits::PalletInfo for PalletInfo {
+	fn index<P: 'static>() -> Option<usize> {
+		return Some(0)
+	}
+
+	fn name<P: 'static>() -> Option<&'static str> {
+		return Some("TestName")
+	}
+}
+
 #[derive(Clone, Eq, PartialEq)]
 pub struct Test;
 parameter_types! {
@@ -63,7 +75,7 @@ impl frame_system::Config for Test {
 	type Event = ();
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
-	type PalletInfo = ();
+	type PalletInfo = PalletInfo;
 	type AccountData = pallet_balances::AccountData<u64>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();

--- a/primitives/consensus/Cargo.toml
+++ b/primitives/consensus/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/paritytech/substrate/"
 sp-std = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-runtime = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 ethereum = { version = "0.6.0", default-features = false, features = ["with-codec"] }
 rlp = { version = "0.5", default-features = false }
 sha3 = { version = "0.8", default-features = false }

--- a/primitives/consensus/Cargo.toml
+++ b/primitives/consensus/Cargo.toml
@@ -13,7 +13,7 @@ sp-std = { version = "3.0.0", default-features = false, git = "https://github.co
 sp-runtime = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
-ethereum = { version = "0.6.0", default-features = false, features = ["with-codec"] }
+ethereum = { version = "0.7.1", default-features = false, features = ["with-codec"] }
 rlp = { version = "0.5", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 

--- a/primitives/consensus/Cargo.toml
+++ b/primitives/consensus/Cargo.toml
@@ -9,9 +9,9 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 
 [dependencies]
-sp-std = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-runtime = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-core = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-std = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-runtime = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false, features = ["derive"] }
 ethereum = { version = "0.6.0", default-features = false, features = ["with-codec"] }
 rlp = { version = "0.5", default-features = false }

--- a/primitives/consensus/src/lib.rs
+++ b/primitives/consensus/src/lib.rs
@@ -45,15 +45,15 @@ impl Log {
 
 #[derive(Decode, Encode, Clone, PartialEq, Eq)]
 pub enum PreLog {
-	#[codec(index = "3")]
+	#[codec(index = 3)]
 	Block(ethereum::Block),
 }
 
 #[derive(Decode, Encode, Clone, PartialEq, Eq)]
 pub enum PostLog {
-	#[codec(index = "1")]
+	#[codec(index = 1)]
 	Hashes(Hashes),
-	#[codec(index = "2")]
+	#[codec(index = 2)]
 	Block(ethereum::Block),
 }
 

--- a/primitives/consensus/src/lib.rs
+++ b/primitives/consensus/src/lib.rs
@@ -27,11 +27,11 @@ pub const FRONTIER_ENGINE_ID: ConsensusEngineId = [b'f', b'r', b'o', b'n'];
 
 #[derive(Decode, Encode, Clone, PartialEq, Eq)]
 pub enum ConsensusLog {
-	#[codec(index = "1")]
+	#[codec(index = 1)]
 	PostHashes(PostHashes),
-	#[codec(index = "2")]
+	#[codec(index = 2)]
 	PostBlock(ethereum::Block),
-	#[codec(index = "3")]
+	#[codec(index = 3)]
 	PreBlock(ethereum::Block),
 }
 

--- a/primitives/evm/Cargo.toml
+++ b/primitives/evm/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 sp-core = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier", default-features = false }
 sp-std = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier", default-features = false }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "1.3.4", default-features = false }
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 evm = { version = "0.23.0", default-features = false, features = ["with-codec"] }
 impl-trait-for-tuples = "0.1"
 

--- a/primitives/evm/Cargo.toml
+++ b/primitives/evm/Cargo.toml
@@ -18,7 +18,7 @@ sp-core = { version = "3.0.0", git = "https://github.com/paritytech/substrate.gi
 sp-std = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier", default-features = false }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
-evm = { version = "0.23.0", default-features = false, features = ["with-codec"] }
+evm = { version = "0.24.0", default-features = false, features = ["with-codec"] }
 impl-trait-for-tuples = "0.1"
 
 [features]

--- a/primitives/evm/Cargo.toml
+++ b/primitives/evm/Cargo.toml
@@ -14,8 +14,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-core = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier", default-features = false }
-sp-std = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier", default-features = false }
+sp-core = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier", default-features = false }
+sp-std = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier", default-features = false }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "1.3.4", default-features = false }
 evm = { version = "0.23.0", default-features = false, features = ["with-codec"] }

--- a/primitives/rpc/Cargo.toml
+++ b/primitives/rpc/Cargo.toml
@@ -11,7 +11,7 @@ sp-core = { version = "3.0.0-dev", default-features = false, git = "https://gith
 sp-api = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-evm = { version = "0.8.0", default-features = false, path = "../../primitives/evm" }
 ethereum = { version = "0.7.1", default-features = false, features = ["with-codec"] }
-ethereum-types = { version = "0.10", default-features = false }
+ethereum-types = { version = "0.11", default-features = false }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 sp-runtime = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-std = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }

--- a/primitives/rpc/Cargo.toml
+++ b/primitives/rpc/Cargo.toml
@@ -12,7 +12,7 @@ sp-api = { version = "3.0.0-dev", default-features = false, git = "https://githu
 fp-evm = { version = "0.8.0", default-features = false, path = "../../primitives/evm" }
 ethereum = { version = "0.6", default-features = false, features = ["with-codec"] }
 ethereum-types = { version = "0.10", default-features = false }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 sp-runtime = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-std = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }

--- a/primitives/rpc/Cargo.toml
+++ b/primitives/rpc/Cargo.toml
@@ -7,15 +7,15 @@ description = "Runtime primitives for Ethereum RPC (web3) compatibility layer fo
 license = "Apache-2.0"
 
 [dependencies]
-sp-core = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-api = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-core = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-api = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-evm = { version = "0.8.0", default-features = false, path = "../../primitives/evm" }
 ethereum = { version = "0.6", default-features = false, features = ["with-codec"] }
 ethereum-types = { version = "0.10", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
-sp-runtime = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-std = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-io = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-runtime = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-std = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-io = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 
 [features]
 default = ["std"]

--- a/primitives/rpc/Cargo.toml
+++ b/primitives/rpc/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 sp-core = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-api = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-evm = { version = "0.8.0", default-features = false, path = "../../primitives/evm" }
-ethereum = { version = "0.6", default-features = false, features = ["with-codec"] }
+ethereum = { version = "0.7.1", default-features = false, features = ["with-codec"] }
 ethereum-types = { version = "0.10", default-features = false }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 sp-runtime = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }

--- a/template/node/Cargo.toml
+++ b/template/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frontier-template-node"
-version = "2.0.0-dev"
+version = "3.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate Node template"
 edition = "2018"

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -1,6 +1,6 @@
 //! A collection of node-specific RPC methods.
 
-use std::{sync::Arc, fmt};
+use std::sync::Arc;
 
 use fc_rpc_core::types::{PendingTransactions, FilterPool};
 use sc_consensus_manual_seal::rpc::{ManualSeal, ManualSealApi};
@@ -70,7 +70,6 @@ pub fn create_full<C, P, BE>(
 	C::Api: BlockBuilder<Block>,
 	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
 	C::Api: fp_rpc::EthereumRuntimeRPCApi<Block>,
-	<C::Api as sp_api::ApiErrorExt>::Error: fmt::Debug,
 	P: TransactionPool<Block=Block> + 'static,
 {
 	use substrate_frame_rpc_system::{FullSystem, SystemApi};

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -95,11 +95,11 @@ pub fn new_partial(config: &Configuration, sealing: Option<Sealing>) -> Result<
 		FullClient, FullBackend, FullSelectChain,
 		sp_consensus::import_queue::BasicQueue<Block, sp_api::TransactionFor<FullClient, Block>>,
 		sc_transaction_pool::FullPool<Block, FullClient>,
-		(ConsensusResult, PendingTransactions, Option<TelemetrySpan>, Option<FilterPool>, Arc<fc_db::Backend<Block>>),
+		(ConsensusResult, PendingTransactions, Option<FilterPool>, Arc<fc_db::Backend<Block>>),
 >, ServiceError> {
 	let inherent_data_providers = sp_inherents::InherentDataProviders::new();
 
-	let (client, backend, keystore_container, task_manager, telemetry_span) =
+	let (client, backend, keystore_container, task_manager) =
 		sc_service::new_full_parts::<Block, RuntimeApi, Executor>(&config)?;
 	let client = Arc::new(client);
 
@@ -107,6 +107,7 @@ pub fn new_partial(config: &Configuration, sealing: Option<Sealing>) -> Result<
 
 	let transaction_pool = sc_transaction_pool::BasicPool::new_full(
 		config.transaction_pool.clone(),
+		config.role.is_authority().into(),
 		config.prometheus_registry(),
 		task_manager.spawn_handle(),
 		client.clone(),
@@ -142,7 +143,7 @@ pub fn new_partial(config: &Configuration, sealing: Option<Sealing>) -> Result<
 		return Ok(sc_service::PartialComponents {
 			client, backend, task_manager, import_queue, keystore_container,
 			select_chain, transaction_pool, inherent_data_providers,
-			other: (ConsensusResult::ManualSeal(frontier_block_import, sealing), pending_transactions, telemetry_span, filter_pool, frontier_backend)
+			other: (ConsensusResult::ManualSeal(frontier_block_import, sealing), pending_transactions, filter_pool, frontier_backend)
 		})
 	}
 
@@ -175,7 +176,7 @@ pub fn new_partial(config: &Configuration, sealing: Option<Sealing>) -> Result<
 	Ok(sc_service::PartialComponents {
 		client, backend, task_manager, import_queue, keystore_container,
 		select_chain, transaction_pool, inherent_data_providers,
-		other: (ConsensusResult::Aura(aura_block_import, grandpa_link), pending_transactions, telemetry_span, filter_pool, frontier_backend)
+		other: (ConsensusResult::Aura(aura_block_import, grandpa_link), pending_transactions, filter_pool, frontier_backend)
 	})
 }
 
@@ -188,7 +189,7 @@ pub fn new_full(
 	let sc_service::PartialComponents {
 		client, backend, mut task_manager, import_queue, keystore_container,
 		select_chain, transaction_pool, inherent_data_providers,
-		other: (consensus_result, pending_transactions, telemetry_span, filter_pool, frontier_backend),
+		other: (consensus_result, pending_transactions, filter_pool, frontier_backend),
 	} = new_partial(&config, sealing)?;
 
 	let (network, network_status_sinks, system_rpc_tx, network_starter) =
@@ -246,6 +247,9 @@ pub fn new_full(
 		})
 	};
 
+	let telemetry_span = TelemetrySpan::new();
+	let _telemetry_span_entered = telemetry_span.enter();
+
 	let (_rpc_handlers, telemetry_connection_notifier) = sc_service::spawn_tasks(sc_service::SpawnTasksParams {
 		network: network.clone(),
 		client: client.clone(),
@@ -255,7 +259,7 @@ pub fn new_full(
 		rpc_extensions_builder: rpc_extensions_builder,
 		on_demand: None,
 		remote_blockchain: None,
-		backend, network_status_sinks, system_rpc_tx, config, telemetry_span,
+		backend, network_status_sinks, system_rpc_tx, config, telemetry_span: Some(telemetry_span.clone()),
 	})?;
 
 	// Spawn Frontier EthFilterApi maintenance task.
@@ -419,7 +423,7 @@ pub fn new_full(
 					name: Some(name),
 					observer_enabled: false,
 					keystore,
-					is_authority: role.is_network_authority(),
+					is_authority: role.is_authority(),
 				};
 
 				if enable_grandpa {
@@ -457,10 +461,13 @@ pub fn new_full(
 // FIXME: #238 Light client does not have a complete import pipeline or support manual/instant seal.
 /// Builds a new service for a light client.
 pub fn new_light(config: Configuration) -> Result<TaskManager, ServiceError> {
-	let (client, backend, keystore_container, mut task_manager, on_demand, telemetry_span) =
+	let (client, backend, keystore_container, mut task_manager, on_demand) =
 		sc_service::new_light_parts::<Block, RuntimeApi, Executor>(&config)?;
 
 	let select_chain = sc_consensus::LongestChain::new(backend.clone());
+
+	let telemetry_span = TelemetrySpan::new();
+	let _telemetry_span_entered = telemetry_span.enter();
 
 	let transaction_pool = Arc::new(sc_transaction_pool::BasicPool::new_light(
 		config.transaction_pool.clone(),
@@ -526,7 +533,7 @@ pub fn new_light(config: Configuration) -> Result<TaskManager, ServiceError> {
 		network,
 		network_status_sinks,
 		system_rpc_tx,
-		telemetry_span,
+		telemetry_span: Some(telemetry_span.clone()),
 	})?;
 
 	network_starter.start_network();

--- a/template/runtime/Cargo.toml
+++ b/template/runtime/Cargo.toml
@@ -33,7 +33,7 @@ pallet-transaction-payment-rpc-runtime-api = { version = "3.0.0-dev", default-fe
 
 sp-api = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-block-builder = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier"}
-sp-consensus-aura = { version = "0.8.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-consensus-aura = { version = "0.9.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-core = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-inherents = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier"}
 sp-io = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }

--- a/template/runtime/Cargo.toml
+++ b/template/runtime/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 
 frame-executive = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }

--- a/template/runtime/Cargo.toml
+++ b/template/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frontier-template-runtime"
-version = "2.0.0-dev"
+version = "3.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Unlicense"
@@ -14,35 +14,35 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 
-frame-executive = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-frame-support = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-frame-system = { version = "2.0.0-dev", default-features = false, package = "frame-system", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-frame-system-rpc-runtime-api = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+frame-executive = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+frame-support = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+frame-system = { version = "3.0.0-dev", default-features = false, package = "frame-system", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+frame-system-rpc-runtime-api = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 
 pallet-ethereum = { version = "0.1.0", default-features = false, path = "../../frame/ethereum" }
-pallet-evm = { version = "2.0.0-dev", default-features = false, path = "../../frame/evm" }
-pallet-evm-precompile-simple = { version = "2.0.0-dev", default-features = false, path = "../../frame/evm/precompile/simple" }
-pallet-aura = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-pallet-balances = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-pallet-grandpa = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-pallet-randomness-collective-flip = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-pallet-sudo = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-pallet-timestamp = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-pallet-transaction-payment = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-pallet-transaction-payment-rpc-runtime-api = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+pallet-evm = { version = "3.0.0-dev", default-features = false, path = "../../frame/evm" }
+pallet-evm-precompile-simple = { version = "3.0.0-dev", default-features = false, path = "../../frame/evm/precompile/simple" }
+pallet-aura = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+pallet-balances = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+pallet-grandpa = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+pallet-randomness-collective-flip = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+pallet-sudo = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+pallet-timestamp = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+pallet-transaction-payment = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+pallet-transaction-payment-rpc-runtime-api = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 
-sp-api = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-api = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-block-builder = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier"}
 sp-consensus-aura = { version = "0.8.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-core = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-core = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-inherents = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier"}
-sp-io = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-offchain = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-runtime = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-session = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-std = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-transaction-pool = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-sp-version = { version = "2.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-io = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-offchain = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-runtime = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-session = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-std = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-transaction-pool = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-version = { version = "3.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 
 fp-rpc = { default-features = false, path = "../../primitives/rpc" }
 

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -221,7 +221,7 @@ parameter_types! {
 impl pallet_timestamp::Config for Runtime {
 	/// A timestamp: milliseconds since the unix epoch.
 	type Moment = u64;
-	type OnTimestampSet = Aura;
+	type OnTimestampSet = ();
 	type MinimumPeriod = MinimumPeriod;
 	type WeightInfo = ();
 }

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -221,9 +221,13 @@ parameter_types! {
 impl pallet_timestamp::Config for Runtime {
 	/// A timestamp: milliseconds since the unix epoch.
 	type Moment = u64;
-	type OnTimestampSet = ();
 	type MinimumPeriod = MinimumPeriod;
 	type WeightInfo = ();
+
+	// Implementations using Aura should set this to 'Aura'. However, this is currently
+	// incompatible with manual-sealing. See https://github.com/paritytech/frontier/issues/315
+	// for more details.
+	type OnTimestampSet = ();
 }
 
 parameter_types! {

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -329,7 +329,7 @@ construct_runtime!(
 		System: frame_system::{Module, Call, Config, Storage, Event<T>},
 		RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Module, Call, Storage},
 		Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},
-		Aura: pallet_aura::{Module, Config<T>, Inherent},
+		Aura: pallet_aura::{Module, Config<T>},
 		Grandpa: pallet_grandpa::{Module, Call, Storage, Config, Event},
 		Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
 		TransactionPayment: pallet_transaction_payment::{Module, Storage},

--- a/template/test-utils/client/Cargo.toml
+++ b/template/test-utils/client/Cargo.toml
@@ -7,7 +7,7 @@ description = "Ethereum RPC (web3) compatibility layer for Substrate."
 license = "GPL-3.0"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.3.1" }
+codec = { package = "parity-scale-codec", version = "2.0.0" }
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-api = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sc-executor = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }


### PR DESCRIPTION
This cherry-picks commits related to updating Substrate to v3.0 from Moonbeam's effort on the purestake/v0.7-moonbeam branch (https://github.com/purestake/frontier/tree/v0.7-moonbeam).

Related to #300, #306, and #308.

@drewstone I believe this addresses your #308 issues, although I don't recall exactly which commit was responsible.

This isn't quite done, but is very close.