### PR TITLE
Use `skip_initialize_block` for `call` and `create`

### DIFF
--- a/primitives/rpc/src/lib.rs
+++ b/primitives/rpc/src/lib.rs
@@ -64,6 +64,7 @@ sp_api::decl_runtime_apis! {
 		/// For a given account address and index, returns pallet_evm::AccountStorages.
 		fn storage_at(address: H160, index: U256) -> H256;
 		/// Returns a frame_ethereum::call response. If `estimate` is true,
+		#[skip_initialize_block]
 		fn call(
 			from: H160,
 			to: H160,
@@ -75,6 +76,7 @@ sp_api::decl_runtime_apis! {
 			estimate: bool,
 		) -> Result<fp_evm::CallInfo, sp_runtime::DispatchError>;
 		/// Returns a frame_ethereum::create response.
+		#[skip_initialize_block]
 		fn create(
 			from: H160,
 			data: Vec<u8>,

--- a/ts-tests/contracts/Test.sol
+++ b/ts-tests/contracts/Test.sol
@@ -4,4 +4,7 @@ contract Test {
     function multiply(uint a) public pure returns(uint d) {
         return a * 7;
     }
+    function currentBlock() public view  returns(uint) {
+        return block.number;
+    }
 }

--- a/ts-tests/tests/test-contract-methods.ts
+++ b/ts-tests/tests/test-contract-methods.ts
@@ -45,6 +45,18 @@ describeWithFrontier("Frontier RPC (Contract Methods)", (context) => {
 
 		expect(await contract.methods.multiply(3).call()).to.equal("21");
 	});
+	it("should get correct environmental block number", async function () {
+		// Solidity `block.number` is expected to return the same height at which the runtime call was made.
+		const contract = new context.web3.eth.Contract(TEST_CONTRACT_ABI, FIRST_CONTRACT_ADDRESS, {
+			from: GENESIS_ACCOUNT,
+			gasPrice: "0x01",
+		});
+		let block = await context.web3.eth.getBlock("latest");
+		expect(await contract.methods.currentBlock().call()).to.eq(block.number.toString());
+		await createAndFinalizeBlock(context.web3);
+		block = await context.web3.eth.getBlock("latest");
+		expect(await contract.methods.currentBlock().call()).to.eq(block.number.toString());
+	});
 
 	// Requires error handling
 	it.skip("should fail for missing parameters", async function () {

--- a/ts-tests/tests/test-gas.ts
+++ b/ts-tests/tests/test-gas.ts
@@ -17,7 +17,7 @@ describeWithFrontier("Frontier RPC (Gas)", (context) => {
 				from: GENESIS_ACCOUNT,
 				data: Test.bytecode,
 			})
-		).to.equal(149143);
+		).to.equal(159715);
 	});
 
 	it.skip("block gas limit over 5M", async function () {


### PR DESCRIPTION
`#[skip_initialize_block]` prevents block `X` initialization for the `call` and `create` runtime api methods. Without it, `frame_system` will initialize it's state to block number `X+1`.

### Expected behaviour

Solidity `block.number` is expected to return the same height at which the runtime call was made. `frame_system::block_number` is used to get the environmental block number from within the evm execution context.

To reproduce this on Kovan:

- Copy code below in a `test.js` file (replace `{TOKEN}` with your token).
- `npm init && npm i ethers && node test.js`

```
// [test.js]

const ethers = require('ethers');
const providerRPC = {
  kovan: {
    name: 'kovan',
    rpc: 'https://eth-kovan.alchemyapi.io/v2/{TOKEN}',
    chainId: 42,
  },
};
let abi = [
  {
    inputs: [],
    stateMutability: 'nonpayable',
    type: 'constructor',
  },
  {
    inputs: [],
    name: 'currentBlock',
    outputs: [
      {
        internalType: 'uint256',
        name: '',
        type: 'uint256',
      },
    ],
    stateMutability: 'view',
    type: 'function',
  },
];
// Already deployed contract
let contractAddress = '0xEfb82E63fED441222e7c2aF1c3cd30CDb612B854';
const provider = new ethers.providers.StaticJsonRpcProvider(
  providerRPC.kovan.rpc,
  {
    chainId: providerRPC.kovan.chainId,
    name: providerRPC.kovan.name,
  }
);
const blockNumber = async () => {
  const contractDeployed = new ethers.Contract(contractAddress, abi, provider);
  const ethersBlock = await provider.getBlockNumber();
  console.log(`Ethers block ${ethersBlock}`); // i.e. 25403776
  const contractBlock = await contractDeployed.currentBlock();
  console.log(`Contract block ${contractBlock}`); // i.e. 25403776
};
blockNumber(); 
```



