### PR TITLE
Fix remaining release issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2213,6 +2213,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac-drbg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
+dependencies = [
+ "digest 0.9.0",
+ "generic-array 0.14.4",
+ "hmac 0.8.1",
+]
+
+[[package]]
 name = "http"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3263,7 +3274,7 @@ dependencies = [
  "arrayref",
  "crunchy",
  "digest 0.8.1",
- "hmac-drbg",
+ "hmac-drbg 0.2.0",
  "rand 0.7.3",
  "sha2 0.8.2",
  "subtle 2.4.0",
@@ -3279,19 +3290,21 @@ dependencies = [
  "arrayref",
  "base64 0.12.3",
  "digest 0.9.0",
+ "hmac-drbg 0.3.0",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.7.3",
  "serde",
  "sha2 0.9.3",
+ "typenum",
 ]
 
 [[package]]
 name = "libsecp256k1-core"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daaa407ce05dc49849836840fb2542edcadafc4f55e314840cbb5b49359a6919"
+checksum = "4ee11012b293ea30093c129173cac4335513064094619f4639a25b310fd33c11"
 dependencies = [
  "crunchy",
  "digest 0.9.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "fc-mapping-sync"
-version = "2.0.0"
+version = "2.0.0-dev"
 dependencies = [
  "fc-consensus",
  "fc-db",

--- a/client/mapping-sync/Cargo.toml
+++ b/client/mapping-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fc-mapping-sync"
-version = "2.0.0"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 description = "Mapping sync logic for Frontier."
@@ -12,9 +12,9 @@ sp-blockchain = { version = "3.0.0", git = "https://github.com/paritytech/substr
 sc-client-api = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-api = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 fp-consensus = { version = "1.0.0", path = "../../primitives/consensus" }
-fc-consensus = { version = "2.0.0", path = "../consensus" }
+fc-consensus = { version = "2.0.0-dev", path = "../consensus" }
 fc-db = { version = "1.0.0", path = "../db" }
-fp-rpc = { version = "2.0.0", path = "../../primitives/rpc" }
+fp-rpc = { version = "2.0.0-dev", path = "../../primitives/rpc" }
 futures = { version = "0.3.1", features = ["compat"] }
 futures-timer = "3.0.1"
 log = "0.4.8"

--- a/frame/ethereum/Cargo.toml
+++ b/frame/ethereum/Cargo.toml
@@ -24,7 +24,7 @@ ethereum = { version = "0.7.1", default-features = false, features = ["with-code
 ethereum-types = { version = "0.11", default-features = false }
 rlp = { version = "0.5", default-features = false }
 sha3 = { version = "0.8", default-features = false }
-libsecp256k1 = { version = "0.5", default-features = false }
+libsecp256k1 = { version = "0.5", default-features = false, features = ["static-context", "hmac"] }
 fp-consensus = { version = "1.0.0", path = "../../primitives/consensus", default-features = false }
 fp-rpc = { version = "2.0.0", path = "../../primitives/rpc", default-features = false }
 fp-storage = { version = "1.0.1", path = "../../primitives/storage", default-features = false}

--- a/frame/ethereum/src/mock.rs
+++ b/frame/ethereum/src/mock.rs
@@ -179,8 +179,8 @@ pub struct AccountInfo {
 
 fn address_build(seed: u8) -> AccountInfo {
 	let private_key = H256::from_slice(&[(seed + 1) as u8; 32]); //H256::from_low_u64_be((i + 1) as u64);
-	let secret_key = secp256k1::SecretKey::parse_slice(&private_key[..]).unwrap();
-	let public_key = &secp256k1::PublicKey::from_secret_key(&secret_key).serialize()[1..65];
+	let secret_key = libsecp256k1::SecretKey::parse_slice(&private_key[..]).unwrap();
+	let public_key = &libsecp256k1::PublicKey::from_secret_key(&secret_key).serialize()[1..65];
 	let address = H160::from(H256::from_slice(
 		&Keccak256::digest(public_key)[..],
 	));
@@ -267,8 +267,8 @@ impl UnsignedTransaction {
 
 	pub fn sign(&self, key: &H256) -> Transaction {
 		let hash = self.signing_hash();
-		let msg = secp256k1::Message::parse(hash.as_fixed_bytes());
-		let s = secp256k1::sign(&msg, &secp256k1::SecretKey::parse_slice(&key[..]).unwrap());
+		let msg = libsecp256k1::Message::parse(hash.as_fixed_bytes());
+		let s = libsecp256k1::sign(&msg, &libsecp256k1::SecretKey::parse_slice(&key[..]).unwrap());
 		let sig = s.0.serialize();
 
 		let sig = TransactionSignature::new(


### PR DESCRIPTION
### Partial rolling releases

We're going to switch to partial rolling releases due to lack of corresponding Substrate releases. That is, we only release what we can but not everything else. You can easily distinguish released crates and unreleased ones by whether they have the `-dev` suffix.

If your dependency has any of the crates that we are not able to release, you'll unfortunately have to stick with git dependencies or vendored dependencies.

### `libsecp256k1` no-std fix

Fix a missing feature issue in the `libsecp256k1` version bump.