### PR TITLE
Prioritize by gas price

### DIFF
--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -244,12 +244,7 @@ impl<T: Config> frame_support::unsigned::ValidateUnsigned for Module<T> {
 
 			let mut builder = ValidTransactionBuilder::default()
 				.and_provides((origin, transaction.nonce))
-				.priority(if min_gas_price == U256::zero() {
-						0
-					} else {
-						let target_gas = (transaction.gas_limit * transaction.gas_price) / min_gas_price;
-						T::GasWeightMapping::gas_to_weight(target_gas.unique_saturated_into())
-				});
+				.priority(transaction.gas_price.unique_saturated_into());
 
 			if transaction.nonce > account_data.nonce {
 				if let Some(prev_nonce) = transaction.nonce.checked_sub(1.into()) {

--- a/frame/ethereum/src/tests.rs
+++ b/frame/ethereum/src/tests.rs
@@ -101,7 +101,7 @@ fn transaction_with_invalid_nonce_should_not_work() {
 			Ethereum::validate_unsigned(TransactionSource::External, &Call::transact(signed)),
 			ValidTransactionBuilder::default()
 				.and_provides((alice.address, U256::from(1)))
-				.priority(1048576 as u64)
+				.priority(1u64)
 				.and_requires((alice.address, U256::from(0)))
 				.build()
 		);


### PR DESCRIPTION
This replaces the previous transaction prioritization logic with a simple prioritization by gas price.

This PR takes the opinion that it is not pallet-ethereum's job to ensure that ethereum transactions are prioritized fairly with "normal" frame transactions. Rather it it pallet ethereum's job to prioritize transactions the way ethereum does.

It is the up to any runtime that uses both frame- and pallet-ethereum-style transactions to make sure they are prioritized fairly relative to one another. (This concern is not addressed in this PR.)