### PR TITLE
Update substrate-bn to 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4776,15 +4776,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -7138,14 +7129,14 @@ dependencies = [
 
 [[package]]
 name = "substrate-bn"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acb439bec2318e98b83f1e12ddaaf2082d6fc29becc3117714ccb575fa343bc1"
+checksum = "72b5bbfa79abbae15dd642ea8176a21a635ff3c00059961d1ea27ad04e5b441c"
 dependencies = [
  "byteorder",
  "crunchy",
  "lazy_static",
- "rand 0.5.6",
+ "rand 0.8.3",
  "rustc-hex",
 ]
 

--- a/frame/evm/precompile/bn128/Cargo.toml
+++ b/frame/evm/precompile/bn128/Cargo.toml
@@ -13,7 +13,7 @@ sp-core = { version = "3.0.0", default-features = false, git = "https://github.c
 sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-evm = { version = "1.0.0", default-features = false, path = "../../../../primitives/evm" }
 evm = { version = "0.25.0", default-features = false, features = ["with-codec"] }
-bn = { package = "substrate-bn", version = "0.5", default-features = false }
+bn = { package = "substrate-bn", version = "0.6", default-features = false }
 
 [features]
 default = ["std"]

--- a/frame/evm/precompile/bn128/Cargo.toml
+++ b/frame/evm/precompile/bn128/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-evm-precompile-bn128"
-version = "1.0.0"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
Updates substrate-bn to the recently published version 0.6 to avoid rand 0.5.6 package issues when importing bn-128 precompiles