### PR TITLE
Estimate_gas return issues

### DIFF
--- a/client/rpc/CHANGELOG.md
+++ b/client/rpc/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## Unreleased
 
 * `EthPubSubApi::new` takes an additional `overrides` parameter.
+* Fix `estimate_gas` inaccurate issue.

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -821,7 +821,7 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 					}
 
 					Err(err) => {
-						// if Err == OutofGas or OutofFund, we need more gas
+						// if Err == OutofGas, we need more gas
 						if err.code == ErrorCode::ServerError(0) {
 							lower = mid;
 							mid = (lower + upper + 1) / 2;

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -828,10 +828,10 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 							if mid == lower {
 								break;
 							}
+						} else {
+							// Other errors, return directly
+							return Err(err);
 						}
-
-						// Other errors, return directly
-						return Err(err);
 					}
 				}
 			}

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -172,7 +172,7 @@ pub fn error_on_execution_failure(reason: &ExitReason, data: &[u8]) -> Result<()
 				// `ServerError(0)` will be useful in estimate gas
 				return Err(Error {
 					code: ErrorCode::ServerError(0),
-					message: format!("out of gas or fund"),
+					message: format!("out of gas"),
 					data: None,
 				});
 			}

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -168,7 +168,7 @@ pub fn error_on_execution_failure(reason: &ExitReason, data: &[u8]) -> Result<()
 	match reason {
 		ExitReason::Succeed(_) => Ok(()),
 		ExitReason::Error(e) => {
-			if *e == ExitError::OutOfGas || *e == ExitError::OutOfFund {
+			if *e == ExitError::OutOfGas {
 				// `ServerError(0)` will be useful in estimate gas
 				return Err(Error {
 					code: ErrorCode::ServerError(0),


### PR DESCRIPTION
If `OutOfFund` happened, should return right now instead of continuing with the estimating process.
