### PR TITLE
The new rpc handle should returns the same data as the old one

### DIFF
--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -26,7 +26,6 @@ use futures::{StreamExt, future::TryFutureExt};
 use sp_runtime::{
 	traits::{Block as BlockT, UniqueSaturatedInto, Zero, One, Saturating, BlakeTwo256},
 	transaction_validity::TransactionSource,
-	generic::OpaqueDigestItemId
 };
 use sp_api::{ProvideRuntimeApi, BlockId, Core, HeaderT};
 use sp_transaction_pool::{TransactionPool, InPoolTransaction};
@@ -472,9 +471,8 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 					.get(&schema)
 					.unwrap_or(&self.fallback)
 					.storage_at(&id, address, index)
-					.ok_or(internal_err("Fetching account storage through override failed"))?
-					.into()
-			);
+					.unwrap_or_default()
+			)
 		}
 		Ok(H256::default())
 	}

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -532,7 +532,7 @@ impl<T: Config> Module<T> {
 	pub fn remove_account(address: &H160) {
 		if AccountCodes::contains_key(address) {
 			let account_id = T::AddressMapping::into_account_id(*address);
-			frame_system::Module::<T>::dec_ref(&account_id);
+			let _ = frame_system::Module::<T>::dec_consumers(&account_id);
 		}
 
 		AccountCodes::remove(address);
@@ -547,7 +547,7 @@ impl<T: Config> Module<T> {
 
 		if !AccountCodes::contains_key(&address) {
 			let account_id = T::AddressMapping::into_account_id(address);
-			frame_system::Module::<T>::inc_ref(&account_id);
+			let _ = frame_system::Module::<T>::inc_consumers(&account_id);
 		}
 
 		AccountCodes::insert(address, code);


### PR DESCRIPTION
Calling `storage_at` with the storage override rpc handler should return `H256::default()` instead of error if there is no value returned, consistent with the runtime api query.