### PR TITLE
Fix `Event::Executed` for transaction `Call`.

### DIFF
--- a/frame/ethereum/CHANGELOG.md
+++ b/frame/ethereum/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## Unreleased
 
 * Uses unreleased pallet-evm 5.0.0-dev
+* Fix `Event::Executed` for transaction `Call`

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -344,7 +344,7 @@ impl<T: Config> Pallet<T> {
 			None,
 		)?;
 
-		let (reason, status, used_gas) = match info {
+		let (reason, status, used_gas, dest) = match info {
 			CallOrCreateInfo::Call(info) => (
 				info.exit_reason,
 				TransactionStatus {
@@ -361,6 +361,7 @@ impl<T: Config> Pallet<T> {
 					},
 				},
 				info.used_gas,
+				to,
 			),
 			CallOrCreateInfo::Create(info) => (
 				info.exit_reason,
@@ -378,6 +379,7 @@ impl<T: Config> Pallet<T> {
 					},
 				},
 				info.used_gas,
+				Some(info.value),
 			),
 		};
 
@@ -397,7 +399,7 @@ impl<T: Config> Pallet<T> {
 
 		Self::deposit_event(Event::Executed(
 			source,
-			contract_address.unwrap_or_default(),
+			dest.unwrap_or_default(),
 			transaction_hash,
 			reason,
 		));


### PR DESCRIPTION
Currently we only unwrap created contract address or `H160::default`, that is, we are only covering `Create`. This PR fixes that to use `to` for `Call` desposited events.