### PR TITLE
Use `TransactionPool` notification stream in pusbub

### DIFF
--- a/client/rpc/src/eth_pubsub.rs
+++ b/client/rpc/src/eth_pubsub.rs
@@ -28,8 +28,6 @@ use sp_runtime::traits::{
 use sp_transaction_pool::TransactionPool;
 use sp_api::{ProvideRuntimeApi, BlockId};
 use sp_blockchain::{Error as BlockChainError, HeaderMetadata, HeaderBackend};
-use sp_storage::{StorageKey, StorageData};
-use sp_io::hashing::twox_128;
 use sc_client_api::{
 	backend::{StorageProvider, Backend, StateBackend},
 	client::BlockchainEvents
@@ -47,14 +45,13 @@ use fc_rpc_core::types::{
 	pubsub::{Kind, Params, Result as PubSubResult, PubSubSyncStatus}
 };
 use ethereum_types::{H256, U256};
-use codec::Decode;
 use sha3::{Keccak256, Digest};
 
 pub use fc_rpc_core::EthPubSubApiServer;
 use futures::{StreamExt as _, TryStreamExt as _};
 
 use jsonrpc_core::{Result as JsonRpcResult, futures::{Future, Sink}};
-use fp_rpc::{EthereumRuntimeRPCApi, TransactionStatus};
+use fp_rpc::EthereumRuntimeRPCApi;
 
 use sc_network::{NetworkService, ExHashT};
 
@@ -238,10 +235,6 @@ impl SubscriptionResult {
 		}
 		true
 	}
-}
-
-fn storage_prefix_build(module: &[u8], storage: &[u8]) -> Vec<u8> {
-	[twox_128(module), twox_128(storage)].concat().to_vec()
 }
 
 impl<B: BlockT, P, C, BE, H: ExHashT> EthPubSubApiT for EthPubSubApi<B, P, C, BE, H>

--- a/client/rpc/src/eth_pubsub.rs
+++ b/client/rpc/src/eth_pubsub.rs
@@ -85,7 +85,7 @@ impl IdProvider for HexEncodedIdProvider {
 }
 
 pub struct EthPubSubApi<B: BlockT, P, C, BE, H: ExHashT> {
-	_pool: Arc<P>,
+	pool: Arc<P>,
 	client: Arc<C>,
 	network: Arc<NetworkService<B, H>>,
 	subscriptions: SubscriptionManager<HexEncodedIdProvider>,
@@ -100,14 +100,14 @@ impl<B: BlockT, P, C, BE, H: ExHashT> EthPubSubApi<B, P, C, BE, H> where
 	C: Send + Sync + 'static,
 {
 	pub fn new(
-		_pool: Arc<P>,
+		pool: Arc<P>,
 		client: Arc<C>,
 		network: Arc<NetworkService<B, H>>,
 		subscriptions: SubscriptionManager<HexEncodedIdProvider>,
 		overrides: Arc<OverrideHandle<B>>,
 	) -> Self {
 		Self {
-			_pool,
+			pool: pool.clone(),
 			client: client.clone(),
 			network,
 			subscriptions,
@@ -270,6 +270,7 @@ impl<B: BlockT, P, C, BE, H: ExHashT> EthPubSubApiT for EthPubSubApi<B, P, C, BE
 		};
 
 		let client = self.client.clone();
+		let pool = self.pool.clone();
 		let network = self.network.clone();
 		let overrides = self.overrides.clone();
 		match kind {
@@ -354,58 +355,47 @@ impl<B: BlockT, P, C, BE, H: ExHashT> EthPubSubApiT for EthPubSubApi<B, P, C, BE
 				});
 			},
 			Kind::NewPendingTransactions => {
-				if let Ok(stream) = client.storage_changes_notification_stream(
-					Some(&[StorageKey(
-						storage_prefix_build(b"Ethereum", b"Pending")
-					)]),
-					None
-				) {
-					self.subscriptions.add(subscriber, |sink| {
-						let stream = stream
-						.flat_map(|(_block, changes)| {
-							let mut transactions: Vec<ethereum::Transaction> = vec![];
-							let storage: Vec<Option<StorageData>> = changes.iter()
-								.filter_map(|(o_sk, _k, v)| {
-									if o_sk.is_none() {
-										Some(v.cloned())
-									} else { None }
-								}).collect();
-							for change in storage {
-								if let Some(data) = change {
-									let storage: Vec<(
-										ethereum::Transaction,
-										TransactionStatus,
-										ethereum::Receipt
-									)> = Decode::decode(&mut &data.0[..]).unwrap();
-									let tmp: Vec<ethereum::Transaction> =
-										storage.iter().map(|x| x.0.clone()).collect();
-									transactions.extend(tmp);
-								}
-							}
-							futures::stream::iter(transactions)
-						})
-						.map(|transaction| {
-							return Ok::<Result<
-								PubSubResult,
-								jsonrpc_core::types::error::Error
-							>, ()>(Ok(
-								PubSubResult::TransactionHash(H256::from_slice(
-									Keccak256::digest(
-										&rlp::encode(&transaction)
-									).as_slice()
-								))
-							));
-						})
-						.compat();
-
-						sink
-							.sink_map_err(|e| warn!(
-								"Error sending notifications: {:?}", e
+				use sp_transaction_pool::InPoolTransaction;
+				self.subscriptions.add(subscriber, move |sink| {
+					let stream = pool.import_notification_stream()
+					.filter_map(move |txhash| {
+						if let Some(xt) = pool.ready_transaction(&txhash) {
+							let best_block: BlockId<B> = BlockId::Hash(client.info().best_hash);
+							let res = match client.runtime_api().extrinsic_filter(
+								&best_block, vec![xt.data().clone()]
+							) {
+								Ok(txs) => if txs.len() == 1 {
+									Some(txs[0].clone())
+								} else {
+									None
+								},
+								_ => None
+							};
+							futures::future::ready(res)
+						} else {
+							futures::future::ready(None)
+						}
+					})
+					.map(|transaction| {
+						return Ok::<Result<
+							PubSubResult,
+							jsonrpc_core::types::error::Error
+						>, ()>(Ok(
+							PubSubResult::TransactionHash(H256::from_slice(
+								Keccak256::digest(
+									&rlp::encode(&transaction)
+								).as_slice()
 							))
-							.send_all(stream)
-							.map(|_| ())
-					});
-				}
+						));
+					})
+					.compat();
+					sink
+						.sink_map_err(|e| warn!(
+							"Error sending notifications: {:?}", e
+						))
+						.send_all(stream)
+						.map(|_| ())
+				});
 			},
 			Kind::Syncing => {
 				self.subscriptions.add(subscriber, |sink| {

--- a/primitives/rpc/src/lib.rs
+++ b/primitives/rpc/src/lib.rs
@@ -22,6 +22,7 @@ use ethereum::{Log, Block as EthereumBlock};
 use ethereum_types::Bloom;
 use codec::{Encode, Decode};
 use sp_std::vec::Vec;
+use sp_runtime::traits::Block as BlockT;
 
 #[derive(Eq, PartialEq, Clone, Encode, Decode, sp_runtime::RuntimeDebug)]
 pub struct TransactionStatus {
@@ -98,6 +99,10 @@ sp_api::decl_runtime_apis! {
 			Option<Vec<ethereum::Receipt>>,
 			Option<Vec<TransactionStatus>>
 		);
+		/// Receives a `Vec<OpaqueExtrinsic>` and filters all the ethereum transactions.
+		fn extrinsic_filter(
+			xts: Vec<<Block as BlockT>::Extrinsic>,
+		) -> Vec<ethereum::Transaction>;
 	}
 }
 

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -48,6 +48,7 @@ use pallet_evm::{
 };
 use fp_rpc::TransactionStatus;
 use pallet_transaction_payment::CurrencyAdapter;
+use pallet_ethereum::{Transaction as EthereumTransaction, Call::transact};
 
 /// Type of block number.
 pub type BlockNumber = u32;
@@ -576,6 +577,15 @@ impl_runtime_apis! {
 				Ethereum::current_receipts(),
 				Ethereum::current_transaction_statuses()
 			)
+		}
+
+		fn extrinsic_filter(
+			xts: Vec<<Block as BlockT>::Extrinsic>,
+		) -> Vec<EthereumTransaction> {
+			xts.into_iter().filter_map(|xt| match xt.function {
+				Call::Ethereum(transact(t)) => Some(t),
+				_ => None
+			}).collect::<Vec<EthereumTransaction>>()
 		}
 	}
 

--- a/ts-tests/tests/test-subscription.ts
+++ b/ts-tests/tests/test-subscription.ts
@@ -96,7 +96,6 @@ describeWithFrontier("Frontier RPC (Subscription)", (context) => {
 		const tx = await sendTransaction(context);
 		let data = null;
 		await new Promise((resolve) => {
-			createAndFinalizeBlock(context.web3);
 			subscription.on("data", function (d: any) {
 				data = d;
 				logs_generated += 1;
@@ -107,6 +106,7 @@ describeWithFrontier("Frontier RPC (Subscription)", (context) => {
 
 		expect(data).to.be.not.null;
 		expect(tx["transactionHash"]).to.be.eq(data);
+		await createAndFinalizeBlock(context.web3);
 		setTimeout(done,10000);
 	}).timeout(20000);
 


### PR DESCRIPTION
In `Kind::NewPendingTransactions`, current approach of subscribing to storage changes t is not good for many reasons, and will lead to problems because:

- currently it does not make use of the schema overrides. This is not critical, as subscriptions are "from now on", but still incorrect as may force to do a client upgrade when doing a runtime upgrade that affects that storage item.
- Moreover, is coupled to the pallet-ethereum storage when this has nothing to do with storage.
- `pallet-ethereum::Pending` data is appended when the transact dispatchable is actually dispatched, not when the unsigned extrinsic is preliminarily added to the pool. The pending transaction WS subscription is supposed to notify the subscriber when the transaction is in the ready queue, not when whatever we do in pallet-ethereum.

Instead we want to:

- Listen for [`TransactionPool` notifications](https://crates.parity.io/sc_service/trait.TransactionPool.html#tymethod.import_notification_stream). Internally this will use the `ValidatedPool` to get transactions that are on the **ready** queue. 
- This will get us a `TxHash`, which we can use to [get the extrinsic](https://crates.parity.io/sp_transaction_pool/trait.TransactionPool.html#tymethod.ready_transaction).
- Then use the runtime to get back a known type we can deal with (`ethereum::Transaction`).

Then hash it as we do now and notify the subscriber.

**Note**

This includes some duplicated code (runtime api method) with #403 to illustrate how it works, it will be fused once one of them goes through.

