### PR TITLE
Remove only() call in tests

### DIFF
--- a/ts-tests/tests/test-precompiles.ts
+++ b/ts-tests/tests/test-precompiles.ts
@@ -35,7 +35,7 @@ describeWithFrontier("Frontier RPC (Precompile)", `simple-specs.json`, (context)
 	// Those test are ordered. In general this should be avoided, but due to the time it takes
 	// to spin up a frontier node, it saves a lot of time.
 
-	it.only('should perform ecrecover', async () => {
+	it('should perform ecrecover', async () => {
 		const web3 = context.web3;
 
 		const message = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Tubulum fuisse, qua illum, cuius is condemnatus est rogatione, P. Eaedem res maneant alio modo.'


### PR DESCRIPTION
This removes a call to `.only()` in the `ts-tests`, which causes this to be the only test run.

https://mochajs.org/#exclusive-tests

@drewstone If this needs to be handled differently, let me know. I'm not a `mocha` expert...