### PR TITLE
Switch to one-to-one block mapping in db

### DIFF
--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -159,13 +159,13 @@ impl<Block: BlockT> MappingDb<Block> {
 		}
 	}
 
-	pub fn block_hashes(
+	pub fn block_hash(
 		&self,
 		ethereum_block_hash: &H256,
-	) -> Result<Vec<Block::Hash>, String> {
+	) -> Result<Option<Block::Hash>, String> {
 		match self.db.get(crate::columns::BLOCK_MAPPING, &ethereum_block_hash.encode()) {
-			Some(raw) => Ok(Vec::<Block::Hash>::decode(&mut &raw[..]).map_err(|e| format!("{:?}", e))?),
-			None => Ok(Vec::new()),
+			Some(raw) => Ok(Some(Block::Hash::decode(&mut &raw[..]).map_err(|e| format!("{:?}", e))?)),
+			None => Ok(None),
 		}
 	}
 
@@ -187,12 +187,10 @@ impl<Block: BlockT> MappingDb<Block> {
 
 		let mut transaction = sp_database::Transaction::new();
 
-		let mut block_hashes = self.block_hashes(&commitment.ethereum_block_hash)?;
-		block_hashes.push(commitment.block_hash);
 		transaction.set(
 			crate::columns::BLOCK_MAPPING,
 			&commitment.ethereum_block_hash.encode(),
-			&block_hashes.encode()
+			&commitment.block_hash.encode()
 		);
 
 		for (i, ethereum_transaction_hash) in commitment.ethereum_transaction_hashes.into_iter().enumerate() {

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -89,20 +89,12 @@ pub mod frontier_backend_client {
 		B: BlockT<Hash=H256> + Send + Sync + 'static,
 		C: Send + Sync + 'static,
 	{
-		let hashes = backend.mapping().block_hashes(&hash)
+		let substrate_hash = backend.mapping().block_hash(&hash)
 			.map_err(|err| internal_err(format!("fetch aux store failed: {:?}", err)))?;
-		let out: Vec<H256> = hashes.into_iter()
-			.filter_map(|h| {
-				if is_canon::<B, C>(client, h) {
-					Some(h)
-				} else {
-					None
-				}
-			}).collect();
 
-		if out.len() == 1 {
+		if let Some(substrate_hash) = substrate_hash {
 			return Ok(Some(
-				BlockId::Hash(out[0])
+				BlockId::Hash(substrate_hash)
 			));
 		}
 		Ok(None)

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -82,7 +82,6 @@ pub mod frontier_backend_client {
 		})
 	}
 
-	// Asumes there is only one mapped canonical block in the AuxStore, otherwise something is wrong
 	pub fn load_hash<B: BlockT, C>(client: &C, backend: &fc_db::Backend<B>, hash: H256) -> RpcResult<Option<BlockId<B>>> where
 		B: BlockT,
 		C: HeaderBackend<B> + 'static,


### PR DESCRIPTION
Remove legacy one-to-many block mapping from the database.

Currently we include the intermediate state root as part of the pallet-ethereum block so there is no way for two identical ethereum hashes under fork conditions: there will always be a unique association between substrate and ethereum hashes.

- Sets `BLOCK_MAPPING` column to hold a single `Block::Hash` value.
- Adapt the `block_hash` function to return an `Option<Block::Hash>` instead a `Vec`.
- Simplifies the `frontier_backend_client::load_hash` function to assume there is indeed always a one-to-one association.