### PR TITLE
Refactor pending transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,7 +953,7 @@ dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
- "itertools 0.10.1",
+ "itertools",
  "log",
  "serde",
  "smallvec",
@@ -1675,7 +1675,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1737,7 +1737,7 @@ version = "2.0.0"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1756,7 +1756,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "Inflector",
  "chrono",
@@ -1782,7 +1782,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1797,7 +1797,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "14.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1808,7 +1808,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -1834,7 +1834,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -1846,7 +1846,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 1.0.0",
@@ -1858,7 +1858,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1868,7 +1868,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "log",
@@ -1884,7 +1884,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1898,7 +1898,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2477,7 +2477,7 @@ dependencies = [
  "itoa",
  "pin-project-lite 0.2.7",
  "socket2 0.4.1",
- "tokio 1.10.0",
+ "tokio",
  "tower-service",
  "tracing",
  "want",
@@ -2495,7 +2495,7 @@ dependencies = [
  "log",
  "rustls",
  "rustls-native-certs",
- "tokio 1.10.0",
+ "tokio",
  "tokio-rustls",
  "webpki",
 ]
@@ -2682,15 +2682,6 @@ checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
@@ -2833,7 +2824,7 @@ dependencies = [
  "jsonrpc-core",
  "lazy_static",
  "log",
- "tokio 1.10.0",
+ "tokio",
  "tokio-stream",
  "tokio-util",
  "unicase",
@@ -3025,8 +3016,8 @@ dependencies = [
  "multistream-select",
  "parking_lot 0.11.1",
  "pin-project 1.0.8",
- "prost 0.8.0",
- "prost-build 0.8.0",
+ "prost",
+ "prost-build",
  "rand 0.7.3",
  "ring",
  "rw-stream-sink",
@@ -3075,8 +3066,8 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "prost 0.8.0",
- "prost-build 0.8.0",
+ "prost",
+ "prost-build",
  "rand 0.7.3",
  "smallvec",
 ]
@@ -3097,8 +3088,8 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "prost 0.8.0",
- "prost-build 0.8.0",
+ "prost",
+ "prost-build",
  "rand 0.7.3",
  "regex",
  "sha2 0.9.5",
@@ -3117,8 +3108,8 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "prost 0.8.0",
- "prost-build 0.8.0",
+ "prost",
+ "prost-build",
  "smallvec",
  "wasm-timer",
 ]
@@ -3138,8 +3129,8 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "prost 0.8.0",
- "prost-build 0.8.0",
+ "prost",
+ "prost-build",
  "rand 0.7.3",
  "sha2 0.9.5",
  "smallvec",
@@ -3200,8 +3191,8 @@ dependencies = [
  "lazy_static",
  "libp2p-core",
  "log",
- "prost 0.8.0",
- "prost-build 0.8.0",
+ "prost",
+ "prost-build",
  "rand 0.8.4",
  "sha2 0.9.5",
  "snow",
@@ -3236,8 +3227,8 @@ dependencies = [
  "futures 0.3.16",
  "libp2p-core",
  "log",
- "prost 0.8.0",
- "prost-build 0.8.0",
+ "prost",
+ "prost-build",
  "unsigned-varint 0.7.0",
  "void",
 ]
@@ -3270,8 +3261,8 @@ dependencies = [
  "libp2p-swarm",
  "log",
  "pin-project 1.0.8",
- "prost 0.8.0",
- "prost-build 0.8.0",
+ "prost",
+ "prost-build",
  "rand 0.7.3",
  "smallvec",
  "unsigned-varint 0.7.0",
@@ -3769,17 +3760,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio-uds"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
-dependencies = [
- "iovec",
- "libc",
- "mio 0.6.23",
-]
-
-[[package]]
 name = "miow"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4169,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4184,7 +4164,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4198,7 +4178,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4391,7 +4371,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4413,7 +4393,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4426,7 +4406,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4446,7 +4426,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4459,7 +4439,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4475,7 +4455,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4491,7 +4471,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4508,7 +4488,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -4577,7 +4557,7 @@ dependencies = [
  "libc",
  "log",
  "rand 0.7.3",
- "tokio 1.10.0",
+ "tokio",
  "winapi 0.3.9",
 ]
 
@@ -4997,40 +4977,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
-dependencies = [
- "bytes 1.0.1",
- "prost-derive 0.7.0",
-]
-
-[[package]]
-name = "prost"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes 1.0.1",
- "prost-derive 0.8.0",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
-dependencies = [
- "bytes 1.0.1",
- "heck",
- "itertools 0.9.0",
- "log",
- "multimap",
- "petgraph",
- "prost 0.7.0",
- "prost-types 0.7.0",
- "tempfile",
- "which",
+ "prost-derive",
 ]
 
 [[package]]
@@ -5041,27 +4993,14 @@ checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
 dependencies = [
  "bytes 1.0.1",
  "heck",
- "itertools 0.10.1",
+ "itertools",
  "log",
  "multimap",
  "petgraph",
- "prost 0.8.0",
- "prost-types 0.8.0",
+ "prost",
+ "prost-types",
  "tempfile",
  "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
-dependencies = [
- "anyhow",
- "itertools 0.9.0",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -5071,20 +5010,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
- "itertools 0.10.1",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
-dependencies = [
- "bytes 1.0.1",
- "prost 0.7.0",
 ]
 
 [[package]]
@@ -5094,7 +5023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
  "bytes 1.0.1",
- "prost 0.8.0",
+ "prost",
 ]
 
 [[package]]
@@ -5645,7 +5574,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "log",
  "sp-core",
@@ -5656,7 +5585,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "futures 0.3.16",
  "futures-timer 3.0.2",
@@ -5679,7 +5608,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5695,7 +5624,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "impl-trait-for-tuples 0.2.1",
  "parity-scale-codec",
@@ -5711,7 +5640,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -5722,7 +5651,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "chrono",
  "fdlimit",
@@ -5741,6 +5670,7 @@ dependencies = [
  "sc-service",
  "sc-telemetry",
  "sc-tracing",
+ "sc-utils",
  "serde",
  "serde_json",
  "sp-blockchain",
@@ -5749,18 +5679,17 @@ dependencies = [
  "sp-keystore",
  "sp-panic-handler",
  "sp-runtime",
- "sp-utils",
  "sp-version",
  "structopt",
  "thiserror",
  "tiny-bip39",
- "tokio 0.2.25",
+ "tokio",
 ]
 
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "fnv",
  "futures 0.3.16",
@@ -5770,6 +5699,7 @@ dependencies = [
  "parking_lot 0.11.1",
  "sc-executor",
  "sc-transaction-pool-api",
+ "sc-utils",
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
@@ -5781,14 +5711,13 @@ dependencies = [
  "sp-state-machine",
  "sp-storage",
  "sp-trie",
- "sp-utils",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -5813,7 +5742,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "futures 0.3.16",
@@ -5822,6 +5751,7 @@ dependencies = [
  "log",
  "parking_lot 0.11.1",
  "sc-client-api",
+ "sc-utils",
  "serde",
  "sp-api",
  "sp-blockchain",
@@ -5829,16 +5759,14 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-state-machine",
- "sp-utils",
  "substrate-prometheus-endpoint",
  "thiserror",
- "wasm-timer",
 ]
 
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -5867,7 +5795,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -5910,7 +5838,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -5923,7 +5851,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -5957,7 +5885,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "futures 0.3.16",
@@ -5983,7 +5911,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "lazy_static",
  "libsecp256k1 0.6.0",
@@ -6009,9 +5937,10 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "derive_more",
+ "environmental",
  "parity-scale-codec",
  "pwasm-utils",
  "sc-allocator",
@@ -6026,12 +5955,13 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "log",
  "parity-scale-codec",
  "sc-allocator",
  "sc-executor-common",
+ "scoped-tls",
  "sp-core",
  "sp-runtime-interface",
  "sp-wasm-interface",
@@ -6041,7 +5971,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -6060,7 +5990,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -6080,6 +6010,7 @@ dependencies = [
  "sc-network",
  "sc-network-gossip",
  "sc-telemetry",
+ "sc-utils",
  "serde_json",
  "sp-api",
  "sp-application-crypto",
@@ -6090,15 +6021,13 @@ dependencies = [
  "sp-finality-grandpa",
  "sp-keystore",
  "sp-runtime",
- "sp-utils",
  "substrate-prometheus-endpoint",
- "wasm-timer",
 ]
 
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.16",
@@ -6110,13 +6039,12 @@ dependencies = [
  "sc-transaction-pool-api",
  "sp-blockchain",
  "sp-runtime",
- "wasm-timer",
 ]
 
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -6131,7 +6059,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -6149,7 +6077,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-std",
  "async-trait",
@@ -6173,13 +6101,14 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.11.1",
  "pin-project 1.0.8",
- "prost 0.7.0",
- "prost-build 0.7.0",
+ "prost",
+ "prost-build",
  "rand 0.7.3",
  "sc-block-builder",
  "sc-client-api",
  "sc-consensus",
  "sc-peerset",
+ "sc-utils",
  "serde",
  "serde_json",
  "smallvec",
@@ -6189,19 +6118,17 @@ dependencies = [
  "sp-core",
  "sp-finality-grandpa",
  "sp-runtime",
- "sp-utils",
  "substrate-prometheus-endpoint",
  "thiserror",
  "unsigned-varint 0.6.0",
  "void",
- "wasm-timer",
  "zeroize",
 ]
 
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "futures 0.3.16",
  "futures-timer 3.0.2",
@@ -6212,13 +6139,12 @@ dependencies = [
  "sp-runtime",
  "substrate-prometheus-endpoint",
  "tracing",
- "wasm-timer",
 ]
 
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "bytes 1.0.1",
  "fnv",
@@ -6234,31 +6160,31 @@ dependencies = [
  "rand 0.7.3",
  "sc-client-api",
  "sc-network",
+ "sc-utils",
  "sp-api",
  "sp-core",
  "sp-offchain",
  "sp-runtime",
- "sp-utils",
  "threadpool",
 ]
 
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "futures 0.3.16",
  "libp2p",
  "log",
+ "sc-utils",
  "serde_json",
- "sp-utils",
  "wasm-timer",
 ]
 
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -6267,7 +6193,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "futures 0.3.16",
  "hash-db",
@@ -6282,6 +6208,7 @@ dependencies = [
  "sc-rpc-api",
  "sc-tracing",
  "sc-transaction-pool-api",
+ "sc-utils",
  "serde_json",
  "sp-api",
  "sp-blockchain",
@@ -6291,16 +6218,14 @@ dependencies = [
  "sp-rpc",
  "sp-runtime",
  "sp-session",
- "sp-utils",
  "sp-version",
 ]
 
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
- "derive_more",
  "futures 0.3.16",
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -6318,12 +6243,13 @@ dependencies = [
  "sp-runtime",
  "sp-tracing",
  "sp-version",
+ "thiserror",
 ]
 
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "futures 0.3.16",
  "jsonrpc-core",
@@ -6339,7 +6265,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "directories",
@@ -6372,6 +6298,7 @@ dependencies = [
  "sc-tracing",
  "sc-transaction-pool",
  "sc-transaction-pool-api",
+ "sc-utils",
  "serde",
  "serde_json",
  "sp-api",
@@ -6391,20 +6318,18 @@ dependencies = [
  "sp-transaction-pool",
  "sp-transaction-storage-proof",
  "sp-trie",
- "sp-utils",
  "sp-version",
  "substrate-prometheus-endpoint",
  "tempfile",
  "thiserror",
  "tracing",
  "tracing-futures",
- "wasm-timer",
 ]
 
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6418,7 +6343,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "chrono",
  "futures 0.3.16",
@@ -6436,7 +6361,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -6460,14 +6385,12 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -6478,7 +6401,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "futures 0.3.16",
  "intervalier",
@@ -6490,6 +6413,7 @@ dependencies = [
  "retain_mut",
  "sc-client-api",
  "sc-transaction-pool-api",
+ "sc-utils",
  "serde",
  "sp-api",
  "sp-blockchain",
@@ -6497,16 +6421,14 @@ dependencies = [
  "sp-runtime",
  "sp-tracing",
  "sp-transaction-pool",
- "sp-utils",
  "substrate-prometheus-endpoint",
  "thiserror",
- "wasm-timer",
 ]
 
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "derive_more",
  "futures 0.3.16",
@@ -6515,6 +6437,17 @@ dependencies = [
  "sp-blockchain",
  "sp-runtime",
  "thiserror",
+]
+
+[[package]]
+name = "sc-utils"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
+dependencies = [
+ "futures 0.3.16",
+ "futures-timer 3.0.2",
+ "lazy_static",
+ "prometheus",
 ]
 
 [[package]]
@@ -6910,7 +6843,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "hash-db",
  "log",
@@ -6927,7 +6860,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate 1.0.0",
@@ -6939,7 +6872,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6951,7 +6884,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -6965,7 +6898,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -6977,7 +6910,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6989,7 +6922,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "futures 0.3.16",
  "log",
@@ -7007,7 +6940,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "futures 0.3.16",
@@ -7026,7 +6959,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -7043,7 +6976,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "merlin",
@@ -7065,7 +6998,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "sp-arithmetic",
@@ -7075,7 +7008,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -7087,7 +7020,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -7131,7 +7064,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "kvdb",
  "parking_lot 0.11.1",
@@ -7140,7 +7073,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7150,7 +7083,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -7161,7 +7094,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -7178,7 +7111,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples 0.2.1",
@@ -7192,7 +7125,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "futures 0.3.16",
  "hash-db",
@@ -7217,7 +7150,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -7228,7 +7161,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7245,7 +7178,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "ruzstd",
  "zstd",
@@ -7254,7 +7187,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -7264,7 +7197,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "backtrace",
 ]
@@ -7272,7 +7205,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -7282,7 +7215,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -7303,7 +7236,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "impl-trait-for-tuples 0.2.1",
  "parity-scale-codec",
@@ -7320,7 +7253,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.0.0",
@@ -7332,7 +7265,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "serde",
  "serde_json",
@@ -7341,7 +7274,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7354,7 +7287,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7364,7 +7297,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "hash-db",
  "log",
@@ -7387,12 +7320,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 
 [[package]]
 name = "sp-storage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7405,7 +7338,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "log",
  "sp-core",
@@ -7418,7 +7351,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "futures-timer 3.0.2",
@@ -7429,13 +7362,12 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "thiserror",
- "wasm-timer",
 ]
 
 [[package]]
 name = "sp-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "erased-serde",
  "log",
@@ -7453,7 +7385,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -7462,7 +7394,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "log",
@@ -7477,7 +7409,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7489,20 +7421,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-utils"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
-dependencies = [
- "futures 0.3.16",
- "futures-timer 3.0.2",
- "lazy_static",
- "prometheus",
-]
-
-[[package]]
 name = "sp-version"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7517,7 +7438,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -7528,7 +7449,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "impl-trait-for-tuples 0.2.1",
  "parity-scale-codec",
@@ -7647,7 +7568,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "platforms",
 ]
@@ -7655,7 +7576,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.16",
@@ -7677,7 +7598,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-std",
  "derive_more",
@@ -7685,13 +7606,13 @@ dependencies = [
  "hyper",
  "log",
  "prometheus",
- "tokio 1.10.0",
+ "tokio",
 ]
 
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#67f28cdba85c362da17909c69c19952e3ef931c7"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "ansi_term 0.12.1",
  "build-helper",
@@ -7875,24 +7796,6 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
-dependencies = [
- "bytes 0.5.6",
- "lazy_static",
- "libc",
- "mio 0.6.23",
- "mio-uds",
- "num_cpus",
- "pin-project-lite 0.1.12",
- "signal-hook-registry",
- "slab",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "tokio"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cf844b23c6131f624accf65ce0e4e9956a8bb329400ea5bcc26ae3a5c20b0b"
@@ -7903,7 +7806,9 @@ dependencies = [
  "memchr",
  "mio 0.7.13",
  "num_cpus",
+ "once_cell",
  "pin-project-lite 0.2.7",
+ "signal-hook-registry",
  "winapi 0.3.9",
 ]
 
@@ -7914,7 +7819,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
  "rustls",
- "tokio 1.10.0",
+ "tokio",
  "webpki",
 ]
 
@@ -7926,7 +7831,7 @@ checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.7",
- "tokio 1.10.0",
+ "tokio",
 ]
 
 [[package]]
@@ -7940,7 +7845,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.2.7",
- "tokio 1.10.0",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,6 +1575,7 @@ dependencies = [
  "sc-network",
  "sc-rpc",
  "sc-service",
+ "sc-transaction-pool",
  "sc-transaction-pool-api",
  "sha3 0.8.2",
  "sp-api",

--- a/client/rpc-core/CHANGELOG.md
+++ b/client/rpc-core/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 ## Unreleased
 - Add `FilteredParams::address_in_bloom()` and `FilteredParams::topics_in_bloom()` functions to check the possible existance of Filter addresses or topics in a block.
+- Removed `PendingTransaction` and `PendingTransactions` types.

--- a/client/rpc-core/src/types/mod.rs
+++ b/client/rpc-core/src/types/mod.rs
@@ -53,7 +53,7 @@ pub use self::sync::{
 	PipProtocolInfo, SyncInfo, SyncStatus, TransactionStats,
 };
 pub use self::transaction::{
-	LocalTransactionStatus, PendingTransaction, PendingTransactions, RichRawTransaction,
+	LocalTransactionStatus, RichRawTransaction,
 	Transaction,
 };
 pub use self::transaction_request::TransactionRequest;

--- a/client/rpc-core/src/types/mod.rs
+++ b/client/rpc-core/src/types/mod.rs
@@ -52,9 +52,6 @@ pub use self::sync::{
 	ChainStatus, EthProtocolInfo, PeerCount, PeerInfo, PeerNetworkInfo, PeerProtocolsInfo, Peers,
 	PipProtocolInfo, SyncInfo, SyncStatus, TransactionStats,
 };
-pub use self::transaction::{
-	LocalTransactionStatus, RichRawTransaction,
-	Transaction,
-};
+pub use self::transaction::{LocalTransactionStatus, RichRawTransaction, Transaction};
 pub use self::transaction_request::TransactionRequest;
 pub use self::work::Work;

--- a/client/rpc-core/src/types/transaction.rs
+++ b/client/rpc-core/src/types/transaction.rs
@@ -159,19 +159,3 @@ pub struct RichRawTransaction {
 	#[serde(rename = "tx")]
 	pub transaction: Transaction,
 }
-
-pub struct PendingTransaction {
-	pub transaction: Transaction,
-	pub at_block: u64,
-}
-
-impl PendingTransaction {
-	pub fn new(transaction: Transaction, at_block: u64) -> Self {
-		Self {
-			transaction,
-			at_block,
-		}
-	}
-}
-
-pub type PendingTransactions = Option<Arc<Mutex<HashMap<H256, PendingTransaction>>>>;

--- a/client/rpc-core/src/types/transaction.rs
+++ b/client/rpc-core/src/types/transaction.rs
@@ -20,10 +20,6 @@ use crate::types::Bytes;
 use ethereum_types::{H160, H256, H512, U256, U64};
 use serde::ser::SerializeStruct;
 use serde::{Serialize, Serializer};
-use std::{
-	collections::HashMap,
-	sync::{Arc, Mutex},
-};
 
 /// Transaction
 #[derive(Debug, Default, Clone, PartialEq, Serialize)]

--- a/client/rpc/CHANGELOG.md
+++ b/client/rpc/CHANGELOG.md
@@ -9,3 +9,4 @@
 * `EthFilterApi::new` takes an additional `backend` parameter.
 * Bump `fp-storage` to `2.0.0-dev`.
 * Bump `fc-db` to `2.0.0-dev`.
+* Removed on-memory pending transactions in favor of transaction pool.

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -24,7 +24,7 @@ sp-io = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate"
 sp-runtime = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }
 sp-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }
 sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }
-sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate"}
+sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }
 sp-storage = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }
 sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }
 sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -24,7 +24,7 @@ sp-io = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate"
 sp-runtime = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }
 sp-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }
 sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }
-sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", features = ["test-helpers"] }
+sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate"}
 sp-storage = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }
 sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }
 sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -24,6 +24,7 @@ sp-io = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate"
 sp-runtime = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }
 sp-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }
 sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }
+sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", features = ["test-helpers"] }
 sp-storage = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }
 sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }
 sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -22,8 +22,8 @@ use ethereum::{BlockV0 as EthereumBlock, TransactionV0 as EthereumTransaction};
 use ethereum_types::{H160, H256, H512, H64, U256, U64};
 use fc_rpc_core::types::{
 	Block, BlockNumber, BlockTransactions, Bytes, CallRequest, Filter, FilterChanges, FilterPool,
-	FilterPoolItem, FilterType, FilteredParams, Header, Index, Log, PeerCount, Receipt, Rich, RichBlock, SyncInfo, SyncStatus, Transaction,
-	TransactionRequest, Work,
+	FilterPoolItem, FilterType, FilteredParams, Header, Index, Log, PeerCount, Receipt, Rich,
+	RichBlock, SyncInfo, SyncStatus, Transaction, TransactionRequest, Work,
 };
 use fc_rpc_core::{
 	EthApi as EthApiT, EthFilterApi as EthFilterApiT, NetApi as NetApiT, Web3Api as Web3ApiT,
@@ -1064,24 +1064,25 @@ where
 	}
 
 	fn transaction_by_hash(&self, hash: H256) -> Result<Option<Transaction>> {
-
 		let mut xts: Vec<<B as BlockT>::Extrinsic> = Vec::new();
 		// Collect transactions in the ready validated pool.
-		xts.extend(self
-			.graph
-			.validated_pool()
-			.ready()
-			.map(|in_pool_tx| in_pool_tx.data().clone())
-			.collect::<Vec<<B as BlockT>::Extrinsic>>());
+		xts.extend(
+			self.graph
+				.validated_pool()
+				.ready()
+				.map(|in_pool_tx| in_pool_tx.data().clone())
+				.collect::<Vec<<B as BlockT>::Extrinsic>>(),
+		);
 
 		// Collect transactions in the future validated pool.
-		xts.extend(self
-			.graph
-			.validated_pool()
-			.futures()
-			.iter()
-			.map(|(_hash, extrinsic)| extrinsic.clone())
-			.collect::<Vec<<B as BlockT>::Extrinsic>>());
+		xts.extend(
+			self.graph
+				.validated_pool()
+				.futures()
+				.iter()
+				.map(|(_hash, extrinsic)| extrinsic.clone())
+				.collect::<Vec<<B as BlockT>::Extrinsic>>(),
+		);
 
 		let best_block: BlockId<B> = BlockId::Hash(self.client.info().best_hash);
 		let ethereum_transactions: Vec<ethereum::TransactionV0> = self
@@ -1093,9 +1094,7 @@ where
 			})?;
 
 		for txn in ethereum_transactions {
-			let inner_hash = H256::from_slice(
-				Keccak256::digest(&rlp::encode(&txn)).as_slice()
-			);
+			let inner_hash = H256::from_slice(Keccak256::digest(&rlp::encode(&txn)).as_slice());
 			if hash == inner_hash {
 				return Ok(Some(transaction_build(txn, None, None)));
 			}
@@ -1109,7 +1108,7 @@ where
 		.map_err(|err| internal_err(format!("{:?}", err)))?
 		{
 			Some((hash, index)) => (hash, index as usize),
-			None => return Ok(None)
+			None => return Ok(None),
 		};
 
 		let id = match frontier_backend_client::load_hash::<B>(self.backend.as_ref(), hash)

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -22,8 +22,7 @@ use ethereum::{BlockV0 as EthereumBlock, TransactionV0 as EthereumTransaction};
 use ethereum_types::{H160, H256, H512, H64, U256, U64};
 use fc_rpc_core::types::{
 	Block, BlockNumber, BlockTransactions, Bytes, CallRequest, Filter, FilterChanges, FilterPool,
-	FilterPoolItem, FilterType, FilteredParams, Header, Index, Log, PeerCount, PendingTransaction,
-	PendingTransactions, Receipt, Rich, RichBlock, SyncInfo, SyncStatus, Transaction,
+	FilterPoolItem, FilterType, FilteredParams, Header, Index, Log, PeerCount, Receipt, Rich, RichBlock, SyncInfo, SyncStatus, Transaction,
 	TransactionRequest, Work,
 };
 use fc_rpc_core::{
@@ -37,6 +36,10 @@ use sc_client_api::{
 	client::BlockchainEvents,
 };
 use sc_network::{ExHashT, NetworkService};
+// `test_helpers` is a misleading name, interface previously available on `sc_transaction_graph`.
+// substrate PR to change this so its available as a public reexport:
+// https://github.com/paritytech/substrate/pull/9726
+use sc_transaction_pool::test_helpers::{ChainApi, Pool};
 use sc_transaction_pool_api::{InPoolTransaction, TransactionPool};
 use sha3::{Digest, Keccak256};
 use sp_api::{BlockId, Core, HeaderT, ProvideRuntimeApi};
@@ -45,7 +48,7 @@ use sp_runtime::{
 	traits::{BlakeTwo256, Block as BlockT, NumberFor, One, Saturating, UniqueSaturatedInto, Zero},
 	transaction_validity::TransactionSource,
 };
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::{
 	marker::PhantomData,
 	sync::{Arc, Mutex},
@@ -57,33 +60,34 @@ use codec::{self, Decode, Encode};
 pub use fc_rpc_core::{EthApiServer, EthFilterApiServer, NetApiServer, Web3ApiServer};
 use pallet_ethereum::EthereumStorageSchema;
 
-pub struct EthApi<B: BlockT, C, P, CT, BE, H: ExHashT> {
+pub struct EthApi<B: BlockT, C, P, CT, BE, H: ExHashT, A: ChainApi> {
 	pool: Arc<P>,
+	graph: Arc<Pool<A>>,
 	client: Arc<C>,
 	convert_transaction: CT,
 	network: Arc<NetworkService<B, H>>,
 	is_authority: bool,
 	signers: Vec<Box<dyn EthSigner>>,
 	overrides: Arc<OverrideHandle<B>>,
-	pending_transactions: PendingTransactions,
 	backend: Arc<fc_db::Backend<B>>,
 	max_past_logs: u32,
 	_marker: PhantomData<(B, BE)>,
 }
 
-impl<B: BlockT, C, P, CT, BE, H: ExHashT> EthApi<B, C, P, CT, BE, H>
+impl<B: BlockT, C, P, CT, BE, H: ExHashT, A: ChainApi> EthApi<B, C, P, CT, BE, H, A>
 where
 	C: ProvideRuntimeApi<B>,
 	C::Api: EthereumRuntimeRPCApi<B>,
 	B: BlockT<Hash = H256> + Send + Sync + 'static,
+	A: ChainApi<Block = B> + 'static,
 	C: Send + Sync + 'static,
 {
 	pub fn new(
 		client: Arc<C>,
 		pool: Arc<P>,
+		graph: Arc<Pool<A>>,
 		convert_transaction: CT,
 		network: Arc<NetworkService<B, H>>,
-		pending_transactions: PendingTransactions,
 		signers: Vec<Box<dyn EthSigner>>,
 		overrides: Arc<OverrideHandle<B>>,
 		backend: Arc<fc_db::Backend<B>>,
@@ -93,12 +97,12 @@ where
 		Self {
 			client: client.clone(),
 			pool,
+			graph,
 			convert_transaction,
 			network,
 			is_authority,
 			signers,
 			overrides,
-			pending_transactions,
 			backend,
 			max_past_logs,
 			_marker: PhantomData,
@@ -408,7 +412,7 @@ fn filter_block_logs<'a>(
 	ret
 }
 
-impl<B, C, P, CT, BE, H: ExHashT> EthApiT for EthApi<B, C, P, CT, BE, H>
+impl<B, C, P, CT, BE, H: ExHashT, A> EthApiT for EthApi<B, C, P, CT, BE, H, A>
 where
 	C: ProvideRuntimeApi<B> + StorageProvider<B, BE> + AuxStore,
 	C: HeaderBackend<B> + HeaderMetadata<B, Error = BlockChainError> + 'static,
@@ -418,6 +422,7 @@ where
 	B: BlockT<Hash = H256> + Send + Sync + 'static,
 	C: Send + Sync + 'static,
 	P: TransactionPool<Block = B> + Send + Sync + 'static,
+	A: ChainApi<Block = B> + 'static,
 	CT: ConvertTransaction<<B as BlockT>::Extrinsic> + Send + Sync + 'static,
 {
 	fn protocol_version(&self) -> Result<u64> {
@@ -796,8 +801,6 @@ where
 		let transaction_hash =
 			H256::from_slice(Keccak256::digest(&rlp::encode(&transaction)).as_slice());
 		let hash = self.client.info().best_hash;
-		let number = self.client.info().best_number;
-		let pending = self.pending_transactions.clone();
 		Box::pin(
 			self.pool
 				.submit_one(
@@ -806,20 +809,7 @@ where
 					self.convert_transaction
 						.convert_transaction(transaction.clone()),
 				)
-				.map_ok(move |_| {
-					if let Some(pending) = pending {
-						if let Ok(locked) = &mut pending.lock() {
-							locked.insert(
-								transaction_hash,
-								PendingTransaction::new(
-									transaction_build(transaction, None, None),
-									UniqueSaturatedInto::<u64>::unique_saturated_into(number),
-								),
-							);
-						}
-					}
-					transaction_hash
-				})
+				.map_ok(move |_| transaction_hash)
 				.map_err(|err| {
 					internal_err(format!("submit transaction to pool failed: {:?}", err))
 				}),
@@ -834,8 +824,6 @@ where
 		let transaction_hash =
 			H256::from_slice(Keccak256::digest(&rlp::encode(&transaction)).as_slice());
 		let hash = self.client.info().best_hash;
-		let number = self.client.info().best_number;
-		let pending = self.pending_transactions.clone();
 		Box::pin(
 			self.pool
 				.submit_one(
@@ -844,20 +832,7 @@ where
 					self.convert_transaction
 						.convert_transaction(transaction.clone()),
 				)
-				.map_ok(move |_| {
-					if let Some(pending) = pending {
-						if let Ok(locked) = &mut pending.lock() {
-							locked.insert(
-								transaction_hash,
-								PendingTransaction::new(
-									transaction_build(transaction, None, None),
-									UniqueSaturatedInto::<u64>::unique_saturated_into(number),
-								),
-							);
-						}
-					}
-					transaction_hash
-				})
+				.map_ok(move |_| transaction_hash)
 				.map_err(|err| {
 					internal_err(format!("submit transaction to pool failed: {:?}", err))
 				}),
@@ -1089,6 +1064,43 @@ where
 	}
 
 	fn transaction_by_hash(&self, hash: H256) -> Result<Option<Transaction>> {
+
+		let mut xts: Vec<<B as BlockT>::Extrinsic> = Vec::new();
+		// Collect transactions in the ready validated pool.
+		xts.extend(self
+			.graph
+			.validated_pool()
+			.ready()
+			.map(|in_pool_tx| in_pool_tx.data().clone())
+			.collect::<Vec<<B as BlockT>::Extrinsic>>());
+
+		// Collect transactions in the future validated pool.
+		xts.extend(self
+			.graph
+			.validated_pool()
+			.futures()
+			.iter()
+			.map(|(_hash, extrinsic)| extrinsic.clone())
+			.collect::<Vec<<B as BlockT>::Extrinsic>>());
+
+		let best_block: BlockId<B> = BlockId::Hash(self.client.info().best_hash);
+		let ethereum_transactions: Vec<ethereum::TransactionV0> = self
+			.client
+			.runtime_api()
+			.extrinsic_filter(&best_block, xts)
+			.map_err(|err| {
+				internal_err(format!("fetch runtime extrinsic filter failed: {:?}", err))
+			})?;
+
+		for txn in ethereum_transactions {
+			let inner_hash = H256::from_slice(
+				Keccak256::digest(&rlp::encode(&txn)).as_slice()
+			);
+			if hash == inner_hash {
+				return Ok(Some(transaction_build(txn, None, None)));
+			}
+		}
+
 		let (hash, index) = match frontier_backend_client::load_transactions::<B, C>(
 			self.client.as_ref(),
 			self.backend.as_ref(),
@@ -1097,16 +1109,7 @@ where
 		.map_err(|err| internal_err(format!("{:?}", err)))?
 		{
 			Some((hash, index)) => (hash, index as usize),
-			None => {
-				if let Some(pending) = &self.pending_transactions {
-					if let Ok(locked) = &mut pending.lock() {
-						if let Some(pending_transaction) = locked.get(&hash) {
-							return Ok(Some(pending_transaction.transaction.clone()));
-						}
-					}
-				}
-				return Ok(None);
-			}
+			None => return Ok(None)
 		};
 
 		let id = match frontier_backend_client::load_hash::<B>(self.backend.as_ref(), hash)
@@ -1861,42 +1864,6 @@ where
 							}
 						}
 					}
-				}
-			}
-		}
-	}
-
-	pub async fn pending_transaction_task(
-		client: Arc<C>,
-		pending_transactions: Arc<Mutex<HashMap<H256, PendingTransaction>>>,
-		retain_threshold: u64,
-	) {
-		let mut notification_st = client.import_notification_stream();
-
-		while let Some(notification) = notification_st.next().await {
-			if notification.is_new_best {
-				if let Ok(mut pending_transactions) = pending_transactions.lock() {
-					// As pending transactions have a finite lifespan anyway
-					// we can ignore MultiplePostRuntimeLogs error checks.
-					let log = fp_consensus::find_log(&notification.header.digest()).ok();
-					let post_hashes = log.map(|log| log.into_hashes());
-
-					if let Some(post_hashes) = post_hashes {
-						// Retain all pending transactions that were not
-						// processed in the current block.
-						pending_transactions
-							.retain(|&k, _| !post_hashes.transaction_hashes.contains(&k));
-					}
-
-					let imported_number: u64 = UniqueSaturatedInto::<u64>::unique_saturated_into(
-						*notification.header.number(),
-					);
-
-					pending_transactions.retain(|_, v| {
-						// Drop all the transactions that exceeded the given lifespan.
-						let lifespan_limit = v.at_block + retain_threshold;
-						lifespan_limit > imported_number
-					});
 				}
 			}
 		}

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -36,10 +36,7 @@ use sc_client_api::{
 	client::BlockchainEvents,
 };
 use sc_network::{ExHashT, NetworkService};
-// `test_helpers` is a misleading name, interface previously available on `sc_transaction_graph`.
-// substrate PR to change this so its available as a public reexport:
-// https://github.com/paritytech/substrate/pull/9726
-use sc_transaction_pool::test_helpers::{ChainApi, Pool};
+use sc_transaction_pool::{ChainApi, Pool};
 use sc_transaction_pool_api::{InPoolTransaction, TransactionPool};
 use sha3::{Digest, Keccak256};
 use sp_api::{BlockId, Core, HeaderT, ProvideRuntimeApi};

--- a/frame/dynamic-fee/src/lib.rs
+++ b/frame/dynamic-fee/src/lib.rs
@@ -178,7 +178,7 @@ mod tests {
 			frame_system::limits::BlockWeights::simple_max(1024);
 	}
 	impl frame_system::Config for Test {
-		type BaseCallFilter = ();
+		type BaseCallFilter = frame_support::traits::Everything;
 		type BlockWeights = ();
 		type BlockLength = ();
 		type DbWeight = ();

--- a/frame/ethereum/src/mock.rs
+++ b/frame/ethereum/src/mock.rs
@@ -55,7 +55,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Test {
-	type BaseCallFilter = ();
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();

--- a/frame/evm/src/mock.rs
+++ b/frame/evm/src/mock.rs
@@ -48,7 +48,7 @@ parameter_types! {
 		frame_system::limits::BlockWeights::simple_max(1024);
 }
 impl frame_system::Config for Test {
-	type BaseCallFilter = ();
+	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
 	type DbWeight = ();

--- a/template/node/src/command.rs
+++ b/template/node/src/command.rs
@@ -148,7 +148,7 @@ pub fn run() -> sc_cli::Result<()> {
 			if cfg!(feature = "runtime-benchmarks") {
 				let runner = cli.create_runner(cmd)?;
 
-				runner.sync_run(|config| cmd.run::<Block, service::Executor>(config))
+				runner.sync_run(|config| cmd.run::<Block, service::ExecutorDispatch>(config))
 			} else {
 				Err(
 					"Benchmarking wasn't enabled when building the node. You can enable it with `--features runtime-benchmarks`."

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use fc_rpc::{OverrideHandle, RuntimeApiStorageOverride, SchemaV1Override, StorageOverride};
-use fc_rpc_core::types::{FilterPool, PendingTransactions};
+use fc_rpc_core::types::FilterPool;
 use frontier_template_runtime::{opaque::Block, AccountId, Balance, Hash, Index};
 use jsonrpc_pubsub::manager::SubscriptionManager;
 use pallet_ethereum::EthereumStorageSchema;
@@ -20,6 +20,10 @@ use sp_api::ProvideRuntimeApi;
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
 use sp_runtime::traits::BlakeTwo256;
+// `test_helpers` is a misleading name, interface previously available on `sc_transaction_graph`.
+// substrate PR to change this so its available as a public reexport:
+// https://github.com/paritytech/substrate/pull/9726
+use sc_transaction_pool::test_helpers::{ChainApi, Pool};
 use std::collections::BTreeMap;
 
 /// Light client extra dependencies.
@@ -35,11 +39,13 @@ pub struct LightDeps<C, F, P> {
 }
 
 /// Full client dependencies.
-pub struct FullDeps<C, P> {
+pub struct FullDeps<C, P, A: ChainApi> {
 	/// The client instance to use.
 	pub client: Arc<C>,
 	/// Transaction pool instance.
 	pub pool: Arc<P>,
+	/// Graph pool instance.
+	pub graph: Arc<Pool<A>>,
 	/// Whether to deny unsafe calls
 	pub deny_unsafe: DenyUnsafe,
 	/// The Node authority flag
@@ -48,8 +54,6 @@ pub struct FullDeps<C, P> {
 	pub enable_dev_signer: bool,
 	/// Network service
 	pub network: Arc<NetworkService<Block, Hash>>,
-	/// Ethereum pending transactions.
-	pub pending_transactions: PendingTransactions,
 	/// EthFilterApi pool.
 	pub filter_pool: Option<FilterPool>,
 	/// Backend.
@@ -62,8 +66,8 @@ pub struct FullDeps<C, P> {
 }
 
 /// Instantiate all Full RPC extensions.
-pub fn create_full<C, P, BE>(
-	deps: FullDeps<C, P>,
+pub fn create_full<C, P, BE, A>(
+	deps: FullDeps<C, P, A>,
 	subscription_task_executor: SubscriptionTaskExecutor,
 ) -> jsonrpc_core::IoHandler<sc_rpc::Metadata>
 where
@@ -78,6 +82,7 @@ where
 	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
 	C::Api: fp_rpc::EthereumRuntimeRPCApi<Block>,
 	P: TransactionPool<Block = Block> + 'static,
+	A: ChainApi<Block = Block> + 'static,
 {
 	use fc_rpc::{
 		EthApi, EthApiServer, EthDevSigner, EthFilterApi, EthFilterApiServer, EthPubSubApi,
@@ -91,10 +96,10 @@ where
 	let FullDeps {
 		client,
 		pool,
+		graph,
 		deny_unsafe,
 		is_authority,
 		network,
-		pending_transactions,
 		filter_pool,
 		command_sink,
 		backend,
@@ -130,9 +135,9 @@ where
 	io.extend_with(EthApiServer::to_delegate(EthApi::new(
 		client.clone(),
 		pool.clone(),
+		graph,
 		frontier_template_runtime::TransactionConverter,
 		network.clone(),
-		pending_transactions.clone(),
 		signers,
 		overrides.clone(),
 		backend.clone(),

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -16,14 +16,11 @@ use sc_network::NetworkService;
 use sc_rpc::SubscriptionTaskExecutor;
 use sc_rpc_api::DenyUnsafe;
 use sc_service::TransactionPool;
+use sc_transaction_pool::{ChainApi, Pool};
 use sp_api::ProvideRuntimeApi;
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
 use sp_runtime::traits::BlakeTwo256;
-// `test_helpers` is a misleading name, interface previously available on `sc_transaction_graph`.
-// substrate PR to change this so its available as a public reexport:
-// https://github.com/paritytech/substrate/pull/9726
-use sc_transaction_pool::test_helpers::{ChainApi, Pool};
 use std::collections::BTreeMap;
 
 /// Light client extra dependencies.

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -294,8 +294,7 @@ pub fn new_full(mut config: Configuration, cli: &Cli) -> Result<TaskManager, Ser
 		mut keystore_container,
 		select_chain,
 		transaction_pool,
-		other:
-			(consensus_result, filter_pool, frontier_backend, mut telemetry),
+		other: (consensus_result, filter_pool, frontier_backend, mut telemetry),
 	} = new_partial(&config, &cli)?;
 
 	if let Some(url) = &config.keystore_remote {

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -192,9 +192,14 @@ impl frame_system::Config for Runtime {
 	type OnSetCode = ();
 }
 
+parameter_types! {
+	pub const MaxAuthorities: u32 = 100;
+}
+
 impl pallet_aura::Config for Runtime {
 	type AuthorityId = AuraId;
 	type DisabledValidators = ();
+	type MaxAuthorities = MaxAuthorities;
 }
 
 impl pallet_grandpa::Config for Runtime {
@@ -470,7 +475,7 @@ impl_runtime_apis! {
 		}
 
 		fn authorities() -> Vec<AuraId> {
-			Aura::authorities()
+			Aura::authorities().to_vec()
 		}
 	}
 


### PR DESCRIPTION
This PR removes the need for using the custom `Mutex` to handle pending transactions and the service background task that mantains it. Instead makes use of the transaction graph interface to get ethereum transactions from the `ready` and `future` queues. 

**Pros**

Uses substrate native Api.

**Cons**

Additional access to the runtime to filter the ethereum Calls.

Rel https://github.com/paritytech/substrate/pull/9726
Closes https://github.com/paritytech/frontier/pull/403 (for convenience, easier to redo than to fix all conflicts)