### PR TITLE
Remove unnecessary trait bound on `Dispatch` precompile

### DIFF
--- a/frame/evm/precompile/dispatch/src/lib.rs
+++ b/frame/evm/precompile/dispatch/src/lib.rs
@@ -30,7 +30,7 @@ use frame_support::{
 };
 use pallet_evm::{AddressMapping, GasWeightMapping};
 
-pub struct Dispatch<T: pallet_evm::Config> {
+pub struct Dispatch<T> {
 	_marker: PhantomData<T>,
 }
 


### PR DESCRIPTION
This small PR removes an unnecessary trait bound from the definition of the `Dispatch` struct. This bound is already included in a `where` clause on the implementation of the `Precompile` trait.