### PR TITLE
Final pallet release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "fp-storage"
-version = "2.0.0-dev"
+version = "2.0.0"
 
 [[package]]
 name = "frame-benchmarking"
@@ -3994,7 +3994,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-dynamic-fee"
-version = "3.0.0-dev"
+version = "3.0.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4011,7 +4011,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ethereum"
-version = "3.0.0-dev"
+version = "3.0.0"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4039,7 +4039,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm"
-version = "5.0.0-dev"
+version = "5.0.0"
 dependencies = [
  "evm",
  "evm-gasometer",

--- a/frame/dynamic-fee/Cargo.toml
+++ b/frame/dynamic-fee/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "pallet-dynamic-fee"
-version = "3.0.0-dev"
+version = "3.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 description = "Dynamic fee handling for EVM."
 license = "Apache-2.0"
 
 [dependencies]
-pallet-evm = { path = "../evm", version = "5.0.0-dev", default-features = false }
+pallet-evm = { path = "../evm", version = "5.0.0", default-features = false }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 serde = { version = "1.0.101", optional = true }
 sp-std = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }

--- a/frame/ethereum/Cargo.toml
+++ b/frame/ethereum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-ethereum"
-version = "3.0.0-dev"
+version = "3.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 description = "Ethereum compatibility full block processing emulation pallet for Substrate."
@@ -14,7 +14,7 @@ frame-support = { version = "3.0.0", default-features = false, git = "https://gi
 frame-system = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 pallet-balances = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 pallet-timestamp = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
-pallet-evm = { version = "5.0.0-dev", default-features = false, path = "../evm" }
+pallet-evm = { version = "5.0.0", default-features = false, path = "../evm" }
 sp-runtime = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-std = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
 sp-io = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "frontier" }
@@ -27,7 +27,7 @@ sha3 = { version = "0.8", default-features = false }
 libsecp256k1 = { version = "0.5", default-features = false, features = ["static-context", "hmac"] }
 fp-consensus = { version = "1.0.0", path = "../../primitives/consensus", default-features = false }
 fp-rpc = { version = "2.0.0", path = "../../primitives/rpc", default-features = false }
-fp-storage = { version = "2.0.0-dev", path = "../../primitives/storage", default-features = false}
+fp-storage = { version = "2.0.0", path = "../../primitives/storage", default-features = false}
 
 [dev-dependencies]
 sp-core = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "frontier" }

--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-evm"
-version = "5.0.0-dev"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/primitives/storage/Cargo.toml
+++ b/primitives/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fp-storage"
-version = "2.0.0-dev"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io"]
 edition = "2018"
 description = "Storage primitives for Ethereum RPC (web3) compatibility layer for Substrate."


### PR DESCRIPTION
Making new Frontier releases while keeping up-to-date with current Substrate has become an impossible task for now. As a result, we're dropping rolling releases for Frontier and making a final Frontier pallet release here.

Until the Substrate release issue is fixed, it's recommended that you follow Substrate master tag and Frontier master tag instead of Cargo versions. This does pose greater stability risk for end users, but from now on we aim to break master as little as possible.

Please continue to follow rolling release guidelines when making PRs, as the releases will be resumed as soon as Substrate release pipeline is resolved.