### PR TITLE
Remove TargetMinGasPrice event

### DIFF
--- a/frame/dynamic-fee/src/lib.rs
+++ b/frame/dynamic-fee/src/lib.rs
@@ -60,6 +60,11 @@ decl_module! {
 	pub struct Module<T: Config> for enum Call where origin: T::Origin {
 		fn deposit_event() = default;
 
+		fn on_initialize(_block_number: T::BlockNumber) -> Weight {
+			TargetMinGasPrice::kill();
+			0
+		}
+
 		fn on_finalize(n: T::BlockNumber) {
 			if let Some(target) = TargetMinGasPrice::get() {
 				let bound = MinGasPrice::get() / T::MinGasPriceBoundDivisor::get() + U256::one();
@@ -69,8 +74,6 @@ decl_module! {
 
 				MinGasPrice::set(min(upper_limit, max(lower_limit, target)));
 			}
-
-			TargetMinGasPrice::kill();
 		}
 
 		#[weight = 0]
@@ -81,7 +84,6 @@ decl_module! {
 			ensure_none(origin)?;
 
 			TargetMinGasPrice::set(Some(target));
-			Self::deposit_event(Event::TargetMinGasPriceSet(target));
 		}
 	}
 }

--- a/frame/dynamic-fee/src/lib.rs
+++ b/frame/dynamic-fee/src/lib.rs
@@ -27,7 +27,7 @@ use sp_inherents::{InherentIdentifier, InherentData, ProvideInherent, IsFatalErr
 use sp_inherents::ProvideInherentData;
 use frame_support::{
 	decl_module, decl_storage, decl_event,
-	traits::Get,
+	traits::Get, weights::Weight,
 };
 use frame_system::ensure_none;
 
@@ -62,7 +62,8 @@ decl_module! {
 
 		fn on_initialize(_block_number: T::BlockNumber) -> Weight {
 			TargetMinGasPrice::kill();
-			0
+
+			T::DbWeight::get().writes(1)
 		}
 
 		fn on_finalize(n: T::BlockNumber) {
@@ -76,7 +77,7 @@ decl_module! {
 			}
 		}
 
-		#[weight = 0]
+		#[weight = T::DbWeight::get().writes(1)]
 		fn note_min_gas_price_target(
 			origin,
 			target: U256,

--- a/frame/dynamic-fee/src/lib.rs
+++ b/frame/dynamic-fee/src/lib.rs
@@ -51,9 +51,7 @@ decl_storage! {
 }
 
 decl_event!(
-	pub enum Event {
-		TargetMinGasPriceSet(U256),
-	}
+	pub enum Event {}
 );
 
 decl_module! {

--- a/frame/dynamic-fee/src/lib.rs
+++ b/frame/dynamic-fee/src/lib.rs
@@ -32,8 +32,6 @@ use frame_support::{
 use frame_system::ensure_none;
 
 pub trait Config: frame_system::Config {
-	/// The overarching event type.
-	type Event: From<Event> + Into<<Self as frame_system::Config>::Event>;
 	/// Bound divisor for min gas price.
 	type MinGasPriceBoundDivisor: Get<U256>;
 }
@@ -50,14 +48,8 @@ decl_storage! {
 	}
 }
 
-decl_event!(
-	pub enum Event {}
-);
-
 decl_module! {
 	pub struct Module<T: Config> for enum Call where origin: T::Origin {
-		fn deposit_event() = default;
-
 		fn on_initialize(_block_number: T::BlockNumber) -> Weight {
 			TargetMinGasPrice::kill();
 

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -25,7 +25,8 @@
 
 use frame_support::{
 	decl_module, decl_storage, decl_error, decl_event,
-	traits::Get, traits::FindAuthor, weights::Weight,
+	traits::Get, traits::FindAuthor,
+	weights::{Pays, PostDispatchInfo, Weight},
 	dispatch::DispatchResultWithPostInfo,
 };
 use sp_std::prelude::*;
@@ -400,7 +401,10 @@ impl<T: Config> Module<T> {
 		Pending::append((transaction, status, receipt));
 
 		Self::deposit_event(Event::Executed(source, contract_address.unwrap_or_default(), transaction_hash, reason));
-		Ok(Some(T::GasWeightMapping::gas_to_weight(used_gas.unique_saturated_into())).into())
+		Ok(PostDispatchInfo {
+			actual_weight: Some(T::GasWeightMapping::gas_to_weight(used_gas.unique_saturated_into())),
+			pays_fee: Pays::No,
+		}).into()
 	}
 
 	/// Get the author using the FindAuthor trait.

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -319,7 +319,6 @@ frame_support::parameter_types! {
 }
 
 impl pallet_dynamic_fee::Config for Runtime {
-	type Event = Event;
 	type MinGasPriceBoundDivisor = BoundDivision;
 }
 
@@ -340,7 +339,7 @@ construct_runtime!(
 		Sudo: pallet_sudo::{Module, Call, Config<T>, Storage, Event<T>},
 		Ethereum: pallet_ethereum::{Module, Call, Storage, Event, Config, ValidateUnsigned},
 		EVM: pallet_evm::{Module, Config, Call, Storage, Event<T>},
-		DynamicFee: pallet_dynamic_fee::{Module, Call, Storage, Config, Event, Inherent},
+		DynamicFee: pallet_dynamic_fee::{Module, Call, Storage, Config, Inherent},
 	}
 );
 


### PR DESCRIPTION
1. There is no need to output the target gas price event for each block.
2. Move `kill()` into the `on_initialize`, then you can viewTargetMinGasPrice value in explorer.
3. Add `Pays::No` in ethereum transact call.

![image](https://user-images.githubusercontent.com/11801722/119354757-069ee800-bcd7-11eb-8966-89128bc4c1ba.png)
