### PR TITLE
Update evm to 0.26.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,9 +1206,9 @@ checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 
 [[package]]
 name = "evm"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b4bd1fb06a4962a243c8be285d8a9b2493ffa79acb32633ad07a0bc523b1acd"
+checksum = "1202e8dfa45bea73ee003c4be2f3549d60cb2e2ac5b0c1db563bd4653213efde"
 dependencies = [
  "ethereum",
  "evm-core",
@@ -1224,9 +1224,9 @@ dependencies = [
 
 [[package]]
 name = "evm-core"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b4eea3882c798813a6f92e8855ec1fc3f5ababd8b274cb81d4bedee701b478e"
+checksum = "9aeed00c943f6347108393c98907f432d8f2b82683725dfefbd734d335faace4"
 dependencies = [
  "funty",
  "parity-scale-codec",
@@ -1236,9 +1236,9 @@ dependencies = [
 
 [[package]]
 name = "evm-gasometer"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a8f04dcc8b0296652eabfa443a08ebed6071a1178e0f42a7f7b63a612bddf0b"
+checksum = "463412356790c5e34e8a13cd23ba06284d9afa999e82e8c64497aed2ee625375"
 dependencies = [
  "evm-core",
  "evm-runtime",
@@ -1247,9 +1247,9 @@ dependencies = [
 
 [[package]]
 name = "evm-runtime"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c302f29ca8bba82a382aa52d427869964179e4f24eae57bde70958ce9b7607"
+checksum = "0c08f510e5535cee2352adb9b93ff24dc80f8ca1bad445a9aa1292ce144b45a1"
 dependencies = [
  "evm-core",
  "primitive-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "fc-consensus"
-version = "1.0.1-dev"
+version = "1.1.0-dev"
 dependencies = [
  "derive_more",
  "fc-db",
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "fc-mapping-sync"
-version = "1.1.0-dev"
+version = "1.2.0-dev"
 dependencies = [
  "fc-consensus",
  "fc-db",
@@ -1357,7 +1357,7 @@ dependencies = [
 
 [[package]]
 name = "fc-rpc"
-version = "2.0.0-dev"
+version = "2.1.0-dev"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "fp-evm"
-version = "1.0.1-dev"
+version = "1.1.0-dev"
 dependencies = [
  "evm",
  "impl-trait-for-tuples 0.1.3",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "fp-rpc"
-version = "1.0.1-dev"
+version = "1.1.0-dev"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "fp-storage"
-version = "1.0.1-dev"
+version = "1.1.0-dev"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3893,7 +3893,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ethereum"
-version = "1.0.1-dev"
+version = "1.1.0-dev"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3921,7 +3921,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm"
-version = "3.0.1-dev"
+version = "3.1.0-dev"
 dependencies = [
  "evm",
  "evm-gasometer",
@@ -3945,7 +3945,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-precompile-blake2"
-version = "1.1.0-dev"
+version = "1.2.0-dev"
 dependencies = [
  "evm",
  "fp-evm",
@@ -3956,7 +3956,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-precompile-bn128"
-version = "2.0.0-dev"
+version = "2.1.0-dev"
 dependencies = [
  "evm",
  "fp-evm",
@@ -3968,7 +3968,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-precompile-dispatch"
-version = "1.0.1-dev"
+version = "1.1.0-dev"
 dependencies = [
  "evm",
  "fp-evm",
@@ -3981,7 +3981,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-precompile-ed25519"
-version = "1.0.1-dev"
+version = "1.1.0-dev"
 dependencies = [
  "ed25519-dalek",
  "evm",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-precompile-modexp"
-version = "1.1.0-dev"
+version = "1.2.0-dev"
 dependencies = [
  "evm",
  "fp-evm",
@@ -4005,7 +4005,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
-version = "1.0.1-dev"
+version = "1.1.0-dev"
 dependencies = [
  "evm",
  "fp-evm",
@@ -4016,7 +4016,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-precompile-simple"
-version = "1.0.1-dev"
+version = "1.1.0-dev"
 dependencies = [
  "evm",
  "fp-evm",
@@ -4028,7 +4028,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-test-vector-support"
-version = "1.0.0-dev"
+version = "1.1.0-dev"
 dependencies = [
  "evm",
  "fp-evm",

--- a/client/consensus/Cargo.toml
+++ b/client/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fc-consensus"
-version = "1.0.1-dev"
+version = "1.1.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Frontier consensus for substrate"
 edition = "2018"
@@ -17,7 +17,7 @@ sc-client-api = { version = "3.0.0", git = "https://github.com/paritytech/substr
 sp-block-builder = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-inherents = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-consensus = { version = "1.0.0", path = "../../primitives/consensus" }
-fp-rpc = { version = "1.0.1-dev", path = "../../primitives/rpc" }
+fp-rpc = { version = "1.1.0-dev", path = "../../primitives/rpc" }
 fc-db = { version = "1.0.0", path = "../db" }
 sp-consensus = { version = "0.9.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 log = "0.4.8"

--- a/client/mapping-sync/Cargo.toml
+++ b/client/mapping-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fc-mapping-sync"
-version = "1.1.0-dev"
+version = "1.2.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 description = "Mapping sync logic for Frontier."
@@ -12,9 +12,9 @@ sp-blockchain = { version = "3.0.0", git = "https://github.com/paritytech/substr
 sc-client-api = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-api = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-consensus = { version = "1.0.0", path = "../../primitives/consensus" }
-fc-consensus = { version = "1.0.1-dev", path = "../consensus" }
+fc-consensus = { version = "1.1.0-dev", path = "../consensus" }
 fc-db = { version = "1.0.0", path = "../db" }
-fp-rpc = { version = "1.0.1-dev", path = "../../primitives/rpc" }
+fp-rpc = { version = "1.1.0-dev", path = "../../primitives/rpc" }
 futures = { version = "0.3.1", features = ["compat"] }
 futures-timer = "3.0.1"
 log = "0.4.8"

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -13,7 +13,7 @@ jsonrpc-core-client = "14.0.3"
 jsonrpc-pubsub = "15.0.0"
 log = "0.4.8"
 ethereum-types = "0.11.0"
-evm = "0.25.0"
+evm = "0.26.0"
 fc-consensus = { version = "1.0.1-dev", path = "../consensus" }
 fc-db = { version = "1.0.0", path = "../db" }
 fc-rpc-core = { version = "1.1.0-dev", path = "../rpc-core" }

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -14,12 +14,12 @@ jsonrpc-pubsub = "15.0.0"
 log = "0.4.8"
 ethereum-types = "0.11.0"
 evm = "0.26.0"
-fc-consensus = { version = "1.0.1-dev", path = "../consensus" }
+fc-consensus = { version = "1.1.0-dev", path = "../consensus" }
 fc-db = { version = "1.0.0", path = "../db" }
 fc-rpc-core = { version = "1.1.0-dev", path = "../rpc-core" }
 fp-consensus = { version = "1.0.0", path = "../../primitives/consensus" }
-fp-rpc = { version = "1.0.1-dev", path = "../../primitives/rpc" }
-fp-storage = { version = "1.0.1-dev", path = "../../primitives/storage"}
+fp-rpc = { version = "1.1.0-dev", path = "../../primitives/rpc" }
+fp-storage = { version = "1.1.0-dev", path = "../../primitives/storage"}
 sp-io = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-runtime = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-api = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
@@ -30,9 +30,9 @@ sc-service = { version = "0.9.0", git = "https://github.com/paritytech/substrate
 sc-client-api = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sc-rpc = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sc-network = { version = "0.9.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-pallet-evm = { version = "3.0.1-dev", path = "../../frame/evm" }
-fp-evm = { version = "1.0.1-dev", path = "../../primitives/evm" }
-pallet-ethereum = { version = "1.0.1-dev", path = "../../frame/ethereum" }
+pallet-evm = { version = "3.1.0-dev", path = "../../frame/evm" }
+fp-evm = { version = "1.1.0-dev", path = "../../primitives/evm" }
+pallet-ethereum = { version = "1.1.0-dev", path = "../../frame/ethereum" }
 ethereum = { version = "0.7.1", features = ["with-codec"] }
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 rlp = "0.5"

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fc-rpc"
-version = "2.0.0-dev"
+version = "2.1.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 description = "Ethereum RPC (web3) compatibility layer for Substrate."

--- a/frame/ethereum/Cargo.toml
+++ b/frame/ethereum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-ethereum"
-version = "1.0.1-dev"
+version = "1.1.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 description = "Ethereum compatibility full block processing emulation pallet for Substrate."

--- a/frame/ethereum/Cargo.toml
+++ b/frame/ethereum/Cargo.toml
@@ -19,7 +19,7 @@ sp-runtime = { version = "3.0.0", default-features = false, git = "https://githu
 sp-std = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-evm = { version = "1.0.1-dev", default-features = false, path = "../../primitives/evm" }
-evm = { version = "0.25.0", features = ["with-codec"], default-features = false }
+evm = { version = "0.26.0", features = ["with-codec"], default-features = false }
 ethereum = { version = "0.7.1", default-features = false, features = ["with-codec"] }
 ethereum-types = { version = "0.11", default-features = false }
 rlp = { version = "0.5", default-features = false }

--- a/frame/ethereum/Cargo.toml
+++ b/frame/ethereum/Cargo.toml
@@ -14,11 +14,11 @@ frame-support = { version = "3.0.0", default-features = false, git = "https://gi
 frame-system = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 pallet-balances = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 pallet-timestamp = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-pallet-evm = { version = "3.0.1-dev", default-features = false, path = "../evm" }
+pallet-evm = { version = "3.1.0-dev", default-features = false, path = "../evm" }
 sp-runtime = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-std = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-fp-evm = { version = "1.0.1-dev", default-features = false, path = "../../primitives/evm" }
+fp-evm = { version = "1.1.0-dev", default-features = false, path = "../../primitives/evm" }
 evm = { version = "0.26.0", features = ["with-codec"], default-features = false }
 ethereum = { version = "0.7.1", default-features = false, features = ["with-codec"] }
 ethereum-types = { version = "0.11", default-features = false }
@@ -26,8 +26,8 @@ rlp = { version = "0.5", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 libsecp256k1 = { version = "0.3", default-features = false }
 fp-consensus = { version = "1.0.0", path = "../../primitives/consensus", default-features = false }
-fp-rpc = { version = "1.0.1-dev", path = "../../primitives/rpc", default-features = false }
-fp-storage = { version = "1.0.1-dev", path = "../../primitives/storage", default-features = false}
+fp-rpc = { version = "1.1.0-dev", path = "../../primitives/rpc", default-features = false }
+fp-storage = { version = "1.1.0-dev", path = "../../primitives/storage", default-features = false}
 
 [dev-dependencies]
 sp-core = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }

--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -26,9 +26,9 @@ sp-io = { version = "3.0.0", default-features = false, git = "https://github.com
 fp-evm = { version = "1.0.1-dev", default-features = false, path = "../../primitives/evm" }
 primitive-types = { version = "0.9.0", default-features = false, features = ["rlp", "byteorder"] }
 rlp = { version = "0.5", default-features = false }
-evm = { version = "0.25.0", default-features = false, features = ["with-codec"] }
-evm-runtime = { version = "0.25.0", default-features = false }
-evm-gasometer = { version = "0.25.0", default-features = false }
+evm = { version = "0.26.0", default-features = false, features = ["with-codec"] }
+evm-runtime = { version = "0.26.0", default-features = false }
+evm-gasometer = { version = "0.26.0", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 log = { version = "0.4", default-features = false }
 

--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -23,7 +23,7 @@ sp-core = { version = "3.0.0", default-features = false, git = "https://github.c
 sp-runtime = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-std = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-fp-evm = { version = "1.0.1-dev", default-features = false, path = "../../primitives/evm" }
+fp-evm = { version = "1.1.0-dev", default-features = false, path = "../../primitives/evm" }
 primitive-types = { version = "0.9.0", default-features = false, features = ["rlp", "byteorder"] }
 rlp = { version = "0.5", default-features = false }
 evm = { version = "0.26.0", default-features = false, features = ["with-codec"] }

--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-evm"
-version = "3.0.1-dev"
+version = "3.1.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/frame/evm/precompile/blake2/Cargo.toml
+++ b/frame/evm/precompile/blake2/Cargo.toml
@@ -12,7 +12,7 @@ description = "BLAKE2 precompiles for EVM pallet."
 sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-evm = { version = "1.0.1-dev", default-features = false, path = "../../../../primitives/evm" }
-evm = { version = "0.25.0", default-features = false, features = ["with-codec"] }
+evm = { version = "0.26.0", default-features = false, features = ["with-codec"] }
 
 [dev-dependencies]
 pallet-evm-test-vector-support = { version = "1.0.0-dev", path = "../../test-vector-support" }

--- a/frame/evm/precompile/blake2/Cargo.toml
+++ b/frame/evm/precompile/blake2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-evm-precompile-blake2"
-version = "1.1.0-dev"
+version = "1.2.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/frame/evm/precompile/blake2/Cargo.toml
+++ b/frame/evm/precompile/blake2/Cargo.toml
@@ -11,11 +11,11 @@ description = "BLAKE2 precompiles for EVM pallet."
 [dependencies]
 sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-fp-evm = { version = "1.0.1-dev", default-features = false, path = "../../../../primitives/evm" }
+fp-evm = { version = "1.1.0-dev", default-features = false, path = "../../../../primitives/evm" }
 evm = { version = "0.26.0", default-features = false, features = ["with-codec"] }
 
 [dev-dependencies]
-pallet-evm-test-vector-support = { version = "1.0.0-dev", path = "../../test-vector-support" }
+pallet-evm-test-vector-support = { version = "1.1.0-dev", path = "../../test-vector-support" }
 
 [features]
 default = ["std"]

--- a/frame/evm/precompile/bn128/Cargo.toml
+++ b/frame/evm/precompile/bn128/Cargo.toml
@@ -12,7 +12,7 @@ description = "BN128 precompiles for EVM pallet."
 sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-evm = { version = "1.0.1-dev", default-features = false, path = "../../../../primitives/evm" }
-evm = { version = "0.25.0", default-features = false, features = ["with-codec"] }
+evm = { version = "0.26.0", default-features = false, features = ["with-codec"] }
 bn = { package = "substrate-bn", version = "0.6", default-features = false }
 
 [dev-dependencies]

--- a/frame/evm/precompile/bn128/Cargo.toml
+++ b/frame/evm/precompile/bn128/Cargo.toml
@@ -11,12 +11,12 @@ description = "BN128 precompiles for EVM pallet."
 [dependencies]
 sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-fp-evm = { version = "1.0.1-dev", default-features = false, path = "../../../../primitives/evm" }
+fp-evm = { version = "1.1.0-dev", default-features = false, path = "../../../../primitives/evm" }
 evm = { version = "0.26.0", default-features = false, features = ["with-codec"] }
 bn = { package = "substrate-bn", version = "0.6", default-features = false }
 
 [dev-dependencies]
-pallet-evm-test-vector-support = { version = "1.0.0-dev", path = "../../test-vector-support" }
+pallet-evm-test-vector-support = { version = "1.1.0-dev", path = "../../test-vector-support" }
 
 [features]
 default = ["std"]

--- a/frame/evm/precompile/bn128/Cargo.toml
+++ b/frame/evm/precompile/bn128/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-evm-precompile-bn128"
-version = "2.0.0-dev"
+version = "2.1.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/frame/evm/precompile/dispatch/Cargo.toml
+++ b/frame/evm/precompile/dispatch/Cargo.toml
@@ -12,8 +12,8 @@ description = "DISPATCH precompiles for EVM pallet."
 sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 frame-support = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-pallet-evm = { version = "3.0.1-dev", default-features = false, path = "../.." }
-fp-evm = { version = "1.0.1-dev", default-features = false, path = "../../../../primitives/evm" }
+pallet-evm = { version = "3.1.0-dev", default-features = false, path = "../.." }
+fp-evm = { version = "1.1.0-dev", default-features = false, path = "../../../../primitives/evm" }
 evm = { version = "0.26.0", default-features = false, features = ["with-codec"] }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 

--- a/frame/evm/precompile/dispatch/Cargo.toml
+++ b/frame/evm/precompile/dispatch/Cargo.toml
@@ -14,7 +14,7 @@ sp-io = { version = "3.0.0", default-features = false, git = "https://github.com
 frame-support = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 pallet-evm = { version = "3.0.1-dev", default-features = false, path = "../.." }
 fp-evm = { version = "1.0.1-dev", default-features = false, path = "../../../../primitives/evm" }
-evm = { version = "0.25.0", default-features = false, features = ["with-codec"] }
+evm = { version = "0.26.0", default-features = false, features = ["with-codec"] }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 
 [features]

--- a/frame/evm/precompile/dispatch/Cargo.toml
+++ b/frame/evm/precompile/dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-evm-precompile-dispatch"
-version = "1.0.1-dev"
+version = "1.1.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/frame/evm/precompile/ed25519/Cargo.toml
+++ b/frame/evm/precompile/ed25519/Cargo.toml
@@ -11,7 +11,7 @@ description = "ED25519 precompiles for EVM pallet."
 [dependencies]
 sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-fp-evm = { version = "1.0.1-dev", default-features = false, path = "../../../../primitives/evm" }
+fp-evm = { version = "1.1.0-dev", default-features = false, path = "../../../../primitives/evm" }
 evm = { version = "0.26.0", default-features = false, features = ["with-codec"] }
 ed25519-dalek = { version = "1.0.0", features = ["alloc", "u64_backend"], default-features = false }
 

--- a/frame/evm/precompile/ed25519/Cargo.toml
+++ b/frame/evm/precompile/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-evm-precompile-ed25519"
-version = "1.0.1-dev"
+version = "1.1.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/frame/evm/precompile/ed25519/Cargo.toml
+++ b/frame/evm/precompile/ed25519/Cargo.toml
@@ -12,7 +12,7 @@ description = "ED25519 precompiles for EVM pallet."
 sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-evm = { version = "1.0.1-dev", default-features = false, path = "../../../../primitives/evm" }
-evm = { version = "0.25.0", default-features = false, features = ["with-codec"] }
+evm = { version = "0.26.0", default-features = false, features = ["with-codec"] }
 ed25519-dalek = { version = "1.0.0", features = ["alloc", "u64_backend"], default-features = false }
 
 [features]

--- a/frame/evm/precompile/modexp/Cargo.toml
+++ b/frame/evm/precompile/modexp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-evm-precompile-modexp"
-version = "1.1.0-dev"
+version = "1.2.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/frame/evm/precompile/modexp/Cargo.toml
+++ b/frame/evm/precompile/modexp/Cargo.toml
@@ -12,7 +12,7 @@ description = "MODEXP precompiles for EVM pallet."
 sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-evm = { version = "1.0.1-dev", default-features = false, path = "../../../../primitives/evm" }
-evm = { version = "0.25.0", default-features = false, features = ["with-codec"] }
+evm = { version = "0.26.0", default-features = false, features = ["with-codec"] }
 num = { version = "0.3", features = ["alloc"], default-features = false }
 
 [dev-dependencies]

--- a/frame/evm/precompile/modexp/Cargo.toml
+++ b/frame/evm/precompile/modexp/Cargo.toml
@@ -11,13 +11,13 @@ description = "MODEXP precompiles for EVM pallet."
 [dependencies]
 sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-fp-evm = { version = "1.0.1-dev", default-features = false, path = "../../../../primitives/evm" }
+fp-evm = { version = "1.1.0-dev", default-features = false, path = "../../../../primitives/evm" }
 evm = { version = "0.26.0", default-features = false, features = ["with-codec"] }
 num = { version = "0.3", features = ["alloc"], default-features = false }
 
 [dev-dependencies]
 hex = "0.4.0"
-pallet-evm-test-vector-support = { version = "1.0.0-dev", path = "../../test-vector-support" }
+pallet-evm-test-vector-support = { version = "1.1.0-dev", path = "../../test-vector-support" }
 
 [features]
 default = ["std"]

--- a/frame/evm/precompile/sha3fips/Cargo.toml
+++ b/frame/evm/precompile/sha3fips/Cargo.toml
@@ -11,7 +11,7 @@ description = "SHA3 FIPS202 precompile for EVM pallet."
 [dependencies]
 sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-fp-evm = { version = "1.0.1-dev", default-features = false, path = "../../../../primitives/evm" }
+fp-evm = { version = "1.1.0-dev", default-features = false, path = "../../../../primitives/evm" }
 evm = { version = "0.26.0", default-features = false, features = ["with-codec"] }
 tiny-keccak = { version = "2.0", features = ["fips202"] }
 

--- a/frame/evm/precompile/sha3fips/Cargo.toml
+++ b/frame/evm/precompile/sha3fips/Cargo.toml
@@ -12,7 +12,7 @@ description = "SHA3 FIPS202 precompile for EVM pallet."
 sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-evm = { version = "1.0.1-dev", default-features = false, path = "../../../../primitives/evm" }
-evm = { version = "0.25.0", default-features = false, features = ["with-codec"] }
+evm = { version = "0.26.0", default-features = false, features = ["with-codec"] }
 tiny-keccak = { version = "2.0", features = ["fips202"] }
 
 [features]

--- a/frame/evm/precompile/sha3fips/Cargo.toml
+++ b/frame/evm/precompile/sha3fips/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-evm-precompile-sha3fips"
-version = "1.0.1-dev"
+version = "1.1.0-dev"
 authors = ["Parity Technologies <admin@parity.io>", "Drew Stone <drew@commonwealth.im>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/frame/evm/precompile/simple/Cargo.toml
+++ b/frame/evm/precompile/simple/Cargo.toml
@@ -11,12 +11,12 @@ description = "Simple precompiles for EVM pallet."
 [dependencies]
 sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-fp-evm = { version = "1.0.1-dev", default-features = false, path = "../../../../primitives/evm" }
+fp-evm = { version = "1.1.0-dev", default-features = false, path = "../../../../primitives/evm" }
 evm = { version = "0.26.0", default-features = false, features = ["with-codec"] }
 ripemd160 = { version = "0.9", default-features = false }
 
 [dev-dependencies]
-pallet-evm-test-vector-support = { version = "1.0.0-dev", path = "../../test-vector-support" }
+pallet-evm-test-vector-support = { version = "1.1.0-dev", path = "../../test-vector-support" }
 
 [features]
 default = ["std"]

--- a/frame/evm/precompile/simple/Cargo.toml
+++ b/frame/evm/precompile/simple/Cargo.toml
@@ -12,7 +12,7 @@ description = "Simple precompiles for EVM pallet."
 sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-evm = { version = "1.0.1-dev", default-features = false, path = "../../../../primitives/evm" }
-evm = { version = "0.25.0", default-features = false, features = ["with-codec"] }
+evm = { version = "0.26.0", default-features = false, features = ["with-codec"] }
 ripemd160 = { version = "0.9", default-features = false }
 
 [dev-dependencies]

--- a/frame/evm/precompile/simple/Cargo.toml
+++ b/frame/evm/precompile/simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-evm-precompile-simple"
-version = "1.0.1-dev"
+version = "1.1.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/frame/evm/test-vector-support/Cargo.toml
+++ b/frame/evm/test-vector-support/Cargo.toml
@@ -12,7 +12,7 @@ description = "Test vector support for EVM pallet."
 hex = { version = "0.4.0", optional = true }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
-evm = { version = "0.25.0", default-features = false, features = ["with-codec"] }
+evm = { version = "0.26.0", default-features = false, features = ["with-codec"] }
 fp-evm = { version = "1.0.1-dev", default-features = false, path = "../../../primitives/evm" }
 
 [features]

--- a/frame/evm/test-vector-support/Cargo.toml
+++ b/frame/evm/test-vector-support/Cargo.toml
@@ -13,7 +13,7 @@ hex = { version = "0.4.0", optional = true }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 evm = { version = "0.26.0", default-features = false, features = ["with-codec"] }
-fp-evm = { version = "1.0.1-dev", default-features = false, path = "../../../primitives/evm" }
+fp-evm = { version = "1.1.0-dev", default-features = false, path = "../../../primitives/evm" }
 
 [features]
 default = ["std"]

--- a/frame/evm/test-vector-support/Cargo.toml
+++ b/frame/evm/test-vector-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-evm-test-vector-support"
-version = "1.0.0-dev"
+version = "1.1.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/primitives/evm/Cargo.toml
+++ b/primitives/evm/Cargo.toml
@@ -17,7 +17,7 @@ sp-core = { version = "3.0.0", git = "https://github.com/paritytech/substrate.gi
 sp-std = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier", default-features = false }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
-evm = { version = "0.25.0", default-features = false, features = ["with-codec"] }
+evm = { version = "0.26.0", default-features = false, features = ["with-codec"] }
 impl-trait-for-tuples = "0.1"
 
 [features]

--- a/primitives/evm/Cargo.toml
+++ b/primitives/evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fp-evm"
-version = "1.0.1-dev"
+version = "1.1.0-dev"
 license = "Apache-2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"

--- a/primitives/rpc/Cargo.toml
+++ b/primitives/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fp-rpc"
-version = "1.0.1-dev"
+version = "1.1.0-dev"
 authors = ["Parity Technologies <admin@parity.io"]
 edition = "2018"
 description = "Runtime primitives for Ethereum RPC (web3) compatibility layer for Substrate."
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 [dependencies]
 sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-api = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-fp-evm = { version = "1.0.1-dev", default-features = false, path = "../../primitives/evm" }
+fp-evm = { version = "1.1.0-dev", default-features = false, path = "../../primitives/evm" }
 ethereum = { version = "0.7.1", default-features = false, features = ["with-codec"] }
 ethereum-types = { version = "0.11", default-features = false }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }

--- a/primitives/storage/Cargo.toml
+++ b/primitives/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fp-storage"
-version = "1.0.1-dev"
+version = "1.1.0-dev"
 authors = ["Parity Technologies <admin@parity.io"]
 edition = "2018"
 description = "Storage primitives for Ethereum RPC (web3) compatibility layer for Substrate."
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 [dependencies]
 sp-core = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-api = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-fp-evm = { version = "1.0.1-dev", default-features = false, path = "../../primitives/evm" }
+fp-evm = { version = "1.1.0-dev", default-features = false, path = "../../primitives/evm" }
 ethereum = { version = "0.7.1", default-features = false, features = ["with-codec"] }
 ethereum-types = { version = "0.11", default-features = false }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }


### PR DESCRIPTION
This PR updates the `evm` dependency to the published version 0.26.0.

@sorpaas I tried to get the rolling release stuff right, but I'm not confident. I'm pretty confident I bumped all the right crates, but I'm not confident whether a minor bump was right. I made each one in its own commit so they are easy to revert if they are wrong.