### PR TITLE
Schema override TODOs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "fc-rpc"
-version = "1.0.0"
+version = "2.0.0-dev"
 dependencies = [
  "ethereum",
  "ethereum-types",

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,0 +1,3 @@
+## [Unreleased]
+### Changed
+- `EthPubSubApi::new` takes an additional `overrides` parameter.

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fc-rpc"
-version = "1.0.0"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 description = "Ethereum RPC (web3) compatibility layer for Substrate."

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -56,7 +56,7 @@ pub struct EthApi<B: BlockT, C, P, CT, BE, H: ExHashT> {
 	network: Arc<NetworkService<B, H>>,
 	is_authority: bool,
 	signers: Vec<Box<dyn EthSigner>>,
-	overrides: BTreeMap<EthereumStorageSchema, Box<dyn StorageOverride<B> + Send + Sync>>,
+	overrides: Arc<BTreeMap<EthereumStorageSchema, Box<dyn StorageOverride<B> + Send + Sync>>>,
 	fallback: Box<dyn StorageOverride<B> + Send + Sync>,
 	pending_transactions: PendingTransactions,
 	backend: Arc<fc_db::Backend<B>>,
@@ -76,7 +76,7 @@ impl<B: BlockT, C, P, CT, BE, H: ExHashT> EthApi<B, C, P, CT, BE, H> where
 		network: Arc<NetworkService<B, H>>,
 		pending_transactions: PendingTransactions,
 		signers: Vec<Box<dyn EthSigner>>,
-		overrides: BTreeMap<EthereumStorageSchema, Box<dyn StorageOverride<B> + Send + Sync>>,
+		overrides: Arc<BTreeMap<EthereumStorageSchema, Box<dyn StorageOverride<B> + Send + Sync>>>,
 		backend: Arc<fc_db::Backend<B>>,
 		is_authority: bool,
 	) -> Self {
@@ -1205,7 +1205,7 @@ pub struct EthFilterApi<B: BlockT, C, BE> {
 	client: Arc<C>,
 	filter_pool: FilterPool,
 	max_stored_filters: usize,
-	overrides: BTreeMap<EthereumStorageSchema, Box<dyn StorageOverride<B> + Send + Sync>>,
+	overrides: Arc<BTreeMap<EthereumStorageSchema, Box<dyn StorageOverride<B> + Send + Sync>>>,
 	fallback: Box<dyn StorageOverride<B> + Send + Sync>,
 	_marker: PhantomData<(B, BE)>,
 }
@@ -1222,7 +1222,7 @@ impl<B: BlockT, C, BE> EthFilterApi<B, C, BE>  where
 		client: Arc<C>,
 		filter_pool: FilterPool,
 		max_stored_filters: usize,
-		overrides: BTreeMap<EthereumStorageSchema, Box<dyn StorageOverride<B> + Send + Sync>>,
+		overrides: Arc<BTreeMap<EthereumStorageSchema, Box<dyn StorageOverride<B> + Send + Sync>>>,
 	) -> Self {
 		Self {
 			client: client.clone(),

--- a/client/rpc/src/eth_pubsub.rs
+++ b/client/rpc/src/eth_pubsub.rs
@@ -291,7 +291,7 @@ impl<B: BlockT, P, C, BE, H: ExHashT> EthPubSubApiT for EthPubSubApi<B, P, C, BE
 
 							let block = handler.current_block(&id);
 							let receipts = handler.current_receipts(&id);
-							
+
 							match (receipts, block) {
 								(Some(receipts), Some(block)) =>
 									futures::future::ready(Some((block, receipts))),

--- a/client/rpc/src/eth_pubsub.rs
+++ b/client/rpc/src/eth_pubsub.rs
@@ -31,7 +31,7 @@ use sp_blockchain::{Error as BlockChainError, HeaderMetadata, HeaderBackend};
 use sp_storage::{StorageKey, StorageData};
 use sp_io::hashing::twox_128;
 use sc_client_api::{
-	backend::{StorageProvider, Backend, StateBackend, AuxStore},
+	backend::{StorageProvider, Backend, StateBackend},
 	client::BlockchainEvents
 };
 use sc_rpc::Metadata;
@@ -57,6 +57,9 @@ use jsonrpc_core::{Result as JsonRpcResult, futures::{Future, Sink}};
 use fp_rpc::{EthereumRuntimeRPCApi, TransactionStatus};
 
 use sc_network::{NetworkService, ExHashT};
+
+use pallet_ethereum::EthereumStorageSchema;
+use crate::{frontier_backend_client, overrides::{StorageOverride, RuntimeApiStorageOverride}};
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub struct HexEncodedIdProvider {
@@ -87,17 +90,33 @@ pub struct EthPubSubApi<B: BlockT, P, C, BE, H: ExHashT> {
 	client: Arc<C>,
 	network: Arc<NetworkService<B, H>>,
 	subscriptions: SubscriptionManager<HexEncodedIdProvider>,
+	overrides: Arc<BTreeMap<EthereumStorageSchema, Box<dyn StorageOverride<B> + Send + Sync>>>,
+	fallback: Arc<Box<dyn StorageOverride<B> + Send + Sync>>,
 	_marker: PhantomData<(B, BE)>,
 }
 
-impl<B: BlockT, P, C, BE, H: ExHashT> EthPubSubApi<B, P, C, BE, H> {
+impl<B: BlockT, P, C, BE, H: ExHashT> EthPubSubApi<B, P, C, BE, H> where
+	B: BlockT<Hash=H256> + Send + Sync + 'static,
+	C: ProvideRuntimeApi<B>,
+	C::Api: EthereumRuntimeRPCApi<B>,
+	C: Send + Sync + 'static,
+{
 	pub fn new(
 		_pool: Arc<P>,
 		client: Arc<C>,
 		network: Arc<NetworkService<B, H>>,
 		subscriptions: SubscriptionManager<HexEncodedIdProvider>,
+		overrides: Arc<BTreeMap<EthereumStorageSchema, Box<dyn StorageOverride<B> + Send + Sync>>>,
 	) -> Self {
-		Self { _pool, client, network, subscriptions, _marker: PhantomData }
+		Self {
+			_pool,
+			client: client.clone(),
+			network,
+			subscriptions,
+			overrides,
+			fallback: Arc::new(Box::new(RuntimeApiStorageOverride::new(client))),
+			_marker: PhantomData
+		}
 	}
 }
 
@@ -233,7 +252,7 @@ impl<B: BlockT, P, C, BE, H: ExHashT> EthPubSubApiT for EthPubSubApi<B, P, C, BE
 		B: BlockT<Hash=H256> + Send + Sync + 'static,
 		P: TransactionPool<Block=B> + Send + Sync + 'static,
 		C: ProvideRuntimeApi<B> + StorageProvider<B,BE> +
-			BlockchainEvents<B> + AuxStore,
+			BlockchainEvents<B>,
 		C: HeaderBackend<B> + HeaderMetadata<B, Error=BlockChainError> + 'static,
 		C: Send + Sync + 'static,
 		C::Api: EthereumRuntimeRPCApi<B>,
@@ -255,6 +274,8 @@ impl<B: BlockT, P, C, BE, H: ExHashT> EthPubSubApiT for EthPubSubApi<B, P, C, BE
 
 		let client = self.client.clone();
 		let network = self.network.clone();
+		let overrides = self.overrides.clone();
+		let fallback = self.fallback.clone();
 		match kind {
 			Kind::Logs => {
 				self.subscriptions.add(subscriber, |sink| {
@@ -262,12 +283,17 @@ impl<B: BlockT, P, C, BE, H: ExHashT> EthPubSubApiT for EthPubSubApi<B, P, C, BE
 					.filter_map(move |notification| {
 						if notification.is_new_best {
 							let id = BlockId::Hash(notification.hash);
-							let receipts = client.runtime_api()
-								.current_receipts(&id);
-							let block = client.runtime_api()
-								.current_block(&id);
+
+							let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(
+								client.as_ref(), id
+							);
+							let handler = overrides.get(&schema).unwrap_or(&fallback);
+
+							let block = handler.current_block(&id);
+							let receipts = handler.current_receipts(&id);
+							
 							match (receipts, block) {
-								(Ok(Some(receipts)), Ok(Some(block))) =>
+								(Some(receipts), Some(block)) =>
 									futures::future::ready(Some((block, receipts))),
 								_ => futures::future::ready(None)
 							}
@@ -304,12 +330,14 @@ impl<B: BlockT, P, C, BE, H: ExHashT> EthPubSubApiT for EthPubSubApi<B, P, C, BE
 					.filter_map(move |notification| {
 						if notification.is_new_best {
 							let id = BlockId::Hash(notification.hash);
-							let block = client.runtime_api()
-								.current_block(&id);
-							match block {
-								Ok(Some(block)) => futures::future::ready(Some(block)),
-								_ => futures::future::ready(None)
-							}
+
+							let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(
+								client.as_ref(), id
+							);
+							let handler = overrides.get(&schema).unwrap_or(&fallback);
+
+							let block = handler.current_block(&id);
+							futures::future::ready(block)
 						} else {
 							futures::future::ready(None)
 						}

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -25,7 +25,7 @@ pub use eth::{
 	EthTask,
 };
 pub use eth_pubsub::{EthPubSubApi, EthPubSubApiServer, HexEncodedIdProvider};
-pub use overrides::{StorageOverride, SchemaV1Override};
+pub use overrides::{StorageOverride, SchemaV1Override, OverrideHandle, RuntimeApiStorageOverride};
 
 use ethereum_types::{H160, H256};
 use ethereum::{

--- a/client/rpc/src/overrides/mod.rs
+++ b/client/rpc/src/overrides/mod.rs
@@ -13,6 +13,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+use std::collections::BTreeMap;
 
 use ethereum::Block as EthereumBlock;
 use ethereum_types::{H160, H256, U256};
@@ -27,6 +28,12 @@ mod schema_v1_override;
 
 pub use fc_rpc_core::{EthApiServer, NetApiServer};
 pub use schema_v1_override::SchemaV1Override;
+use pallet_ethereum::EthereumStorageSchema;
+
+pub struct OverrideHandle<Block: BlockT> {
+	pub schemas: BTreeMap<EthereumStorageSchema, Box<dyn StorageOverride<Block> + Send + Sync>>,
+	pub fallback: Box<dyn StorageOverride<Block> + Send + Sync>
+}
 
 /// Something that can fetch Ethereum-related data. This trait is quite similar to the runtime API,
 /// and indeed oe implementation of it uses the runtime API.

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -128,11 +128,17 @@ pub fn create_full<C, P, BE>(
 	);
 
 	if let Some(filter_pool) = filter_pool {
+		let mut overrides = BTreeMap::new();
+		overrides.insert(
+			EthereumStorageSchema::V1,
+			Box::new(SchemaV1Override::new(client.clone())) as Box<dyn StorageOverride<_> + Send + Sync>
+		);
 		io.extend_with(
 			EthFilterApiServer::to_delegate(EthFilterApi::new(
 				client.clone(),
 				filter_pool.clone(),
 				500 as usize, // max stored filters
+				overrides,
 			))
 		);
 	}

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -20,7 +20,7 @@ use sp_block_builder::BlockBuilder;
 use sc_network::NetworkService;
 use jsonrpc_pubsub::manager::SubscriptionManager;
 use pallet_ethereum::EthereumStorageSchema;
-use fc_rpc::{StorageOverride, SchemaV1Override};
+use fc_rpc::{StorageOverride, SchemaV1Override, OverrideHandle, RuntimeApiStorageOverride};
 
 /// Light client extra dependencies.
 pub struct LightDeps<C, F, P> {
@@ -113,8 +113,11 @@ pub fn create_full<C, P, BE>(
 		EthereumStorageSchema::V1,
 		Box::new(SchemaV1Override::new(client.clone())) as Box<dyn StorageOverride<_> + Send + Sync>
 	);
-
-	let overrides = Arc::new(overrides_map);
+	
+	let overrides = Arc::new(OverrideHandle {
+		schemas: overrides_map,
+		fallback: Box::new(RuntimeApiStorageOverride::new(client.clone())),
+	});
 
 	io.extend_with(
 		EthApiServer::to_delegate(EthApi::new(

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -113,7 +113,7 @@ pub fn create_full<C, P, BE>(
 		EthereumStorageSchema::V1,
 		Box::new(SchemaV1Override::new(client.clone())) as Box<dyn StorageOverride<_> + Send + Sync>
 	);
-	
+
 	let overrides = Arc::new(OverrideHandle {
 		schemas: overrides_map,
 		fallback: Box::new(RuntimeApiStorageOverride::new(client.clone())),

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -136,7 +136,7 @@ pub fn create_full<C, P, BE>(
 				client.clone(),
 				filter_pool.clone(),
 				500 as usize, // max stored filters
-				overrides,
+				overrides.clone(),
 			))
 		);
 	}
@@ -163,6 +163,7 @@ pub fn create_full<C, P, BE>(
 				HexEncodedIdProvider::default(),
 				Arc::new(subscription_task_executor)
 			),
+			overrides
 		))
 	);
 

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -115,7 +115,7 @@ pub fn create_full<C, P, BE>(
 	);
 
 	let overrides = Arc::new(overrides_map);
-	
+
 	io.extend_with(
 		EthApiServer::to_delegate(EthApi::new(
 			client.clone(),

--- a/ts-tests/tests/test-web3api.ts
+++ b/ts-tests/tests/test-web3api.ts
@@ -7,7 +7,7 @@ describeWithFrontier("Frontier RPC (Web3Api)", `simple-specs.json`, (context) =>
 
 	step("should get client version", async function () {
 		const version = await context.web3.eth.getNodeInfo();
-		expect(version).to.be.equal("node-frontier-template/v1.1/fc-rpc-0.1.0");
+		expect(version).to.be.equal("node-frontier-template/v1.1/fc-rpc-2.0.0-dev");
 	});
 
 	step("should remote sha3", async function () {


### PR DESCRIPTION
We still needed to use this on `eth_getLogs` method, `EthFilterApi` as well as in `EthPubSubApi`.