### PR TITLE
Update worker log level

### DIFF
--- a/client/mapping-sync/src/worker.rs
+++ b/client/mapping-sync/src/worker.rs
@@ -27,7 +27,7 @@ use sc_client_api::BlockOf;
 use sp_blockchain::HeaderBackend;
 use fp_rpc::EthereumRuntimeRPCApi;
 use futures_timer::Delay;
-use log::warn;
+use log::debug;
 
 const LIMIT: usize = 8;
 
@@ -114,7 +114,7 @@ impl<Block: BlockT, C, B> Stream for MappingSyncWorker<Block, C, B> where
 				},
 				Err(e) => {
 					self.have_next = false;
-					warn!(target: "mapping-sync", "Syncing failed with error {:?}, retrying.", e);
+					debug!(target: "mapping-sync", "Syncing failed with error {:?}, retrying.", e);
 					Poll::Ready(Some(()))
 				},
 			}


### PR DESCRIPTION
These mapping worker logs might be confusing and easy to be misunderstood as a synchronization problem.

![image](https://user-images.githubusercontent.com/11801722/117608785-59ce5200-b191-11eb-9fa0-8811d6b81875.png)
