### PR TITLE
Optional `net_peerCount` response format

### DIFF
--- a/client/rpc-core/src/net.rs
+++ b/client/rpc-core/src/net.rs
@@ -19,6 +19,7 @@
 //! Net rpc interface.
 use jsonrpc_core::Result;
 use jsonrpc_derive::rpc;
+use crate::types::PeerCount;
 
 pub use rpc_impl_NetApi::gen_server::NetApi as NetApiServer;
 
@@ -31,7 +32,7 @@ pub trait NetApi {
 
 	/// Returns number of peers connected to node.
 	#[rpc(name = "net_peerCount")]
-	fn peer_count(&self) -> Result<u32>;
+	fn peer_count(&self) -> Result<PeerCount>;
 
 	/// Returns true if client is actively listening for network connections.
 	/// Otherwise false.

--- a/client/rpc-core/src/types/mod.rs
+++ b/client/rpc-core/src/types/mod.rs
@@ -48,7 +48,7 @@ pub use self::log::Log;
 pub use self::receipt::Receipt;
 pub use self::sync::{
 	SyncStatus, SyncInfo, Peers, PeerInfo, PeerNetworkInfo, PeerProtocolsInfo,
-	TransactionStats, ChainStatus, EthProtocolInfo, PipProtocolInfo,
+	TransactionStats, ChainStatus, EthProtocolInfo, PipProtocolInfo, PeerCount,
 };
 pub use self::transaction::{
 	Transaction, RichRawTransaction, LocalTransactionStatus, PendingTransactions, PendingTransaction,

--- a/client/rpc-core/src/types/sync.rs
+++ b/client/rpc-core/src/types/sync.rs
@@ -50,6 +50,12 @@ pub struct Peers {
 	pub peers: Vec<PeerInfo>,
 }
 
+#[derive(Debug, Serialize)]
+pub enum PeerCount {
+	U32(u32),
+	String(String)
+}
+
 /// Peer connection information
 #[derive(Default, Debug, Serialize)]
 pub struct PeerInfo {

--- a/client/rpc-core/src/types/sync.rs
+++ b/client/rpc-core/src/types/sync.rs
@@ -51,6 +51,7 @@ pub struct Peers {
 }
 
 #[derive(Debug, Serialize)]
+#[serde(untagged)]
 pub enum PeerCount {
 	U32(u32),
 	String(String)

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -1208,9 +1208,10 @@ impl<B: BlockT, BE, C, H: ExHashT> NetApiT for NetApi<B, BE, C, H> where
 	fn peer_count(&self) -> Result<PeerCount> {
 		let peer_count = self.network.num_connected();
 		Ok(
-		match self.peer_count_as_hex {
-			true => PeerCount::String(format!("0x{:x}", peer_count)),
-			false => PeerCount::U32(peer_count as u32);
+			match self.peer_count_as_hex {
+				true => PeerCount::String(format!("0x{:x}", peer_count)),
+				false => PeerCount::U32(peer_count as u32)
+			}
 		)
 	}
 

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -1207,10 +1207,11 @@ impl<B: BlockT, BE, C, H: ExHashT> NetApiT for NetApi<B, BE, C, H> where
 
 	fn peer_count(&self) -> Result<PeerCount> {
 		let peer_count = self.network.num_connected();
-		if self.peer_count_as_hex {
-			return Ok(PeerCount::String(format!("0x{:x}", peer_count)));
-		}
-		return Ok(PeerCount::U32(peer_count as u32));
+		Ok(
+		match self.peer_count_as_hex {
+			true => PeerCount::String(format!("0x{:x}", peer_count)),
+			false => PeerCount::U32(peer_count as u32);
+		)
 	}
 
 	fn version(&self) -> Result<String> {

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -39,7 +39,7 @@ use fc_rpc_core::{
 use fc_rpc_core::types::{
 	BlockNumber, Bytes, CallRequest, Filter, FilteredParams, FilterChanges, FilterPool, FilterPoolItem,
 	FilterType, Index, Log, Receipt, RichBlock, SyncStatus, SyncInfo, Transaction, Work, Rich, Block,
-	BlockTransactions, TransactionRequest, PendingTransactions, PendingTransaction,
+	BlockTransactions, TransactionRequest, PendingTransactions, PendingTransaction, PeerCount,
 };
 use fp_rpc::{EthereumRuntimeRPCApi, ConvertTransaction, TransactionStatus};
 use crate::{frontier_backend_client, internal_err, error_on_execution_failure, EthSigner, public_key};
@@ -1173,6 +1173,7 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 pub struct NetApi<B: BlockT, BE, C, H: ExHashT> {
 	client: Arc<C>,
 	network: Arc<NetworkService<B, H>>,
+	peer_count_as_hex: bool,
 	_marker: PhantomData<BE>,
 }
 
@@ -1180,10 +1181,12 @@ impl<B: BlockT, BE, C, H: ExHashT> NetApi<B, BE, C, H> {
 	pub fn new(
 		client: Arc<C>,
 		network: Arc<NetworkService<B, H>>,
+		peer_count_as_hex: bool,
 	) -> Self {
 		Self {
 			client,
 			network,
+			peer_count_as_hex,
 			_marker: PhantomData,
 		}
 	}
@@ -1202,8 +1205,12 @@ impl<B: BlockT, BE, C, H: ExHashT> NetApiT for NetApi<B, BE, C, H> where
 		Ok(true)
 	}
 
-	fn peer_count(&self) -> Result<u32> {
-		Ok(self.network.num_connected() as u32)
+	fn peer_count(&self) -> Result<PeerCount> {
+		let peer_count = self.network.num_connected();
+		if self.peer_count_as_hex {
+			return Ok(PeerCount::String(format!("0x{:x}", peer_count)));
+		}
+		return Ok(PeerCount::U32(peer_count as u32));
 	}
 
 	fn version(&self) -> Result<String> {

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -153,6 +153,8 @@ pub fn create_full<C, P, BE>(
 		NetApiServer::to_delegate(NetApi::new(
 			client.clone(),
 			network.clone(),
+			// Whether to format the `peer_count` response as Hex or not.
+			false,
 		))
 	);
 

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -153,8 +153,8 @@ pub fn create_full<C, P, BE>(
 		NetApiServer::to_delegate(NetApi::new(
 			client.clone(),
 			network.clone(),
-			// Whether to format the `peer_count` response as Hex or not.
-			false,
+			// Whether to format the `peer_count` response as Hex (default) or not.
+			true,
 		))
 	);
 

--- a/ts-tests/tests/test-netapi.ts
+++ b/ts-tests/tests/test-netapi.ts
@@ -1,0 +1,16 @@
+import { expect } from "chai";
+import { step } from "mocha-steps";
+
+import { createAndFinalizeBlock, describeWithFrontier, customRequest } from "./util";
+
+describeWithFrontier("Frontier RPC (Net)", (context) => {
+	step("should return `net_version` 42", async function () {
+		expect(await context.web3.eth.net.getId()).to.equal(42);
+	});
+	step("should return `peer_count` in hex directly using the provider", async function () {
+		expect((await customRequest(context.web3, "net_peerCount", [])).result).to.be.eq("0x0");
+	});
+	step("should format `peer_count` as decimal using `web3.net`", async function () {
+		expect(await context.web3.eth.net.getPeerCount()).to.equal(0);
+	});
+});


### PR DESCRIPTION
There are inconsistencies on the response format expected when calling `net_peerCount`. Some tools/dapps expect decimal format, others hex.

This PR adds a bool `peer_count_as_hex` parameter to `NetApi`, so projects instantiating the handler at service level can decide which format to use. Defaulted to `false` in the template.