### PR TITLE
Correctly handle re-org in mapping sync

### DIFF
--- a/client/mapping-sync/src/lib.rs
+++ b/client/mapping-sync/src/lib.rs
@@ -88,10 +88,7 @@ pub fn sync_one_block<Block: BlockT, C, B>(
 
 	let mut operating_tip = None;
 
-	while !current_syncing_tips.is_empty() {
-		let checking_tip = current_syncing_tips.pop()
-			.expect("checked above current_syncing_tips is not empty; qed");
-
+	while let Some(checking_tip) = current_syncing_tips.pop() {
 		if !frontier_backend.mapping().is_synced(&checking_tip).map_err(|e| format!("{:?}", e))? {
 			operating_tip = Some(checking_tip);
 			break

--- a/client/mapping-sync/src/lib.rs
+++ b/client/mapping-sync/src/lib.rs
@@ -66,7 +66,7 @@ pub fn sync_genesis_block<Block: BlockT, C>(
 	Ok(())
 }
 
-pub fn sync_one_level<Block: BlockT, C, B>(
+pub fn sync_one_block<Block: BlockT, C, B>(
 	client: &C,
 	substrate_backend: &B,
 	frontier_backend: &fc_db::Backend<Block>,
@@ -137,7 +137,7 @@ pub fn sync_blocks<Block: BlockT, C, B>(
 	let mut synced_any = false;
 
 	for _ in 0..limit {
-		synced_any = synced_any || sync_one_level(client, substrate_backend, frontier_backend)?;
+		synced_any = synced_any || sync_one_block(client, substrate_backend, frontier_backend)?;
 	}
 
 	Ok(synced_any)

--- a/client/mapping-sync/src/lib.rs
+++ b/client/mapping-sync/src/lib.rs
@@ -77,48 +77,50 @@ pub fn sync_one_level<Block: BlockT, C, B>(
 {
 	let mut current_syncing_tips = frontier_backend.meta().current_syncing_tips()?;
 
-	if current_syncing_tips.len() == 0 {
-		// Sync genesis block.
+	if current_syncing_tips.is_empty() {
+		let mut leaves = substrate_backend.leaves().map_err(|e| format!("{:?}", e))?;
+		if leaves.is_empty() {
+			return Ok(false)
+		}
 
-		let header = substrate_backend.header(BlockId::Number(Zero::zero()))
-			.map_err(|e| format!("{:?}", e))?
-			.ok_or("Genesis header not found".to_string())?;
-		sync_genesis_block(client, frontier_backend, &header)?;
+		current_syncing_tips.append(&mut leaves);
+	}
 
-		current_syncing_tips.push(header.hash());
+	let mut operating_tip = None;
+
+	while !current_syncing_tips.is_empty() {
+		let checking_tip = current_syncing_tips.pop()
+			.expect("checked above current_syncing_tips is not empty; qed");
+
+		if !frontier_backend.mapping().is_synced(&checking_tip).map_err(|e| format!("{:?}", e))? {
+			operating_tip = Some(checking_tip);
+			break
+		}
+	}
+
+	let operating_tip = match operating_tip {
+		Some(operating_tip) => operating_tip,
+		None => {
+			frontier_backend.meta().write_current_syncing_tips(current_syncing_tips)?;
+			return Ok(false)
+		}
+	};
+
+	let operating_header = substrate_backend.header(BlockId::Hash(operating_tip))
+		.map_err(|e| format!("{:?}", e))?
+		.ok_or("Header not found".to_string())?;
+
+	if operating_header.number() == &Zero::zero() {
+		sync_genesis_block(client, frontier_backend, &operating_header)?;
+
 		frontier_backend.meta().write_current_syncing_tips(current_syncing_tips)?;
-
 		Ok(true)
 	} else {
-		let mut syncing_tip_and_children = None;
+		sync_block(frontier_backend, &operating_header)?;
 
-		for tip in &current_syncing_tips {
-			let children = substrate_backend.children(*tip)
-				.map_err(|e| format!("{:?}", e))?;
-
-			if children.len() > 0 {
-				syncing_tip_and_children = Some((*tip, children));
-				break
-			}
-		}
-
-		if let Some((syncing_tip, children)) = syncing_tip_and_children {
-			current_syncing_tips.retain(|tip| tip != &syncing_tip);
-
-			for child in children {
-				let header = substrate_backend.header(BlockId::Hash(child))
-					.map_err(|e| format!("{:?}", e))?
-					.ok_or("Header not found".to_string())?;
-
-				sync_block(frontier_backend, &header)?;
-				current_syncing_tips.push(child);
-			}
-			frontier_backend.meta().write_current_syncing_tips(current_syncing_tips)?;
-
-			Ok(true)
-		} else {
-			Ok(false)
-		}
+		current_syncing_tips.push(*operating_header.parent_hash());
+		frontier_backend.meta().write_current_syncing_tips(current_syncing_tips)?;
+		Ok(true)
 	}
 }
 


### PR DESCRIPTION
Change the mapping sync logic so that:

* We differentiate two states of the syncer a) a syncing operation is ongoing, b) a new syncing operation can be started.
* Under a), we sync from top-down (instead of right now bottom-up), record the current most-bottom blocks, remove any if it's already in the database. The operation is called to end when the bottom block list is empty.
* Under b), we add the current block leaves to the bottom block list, and start a)