### PR TITLE
Update `TargetMinGasPrice` once in a block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3997,10 +3997,12 @@ dependencies = [
  "frame-support",
  "frame-system",
  "pallet-evm",
+ "pallet-timestamp",
  "parity-scale-codec",
  "serde",
  "sp-core",
  "sp-inherents",
+ "sp-io",
  "sp-runtime",
  "sp-std",
 ]

--- a/frame/dynamic-fee/CHANGELOG.md
+++ b/frame/dynamic-fee/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## Unreleased
 
 * Uses unreleased pallet-evm 5.0.0-dev
+* Update `TargetGasPrice` once in a block

--- a/frame/dynamic-fee/Cargo.toml
+++ b/frame/dynamic-fee/Cargo.toml
@@ -17,6 +17,10 @@ sp-inherents = { version = "3.0.0", default-features = false, git = "https://git
 frame-system = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 frame-support = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 
+[dev-dependencies]
+pallet-timestamp = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
+
 [features]
 default = ["std"]
 std = [

--- a/frame/dynamic-fee/src/lib.rs
+++ b/frame/dynamic-fee/src/lib.rs
@@ -19,7 +19,11 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Decode, Encode};
-use frame_support::{decl_error, decl_module, decl_storage, ensure, traits::Get, weights::Weight};
+use frame_support::{
+	decl_error, decl_module, decl_storage, ensure,
+	traits::Get,
+	weights::{DispatchClass, Weight},
+};
 use frame_system::ensure_none;
 use sp_core::U256;
 #[cfg(feature = "std")]
@@ -76,7 +80,7 @@ decl_module! {
 			}
 		}
 
-		#[weight = T::DbWeight::get().writes(1)]
+		#[weight = (T::DbWeight::get().writes(1), DispatchClass::Mandatory)]
 		pub fn note_min_gas_price_target(
 			origin,
 			target: U256,


### PR DESCRIPTION
To avoid potential abuse of unsigned transactions in dynamic fee pallet. This implementation refers to [Timestamp Pallet](https://github.com/paritytech/substrate/blob/master/frame/timestamp/src/lib.rs).