### PR TITLE
Move template tasks into Frontier.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1267,6 +1267,7 @@ dependencies = [
  "fc-consensus",
  "fc-db",
  "fc-rpc-core",
+ "fp-consensus",
  "fp-rpc",
  "futures 0.3.12",
  "jsonrpc-core 15.1.0",

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -17,6 +17,7 @@ fc-consensus = { path = "../consensus" }
 fc-db = { path = "../db" }
 fc-rpc-core = { path = "../rpc-core" }
 fp-rpc = { path = "../../primitives/rpc" }
+fp-consensus = { path = "../../primitives/consensus" }
 sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-api = { git = "https://github.com/paritytech/substrate.git", branch = "frontier" }

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -1537,7 +1537,7 @@ impl<B, C> EthFilterApiT for EthFilterApi<B, C> where
 
 pub struct EthTask<B, C>(PhantomData<(B, C)>);
 
-impl<B, C> EthTask<B, C> 
+impl<B, C> EthTask<B, C>
 where
 	C: ProvideRuntimeApi<B> + BlockchainEvents<B>,
 	B: BlockT,
@@ -1546,9 +1546,9 @@ where
 		client: Arc<C>,
 		pending_transactions: Arc<Mutex<HashMap<H256, PendingTransaction>>>,
 		retain_threshold: u64
-	) {	
+	) {
 		let mut notification_st = client.import_notification_stream();
-	
+
 		while let Some(notification) = notification_st.next().await {
 			if let Ok(mut pending_transactions) = pending_transactions.lock() {
 				// As pending transactions have a finite lifespan anyway
@@ -1565,7 +1565,7 @@ where
 				let imported_number: u64 = UniqueSaturatedInto::<u64>::unique_saturated_into(
 					*notification.header.number()
 				);
-	
+
 				pending_transactions.retain(|_, v| {
 					// Drop all the transactions that exceeded the given lifespan.
 					let lifespan_limit = v.at_block + retain_threshold;
@@ -1574,20 +1574,20 @@ where
 			}
 		}
 	}
-	
+
 	pub async fn filter_pool_task(
 		client: Arc<C>,
 		filter_pool: Arc<Mutex<BTreeMap<U256, FilterPoolItem>>>,
 		retain_threshold: u64
 	) {
 		let mut notification_st = client.import_notification_stream();
-	
+
 		while let Some(notification) = notification_st.next().await {
 			if let Ok(filter_pool) = &mut filter_pool.lock() {
 				let imported_number: u64 = UniqueSaturatedInto::<u64>::unique_saturated_into(
 					*notification.header.number()
 				);
-				
+
 				// BTreeMap::retain is unstable :c.
 				// 1. We collect all keys to remove.
 				// 2. We remove them.
@@ -1602,7 +1602,7 @@ where
 						}
 					})
 					.collect();
-	
+
 				for key in remove_list {
 					filter_pool.remove(&key);
 				}

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -21,7 +21,7 @@ mod eth_pubsub;
 
 pub use eth::{
 	EthApi, EthApiServer, EthFilterApi, EthFilterApiServer, NetApi, NetApiServer, Web3Api, Web3ApiServer,
-	pending_transaction_task,
+	EthTask,
 };
 pub use eth_pubsub::{EthPubSubApi, EthPubSubApiServer, HexEncodedIdProvider};
 

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -20,7 +20,8 @@ mod eth;
 mod eth_pubsub;
 
 pub use eth::{
-	EthApi, EthApiServer, EthFilterApi, EthFilterApiServer, NetApi, NetApiServer, Web3Api, Web3ApiServer
+	EthApi, EthApiServer, EthFilterApi, EthFilterApiServer, NetApi, NetApiServer, Web3Api, Web3ApiServer,
+	pending_transaction_task,
 };
 pub use eth_pubsub::{EthPubSubApi, EthPubSubApiServer, HexEncodedIdProvider};
 


### PR DESCRIPTION
`frontier-filter-pool` and `frontier-pending-transactions` tasks of the node service template are useful for Frontier projects.
This PR moves both tasks into the `fc-rpc` crate as async functions.