### PR TITLE
Make block gas limit accessible in EVM contracts

### DIFF
--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -94,8 +94,6 @@ pub trait Config: frame_system::Config<Hash=H256> + pallet_balances::Config + pa
 	type FindAuthor: FindAuthor<H160>;
 	/// How Ethereum state root is calculated.
 	type StateRoot: Get<H256>;
-	/// The block gas limit. Can be a simple constant, or an adjustment algorithm in another pallet.
-	type BlockGasLimit: Get<U256>;
 }
 
 decl_storage! {

--- a/frame/ethereum/src/mock.rs
+++ b/frame/ethereum/src/mock.rs
@@ -132,6 +132,7 @@ parameter_types! {
 	pub const TransactionByteFee: u64 = 1;
 	pub const ChainId: u64 = 42;
 	pub const EVMModuleId: ModuleId = ModuleId(*b"py/evmpa");
+	pub const BlockGasLimit: U256 = U256::MAX;
 }
 
 pub struct HashedAddressMapping;
@@ -155,18 +156,14 @@ impl pallet_evm::Config for Test {
 	type Precompiles = ();
 	type Runner = pallet_evm::runner::stack::Runner<Self>;
 	type ChainId = ChainId;
+	type BlockGasLimit = BlockGasLimit;
 	type OnChargeTransaction = ();
-}
-
-parameter_types! {
-	pub const BlockGasLimit: U256 = U256::MAX;
 }
 
 impl Config for Test {
 	type Event = ();
 	type FindAuthor = EthereumFindAuthor;
 	type StateRoot = IntermediateStateRoot;
-	type BlockGasLimit = BlockGasLimit;
 }
 
 pub type System = frame_system::Module<Test>;

--- a/frame/evm/src/backend.rs
+++ b/frame/evm/src/backend.rs
@@ -105,7 +105,7 @@ impl<'vicinity, T: Trait> BackendT for Backend<'vicinity, T> {
 	}
 
 	fn block_gas_limit(&self) -> U256 {
-		U256::zero()
+		T::BlockGasLimit::get()
 	}
 
 	fn chain_id(&self) -> U256 {

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -252,6 +252,8 @@ pub trait Config: frame_system::Config + pallet_timestamp::Config {
 	type Precompiles: PrecompileSet;
 	/// Chain ID of EVM.
 	type ChainId: Get<u64>;
+	/// The block gas limit. Can be a simple constant, or an adjustment algorithm in another pallet.
+	type BlockGasLimit: Get<U256>;
 	/// EVM execution runner.
 	type Runner: Runner<Self>;
 

--- a/frame/evm/src/tests.rs
+++ b/frame/evm/src/tests.rs
@@ -129,6 +129,7 @@ impl Config for Test {
 	type Event = Event<Test>;
 	type Precompiles = ();
 	type ChainId = ();
+	type BlockGasLimit = ();
 	type OnChargeTransaction = ();
 }
 

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -276,6 +276,7 @@ impl FeeCalculator for FixedGasPrice {
 
 parameter_types! {
 	pub const ChainId: u64 = 42;
+	pub BlockGasLimit: U256 = U256::from(u32::max_value());
 }
 
 impl pallet_evm::Config for Runtime {
@@ -297,6 +298,7 @@ impl pallet_evm::Config for Runtime {
 		pallet_evm_precompile_sha3fips::Sha3FIPS512,
 	);
 	type ChainId = ChainId;
+	type BlockGasLimit = BlockGasLimit;
 	type OnChargeTransaction = ();
 }
 
@@ -314,15 +316,10 @@ impl<F: FindAuthor<u32>> FindAuthor<H160> for EthereumFindAuthor<F>
 	}
 }
 
-parameter_types! {
-	pub BlockGasLimit: U256 = U256::from(u32::max_value());
-}
-
 impl pallet_ethereum::Config for Runtime {
 	type Event = Event;
 	type FindAuthor = EthereumFindAuthor<Aura>;
 	type StateRoot = pallet_ethereum::IntermediateStateRoot;
-	type BlockGasLimit = BlockGasLimit;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.


### PR DESCRIPTION
Solves #327 

This PR moves the associated type `BlockGasLimit` from `pallet_ethereum` to `pallet_evm`, and makes the data available in contracts.