### PR TITLE
Past events TODOs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1399,7 +1399,7 @@ dependencies = [
 
 [[package]]
 name = "fc-rpc-core"
-version = "1.1.0"
+version = "1.1.0-dev"
 dependencies = [
  "ethereum-types",
  "jsonrpc-core 15.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1399,7 +1399,7 @@ dependencies = [
 
 [[package]]
 name = "fc-rpc-core"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "ethereum-types",
  "jsonrpc-core 15.1.0",

--- a/client/rpc-core/CHANGELOG.md
+++ b/client/rpc-core/CHANGELOG.md
@@ -1,3 +1,4 @@
 # Changelog for `fc-rpc-core`
 
 ## Unreleased
+- Add `FilteredParams::in_bloom()` function to check the possible existance of Filter addresses or topics in a block.

--- a/client/rpc-core/Cargo.toml
+++ b/client/rpc-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fc-rpc-core"
-version = "1.1.0"
+version = "1.1.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 description = "RPC traits of Ethereum."

--- a/client/rpc-core/Cargo.toml
+++ b/client/rpc-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fc-rpc-core"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 description = "RPC traits of Ethereum."

--- a/client/rpc-core/src/types/filter.rs
+++ b/client/rpc-core/src/types/filter.rs
@@ -130,7 +130,7 @@ impl FilteredParams {
 		// Topics
 		let topic_in_bloom = if let Some(topics) = &filter.topics {
 			let mut inner_topics: Vec<Option<H256>> = Vec::new();
-			for flat in FilteredParams::flatten(topics) {
+			for flat in Self::flatten(topics) {
 				match flat {
 					VariadicValue::Single(topic) => {
 						inner_topics.push(topic);
@@ -167,7 +167,7 @@ impl FilteredParams {
 	/// Cartesian product for VariadicValue conditional indexed parameters.
 	/// Executed once on struct instance.
 	/// i.e. `[A,[B,C]]` to `[[A,B],[A,C]]`.
-	pub fn flatten(topic: &Topic) -> Vec<FlatTopic> {
+	fn flatten(topic: &Topic) -> Vec<FlatTopic> {
 		fn cartesian(lists: &Vec<Vec<Option<H256>>>) -> Vec<Vec<Option<H256>>> {
 			let mut res = vec![];
 			let mut list_iter = lists.iter();

--- a/client/rpc-core/src/types/filter.rs
+++ b/client/rpc-core/src/types/filter.rs
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 use std::{sync::{Arc, Mutex}, collections::BTreeMap};
-use ethereum_types::{H160, H256, U256};
+use ethereum_types::{H160, H256, U256, Bloom, BloomInput};
 use serde::de::{Error, DeserializeOwned};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{Value, from_value};
@@ -108,10 +108,66 @@ impl FilteredParams {
 		}
 		Self::default()
 	}
+	/// Checks the possible existance of an address or topic(s) in a Bloom.
+	/// Wildcards (VariadicValue::Null) are matched as positive.
+	pub fn in_bloom(bloom: Bloom, filter: &Filter) -> bool {
+		// Address
+		let address_in_bloom = match filter.address {
+			Some(VariadicValue::Single(address)) => {
+				bloom.contains_input(BloomInput::Raw(&address[..]))
+			},
+			Some(VariadicValue::Multiple(ref addresses)) => {
+				let mut ret = false;
+				for address in addresses {
+					if bloom.contains_input(BloomInput::Raw(&address[..])) {
+						ret = true;
+					}
+				}
+				ret
+			},
+			_ => true
+		};
+		// Topics
+		let topic_in_bloom = if let Some(topics) = &filter.topics {
+			let mut inner_topics: Vec<Option<H256>> = Vec::new();
+			for flat in FilteredParams::flatten(topics) {
+				match flat {
+					VariadicValue::Single(topic) => {
+						inner_topics.push(topic);
+					},
+					VariadicValue::Multiple(topics) => {
+						for topic in topics {
+							inner_topics.push(topic);
+						}
+					},
+					_ => inner_topics.push(None)
+				}
+			}
+			let mut ret = false;
+			if inner_topics.len() == 0 {
+				ret = true;
+			} else {
+				for inner in inner_topics {
+					// Wildcard (None) or matching topic.
+					if inner.is_none() || bloom.contains_input(
+						BloomInput::Raw(&inner.unwrap()[..])
+					) {
+						ret = true;
+						break;
+					}
+				}
+			}
+			ret
+		} else {
+			true
+		};
+		address_in_bloom && topic_in_bloom
+	}
+
 	/// Cartesian product for VariadicValue conditional indexed parameters.
 	/// Executed once on struct instance.
 	/// i.e. `[A,[B,C]]` to `[[A,B],[A,C]]`.
-	fn flatten(topic: &Topic) -> Vec<FlatTopic> {
+	pub fn flatten(topic: &Topic) -> Vec<FlatTopic> {
 		fn cartesian(lists: &Vec<Vec<Option<H256>>>) -> Vec<Vec<Option<H256>>> {
 			let mut res = vec![];
 			let mut list_iter = lists.iter();

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -16,7 +16,7 @@ ethereum-types = "0.11.0"
 evm = "0.25.0"
 fc-consensus = { version = "1.0.0", path = "../consensus" }
 fc-db = { version = "1.0.0", path = "../db" }
-fc-rpc-core = { version = "1.0.0", path = "../rpc-core" }
+fc-rpc-core = { version = "1.1.0-dev", path = "../rpc-core" }
 fp-consensus = { version = "1.0.0", path = "../../primitives/consensus" }
 fp-rpc = { version = "1.0.0", path = "../../primitives/rpc" }
 fp-storage = { version = "1.0.0", path = "../../primitives/storage"}

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -1039,7 +1039,6 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 		let max_duration = time::Duration::from_secs(10);
 		let begin_request = time::Instant::now();
 
-		let mut blocks_and_statuses = Vec::new();
 		let mut ret: Vec<Log> = Vec::new();
 		if let Some(hash) = filter.block_hash.clone() {
 			let id = match frontier_backend_client::load_hash::<B>(self.backend.as_ref(), hash)
@@ -1054,9 +1053,8 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 
 			let block = handler.current_block(&id);
 			let statuses = handler.current_transaction_statuses(&id);
-
 			if let (Some(block), Some(statuses)) = (block, statuses) {
-				blocks_and_statuses.push((block, statuses));
+				logs_build(&mut ret, &filter, block, statuses);
 			}
 		} else {
 			let best_number = self.client.info().best_number;

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -24,7 +24,7 @@ use ethereum_types::{H160, H256, H64, U256, U64, H512};
 use jsonrpc_core::{BoxFuture, Result, ErrorCode, futures::future::{self, Future}};
 use futures::{StreamExt, future::TryFutureExt};
 use sp_runtime::{
-	traits::{Block as BlockT, UniqueSaturatedInto, Zero, One, Saturating, BlakeTwo256},
+	traits::{Block as BlockT, UniqueSaturatedInto, Zero, One, Saturating, BlakeTwo256, NumberFor},
 	transaction_validity::TransactionSource,
 };
 use sp_api::{ProvideRuntimeApi, BlockId, Core, HeaderT};
@@ -213,7 +213,66 @@ fn transaction_build(
 	}
 }
 
-fn logs_build<'a>(
+fn filter_range_logs<B: BlockT, C, BE>(
+	client: &C,
+	overrides: &OverrideHandle<B>,
+	ret: &mut Vec<Log>,
+	max_past_logs: u32,
+	filter: &Filter,
+	from: NumberFor<B>,
+	to: NumberFor<B>,
+) -> Result<()> where
+	C: ProvideRuntimeApi<B> + StorageProvider<B, BE>,
+	C: HeaderBackend<B> + HeaderMetadata<B, Error=BlockChainError> + 'static,
+	C::Api: EthereumRuntimeRPCApi<B>,
+	BE: Backend<B> + 'static,
+	BE::State: StateBackend<BlakeTwo256>,
+	B: BlockT<Hash=H256> + Send + Sync + 'static,
+	C: Send + Sync + 'static,
+{
+	// Max request duration of 10 seconds.
+	let max_duration = time::Duration::from_secs(10);
+	let begin_request = time::Instant::now();
+
+	let mut current_number = to;
+
+	while current_number >= from {
+		let id = BlockId::Number(current_number);
+
+		let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(client, id);
+		let handler = overrides.schemas.get(&schema).unwrap_or(&overrides.fallback);
+
+		let block = handler.current_block(&id);
+
+		if let Some(block) = block {
+			if FilteredParams::in_bloom(block.header.logs_bloom, filter) {
+				let statuses = handler.current_transaction_statuses(&id);
+				if let Some(statuses) = statuses {
+					filter_block_logs(ret, filter, block, statuses);
+				}
+			}
+		}
+		// Check for restrictions
+		if ret.len() as u32 > max_past_logs {
+			return Err(internal_err(
+				format!("query returned more than {} results", max_past_logs)
+			));
+		}
+		if begin_request.elapsed() > max_duration {
+			return Err(internal_err(
+				format!("query timeout of {} seconds exceeded", max_duration.as_secs())
+			));
+		}
+		if current_number == Zero::zero() {
+			break
+		} else {
+			current_number = current_number.saturating_sub(One::one());
+		}
+	}
+	Ok(())
+}
+
+fn filter_block_logs<'a>(
 	ret: &'a mut Vec<Log>,
 	filter: &'a Filter,
 	block: EthereumBlock,
@@ -1035,10 +1094,6 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 	}
 
 	fn logs(&self, filter: Filter) -> Result<Vec<Log>> {
-		// Max request duration of 10 seconds.
-		let max_duration = time::Duration::from_secs(10);
-		let begin_request = time::Instant::now();
-
 		let mut ret: Vec<Log> = Vec::new();
 		if let Some(hash) = filter.block_hash.clone() {
 			let id = match frontier_backend_client::load_hash::<B>(self.backend.as_ref(), hash)
@@ -1054,7 +1109,7 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 			let block = handler.current_block(&id);
 			let statuses = handler.current_transaction_statuses(&id);
 			if let (Some(block), Some(statuses)) = (block, statuses) {
-				logs_build(&mut ret, &filter, block, statuses);
+				filter_block_logs(&mut ret, &filter, block, statuses);
 			}
 		} else {
 			let best_number = self.client.info().best_number;
@@ -1075,39 +1130,15 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 					self.client.info().best_number
 				);
 
-			while current_number >= from_number {
-				let id = BlockId::Number(current_number);
-
-				let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(self.client.as_ref(), id);
-				let handler = self.overrides.schemas.get(&schema).unwrap_or(&self.overrides.fallback);
-
-				let block = handler.current_block(&id);
-
-				if let Some(block) = block {
-					if FilteredParams::in_bloom(block.header.logs_bloom, &filter) {
-						let statuses = handler.current_transaction_statuses(&id);
-						if let Some(statuses) = statuses {
-							logs_build(&mut ret, &filter, block, statuses);
-						}
-					}
-				}
-				// Check for restrictions
-				if ret.len() as u32 > self.max_past_logs {
-					return Err(internal_err(
-						format!("query returned more than {} results", self.max_past_logs)
-					));
-				}
-				if begin_request.elapsed() > max_duration {
-					return Err(internal_err(
-						format!("query timeout of {} seconds exceeded", max_duration.as_secs())
-					));
-				}
-				if current_number == Zero::zero() {
-					break
-				} else {
-					current_number = current_number.saturating_sub(One::one());
-				}
-			}
+			let _ = filter_range_logs(
+				self.client.as_ref(),
+				&self.overrides,
+				&mut ret,
+				self.max_past_logs,
+				&filter,
+				from_number,
+				current_number
+			)?;
 		}
 		Ok(ret)
 	}
@@ -1355,10 +1386,6 @@ impl<B, C, BE> EthFilterApiT for EthFilterApi<B, C, BE> where
 					},
 					// For each event since last poll, get a vector of ethereum logs.
 					FilterType::Log(filter) => {
-						// Max request duration of 10 seconds.
-						let max_duration = time::Duration::from_secs(10);
-						let begin_request = time::Instant::now();
-
 						// Either the filter-specific `to` block or best block.
 						let best_number = self.client.info().best_number;
 						let mut current_number = filter
@@ -1388,39 +1415,15 @@ impl<B, C, BE> EthFilterApiT for EthFilterApi<B, C, BE> where
 
 						// Build the response.
 						let mut ret: Vec<Log> = Vec::new();
-						while current_number >= from_number {
-							let id = BlockId::Number(current_number);
-
-							let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(self.client.as_ref(), id);
-							let handler = self.overrides.schemas.get(&schema).unwrap_or(&self.overrides.fallback);
-
-							let block = handler.current_block(&id);
-
-							if let Some(block) = block {
-								if FilteredParams::in_bloom(block.header.logs_bloom, &filter) {
-									let statuses = handler.current_transaction_statuses(&id);
-									if let Some(statuses) = statuses {
-										logs_build(&mut ret, &filter, block, statuses);
-									}
-								}
-							}
-							// Check for restrictions
-							if ret.len() as u32 > self.max_past_logs {
-								return Err(internal_err(
-									format!("query returned more than {} results", self.max_past_logs)
-								));
-							}
-							if begin_request.elapsed() > max_duration {
-								return Err(internal_err(
-									format!("query timeout of {} seconds exceeded", max_duration.as_secs())
-								));
-							}
-							if current_number == Zero::zero() {
-								break
-							} else {
-								current_number = current_number.saturating_sub(One::one());
-							}
-						}
+						let _ = filter_range_logs(
+							self.client.as_ref(),
+							&self.overrides,
+							&mut ret,
+							self.max_past_logs,
+							&filter,
+							from_number,
+							current_number
+						)?;
 						// Update filter `last_poll`.
 						locked.insert(
 							key,
@@ -1457,9 +1460,6 @@ impl<B, C, BE> EthFilterApiT for EthFilterApi<B, C, BE> where
 			if let Some(pool_item) = locked.clone().get(&key) {
 				match &pool_item.filter_type {
 					FilterType::Log(filter) => {
-						// Max request duration of 10 seconds.
-						let max_duration = time::Duration::from_secs(10);
-						let begin_request = time::Instant::now();
 						let best_number = self.client.info().best_number;
 						let mut current_number = filter
 							.to_block.clone()
@@ -1483,39 +1483,15 @@ impl<B, C, BE> EthFilterApiT for EthFilterApi<B, C, BE> where
 							);
 
 						let mut ret: Vec<Log> = Vec::new();
-						while current_number >= from_number {
-							let id = BlockId::Number(current_number);
-
-							let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(self.client.as_ref(), id);
-							let handler = self.overrides.schemas.get(&schema).unwrap_or(&self.overrides.fallback);
-
-							let block = handler.current_block(&id);
-
-							if let Some(block) = block {
-								if FilteredParams::in_bloom(block.header.logs_bloom, &filter) {
-									let statuses = handler.current_transaction_statuses(&id);
-									if let Some(statuses) = statuses {
-										logs_build(&mut ret, &filter, block, statuses);
-									}
-								}
-							}
-							// Check for restrictions
-							if ret.len() as u32 > self.max_past_logs {
-								return Err(internal_err(
-									format!("query returned more than {} results", self.max_past_logs)
-								));
-							}
-							if begin_request.elapsed() > max_duration {
-								return Err(internal_err(
-									format!("query timeout of {} seconds exceeded", max_duration.as_secs())
-								));
-							}
-							if current_number == Zero::zero() {
-								break
-							} else {
-								current_number = current_number.saturating_sub(One::one());
-							}
-						}
+						let _ = filter_range_logs(
+							self.client.as_ref(),
+							&self.overrides,
+							&mut ret,
+							self.max_past_logs,
+							&filter,
+							from_number,
+							current_number
+						)?;
 						Ok(ret)
 					},
 					_ => Err(internal_err(

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -1076,12 +1076,15 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 				let handler = self.overrides.schemas.get(&schema).unwrap_or(&self.overrides.fallback);
 
 				let block = handler.current_block(&id);
-				let statuses = handler.current_transaction_statuses(&id);
 
-				if let (Some(block), Some(statuses)) = (block, statuses) {
-					logs_build(&mut ret, &filter, block, statuses);
+				if let Some(block) = block {
+					if FilteredParams::in_bloom(block.header.logs_bloom, &filter) {
+						let statuses = handler.current_transaction_statuses(&id);
+						if let Some(statuses) = statuses {
+							logs_build(&mut ret, &filter, block, statuses);
+						}
+					}
 				}
-
 				if current_number == Zero::zero() {
 					break
 				} else {

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -1035,7 +1035,7 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 	}
 
 	fn logs(&self, filter: Filter) -> Result<Vec<Log>> {
-		// Max request duration of 10 seconds. 
+		// Max request duration of 10 seconds.
 		let max_duration = time::Duration::from_secs(10);
 		let begin_request = time::Instant::now();
 
@@ -1355,7 +1355,7 @@ impl<B, C, BE> EthFilterApiT for EthFilterApi<B, C, BE> where
 					},
 					// For each event since last poll, get a vector of ethereum logs.
 					FilterType::Log(filter) => {
-						// Max request duration of 10 seconds. 
+						// Max request duration of 10 seconds.
 						let max_duration = time::Duration::from_secs(10);
 						let begin_request = time::Instant::now();
 
@@ -1457,10 +1457,9 @@ impl<B, C, BE> EthFilterApiT for EthFilterApi<B, C, BE> where
 			if let Some(pool_item) = locked.clone().get(&key) {
 				match &pool_item.filter_type {
 					FilterType::Log(filter) => {
-						// Max request duration of 10 seconds. 
+						// Max request duration of 10 seconds.
 						let max_duration = time::Duration::from_secs(10);
 						let begin_request = time::Instant::now();
-						
 						let best_number = self.client.info().best_number;
 						let mut current_number = filter
 							.to_block.clone()

--- a/template/node/src/cli.rs
+++ b/template/node/src/cli.rs
@@ -35,6 +35,10 @@ pub struct RunCmd {
 
 	#[structopt(long = "enable-dev-signer")]
 	pub enable_dev_signer: bool,
+
+	/// Maximum number of logs in a query.
+	#[structopt(long, default_value = "10000")]
+	pub max_past_logs: u32,
 }
 
 #[derive(Debug, StructOpt)]

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -144,6 +144,7 @@ pub fn create_full<C, P, BE>(
 				filter_pool.clone(),
 				500 as usize, // max stored filters
 				overrides.clone(),
+				max_past_logs,
 			))
 		);
 	}

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -54,6 +54,8 @@ pub struct FullDeps<C, P> {
 	pub filter_pool: Option<FilterPool>,
 	/// Backend.
 	pub backend: Arc<fc_db::Backend<Block>>,
+	/// Maximum number of logs in a query.
+	pub max_past_logs: u32,
 	/// Manual seal command sink
 	pub command_sink: Option<futures::channel::mpsc::Sender<sc_consensus_manual_seal::rpc::EngineCommand<Hash>>>,
 }
@@ -94,6 +96,7 @@ pub fn create_full<C, P, BE>(
 		filter_pool,
 		command_sink,
 		backend,
+		max_past_logs,
 		enable_dev_signer,
 	} = deps;
 
@@ -130,6 +133,7 @@ pub fn create_full<C, P, BE>(
 			overrides.clone(),
 			backend,
 			is_authority,
+			max_past_logs,
 		))
 	);
 

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -277,6 +277,7 @@ pub fn new_full(
 		let pending = pending_transactions.clone();
 		let filter_pool = filter_pool.clone();
 		let frontier_backend = frontier_backend.clone();
+		let max_past_logs = cli.run.max_past_logs;
 
 		Box::new(move |deny_unsafe, _| {
 			let deps = crate::rpc::FullDeps {
@@ -289,7 +290,8 @@ pub fn new_full(
 				pending_transactions: pending.clone(),
 				filter_pool: filter_pool.clone(),
 				backend: frontier_backend.clone(),
-				command_sink: Some(command_sink.clone())
+				max_past_logs,
+				command_sink: Some(command_sink.clone()),
 			};
 			crate::rpc::create_full(
 				deps,


### PR DESCRIPTION
This PR introduces changes to fix some of our outstanding work on the past events queries:

- CLI argument to control the maximum number of logs returned in a single request. Default 10,000.
- Execution limit for a single request. Default 10 seconds.
- Use of logs bloom to pre-filter.

The goal is to have a predictable performance on both `eth_getLogs` and `eth_subscribe` for `logs`. 