### PR TITLE
fix(estimate_gas): Ensure that provided gas limit it never larger than current block's gas limit

### DIFF
--- a/client/rpc/CHANGELOG.md
+++ b/client/rpc/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Fix `estimate_gas`: ensure that provided gas limit it never larger than current block's gas limit
 * `EthPubSubApi::new` takes an additional `overrides` parameter.
 * Fix `estimate_gas` inaccurate issue.
 * Use pallet-ethereum 3.0.0-dev.

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -806,36 +806,36 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 					.map_err(|err| internal_err(format!("runtime error: {:?}", err)))?
 					.map_err(|err| internal_err(format!("execution fatal: {:?}", err)))?;
 
-                error_on_execution_failure(&info.exit_reason, &[])?;
+				error_on_execution_failure(&info.exit_reason, &[])?;
 
-                Ok(Bytes(info.value[..].to_vec()))
-            }
-        }
-    }
+				Ok(Bytes(info.value[..].to_vec()))
+			}
+		}
+	}
 
-    fn estimate_gas(
-        &self,
-        request: CallRequest,
-        _: Option<BlockNumber>,
-    ) -> Result<U256> {
-        let gas_limit = {
-            // query current block's gas limit
+	fn estimate_gas(
+		&self,
+		request: CallRequest,
+		_: Option<BlockNumber>,
+	) -> Result<U256> {
+		let gas_limit = {
+			// query current block's gas limit
 			let id = BlockId::Hash(self.client.info().best_hash);
-            let schema =
-                frontier_backend_client::onchain_storage_schema::<B, C, BE>(&self.client, id);
-            let handler = self
-                .overrides
-                .schemas
-                .get(&schema)
-                .unwrap_or(&self.overrides.fallback);
+			let schema =
+				frontier_backend_client::onchain_storage_schema::<B, C, BE>(&self.client, id);
+			let handler = self
+				.overrides
+				.schemas
+				.get(&schema)
+				.unwrap_or(&self.overrides.fallback);
 
-            let block = handler.current_block(&id);
-            if let Some(block) = block {
-                block.header.gas_limit
-            } else {
-                return Err(internal_err("block unavailable, cannot query gas limit"));
-            }
-        };
+			let block = handler.current_block(&id);
+			if let Some(block) = block {
+				block.header.gas_limit
+			} else {
+				return Err(internal_err("block unavailable, cannot query gas limit"));
+			}
+		};
 
 		let calculate_gas_used = |request, gas_limit| -> Result<U256> {
 			let hash = self.client.info().best_hash;
@@ -851,7 +851,7 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 			} = request;
 
 			// Use request gas limit only if it less than gas_limit parameter
-            let gas_limit = core::cmp::min(gas.unwrap_or(gas_limit), gas_limit);
+			let gas_limit = core::cmp::min(gas.unwrap_or(gas_limit), gas_limit);
 
 			let data = data.map(|d| d.0).unwrap_or_default();
 

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -806,15 +806,38 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 					.map_err(|err| internal_err(format!("runtime error: {:?}", err)))?
 					.map_err(|err| internal_err(format!("execution fatal: {:?}", err)))?;
 
-				error_on_execution_failure(&info.exit_reason, &[])?;
+                error_on_execution_failure(&info.exit_reason, &[])?;
 
-				Ok(Bytes(info.value[..].to_vec()))
-			},
-		}
-	}
+                Ok(Bytes(info.value[..].to_vec()))
+            }
+        }
+    }
 
-	fn estimate_gas(&self, request: CallRequest, _: Option<BlockNumber>) -> Result<U256> {
-		let calculate_gas_used = |request| -> Result<U256> {
+    fn estimate_gas(
+        &self,
+        request: CallRequest,
+        _: Option<BlockNumber>,
+    ) -> Result<U256> {
+        let gas_limit = {
+            // query current block's gas limit
+			let id = BlockId::Hash(self.client.info().best_hash);
+            let schema =
+                frontier_backend_client::onchain_storage_schema::<B, C, BE>(&self.client, id);
+            let handler = self
+                .overrides
+                .schemas
+                .get(&schema)
+                .unwrap_or(&self.overrides.fallback);
+
+            let block = handler.current_block(&id);
+            if let Some(block) = block {
+                block.header.gas_limit
+            } else {
+                return Err(internal_err("block unavailable, cannot query gas limit"));
+            }
+        };
+
+		let calculate_gas_used = |request, gas_limit| -> Result<U256> {
 			let hash = self.client.info().best_hash;
 
 			let CallRequest {
@@ -827,19 +850,8 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 				nonce
 			} = request;
 
-			// use given gas limit or query current block's limit
-			let gas_limit = match gas {
-				Some(amount) => amount,
-				None => {
-					let block = self.client.runtime_api().current_block(&BlockId::Hash(hash))
-						.map_err(|err| internal_err(format!("runtime error: {:?}", err)))?;
-					if let Some(block) = block {
-						block.header.gas_limit
-					} else {
-						return Err(internal_err(format!("block unavailable, cannot query gas limit")));
-					}
-				},
-			};
+			// Use request gas limit only if it less than gas_limit parameter
+            let gas_limit = core::cmp::min(gas.unwrap_or(gas_limit), gas_limit);
 
 			let data = data.map(|d| d.0).unwrap_or_default();
 
@@ -905,7 +917,7 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 			while change_pct > threshold_pct {
 				let mut test_request = request.clone();
 				test_request.gas = Some(mid);
-				match calculate_gas_used(test_request) {
+				match calculate_gas_used(test_request, gas_limit) {
 					// if Ok -- try to reduce the gas used
 					Ok(used_gas) => {
 						old_best = best;
@@ -932,7 +944,7 @@ impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H> where
 			}
 			Ok(best)
 		} else {
-			calculate_gas_used(request)
+			calculate_gas_used(request, gas_limit)
 		}
 	}
 


### PR DESCRIPTION
This PR protects against a DOS attack consisting in making an rpc call forcing the node to perform many calculations.

Indeed, it is possible to ask for an estimate of the gas cost by providing an excessively high amount of gas, an attacker can then easily force the node to do a lot of computation by asking to estimate a call that contains an infinite loop for example.

To mitigate this problem, this RP ensures that the amount of gas provided does not exceed the gas limit of the current block.