### PR TITLE
Returns null receipt for non-canonical block transactions

### DIFF
--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -1093,7 +1093,7 @@ where
 			self.client.as_ref(),
 			self.backend.as_ref(),
 			hash,
-			false,
+			true,
 		)
 		.map_err(|err| internal_err(format!("{:?}", err)))?
 		{

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -1093,7 +1093,7 @@ where
 			self.client.as_ref(),
 			self.backend.as_ref(),
 			hash,
-			false
+			false,
 		)
 		.map_err(|err| internal_err(format!("{:?}", err)))?
 		{
@@ -1211,7 +1211,7 @@ where
 			self.client.as_ref(),
 			self.backend.as_ref(),
 			hash,
-			true
+			true,
 		)
 		.map_err(|err| internal_err(format!("{:?}", err)))?
 		{

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -1093,6 +1093,7 @@ where
 			self.client.as_ref(),
 			self.backend.as_ref(),
 			hash,
+			false
 		)
 		.map_err(|err| internal_err(format!("{:?}", err)))?
 		{
@@ -1210,6 +1211,7 @@ where
 			self.client.as_ref(),
 			self.backend.as_ref(),
 			hash,
+			true
 		)
 		.map_err(|err| internal_err(format!("{:?}", err)))?
 		{

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -176,20 +176,20 @@ pub mod frontier_backend_client {
 			.map_err(|err| internal_err(format!("fetch aux store failed: {:?}", err)))?;
 
 		transaction_metadata
-		.iter()
-		.find(|meta| is_canon::<B, C>(client, meta.block_hash))
-		.map_or_else(
-			|| {
-				if !only_canonical && transaction_metadata.len() > 0 {
-					return Ok(Some((
-						transaction_metadata[0].ethereum_block_hash,
-						transaction_metadata[0].ethereum_index,
-					)));
-				}
-				Ok(None)
-			},
-			|meta| Ok(Some((meta.ethereum_block_hash, meta.ethereum_index))),
-		)
+			.iter()
+			.find(|meta| is_canon::<B, C>(client, meta.block_hash))
+			.map_or_else(
+				|| {
+					if !only_canonical && transaction_metadata.len() > 0 {
+						return Ok(Some((
+							transaction_metadata[0].ethereum_block_hash,
+							transaction_metadata[0].ethereum_index,
+						)));
+					}
+					Ok(None)
+				},
+				|meta| Ok(Some((meta.ethereum_block_hash, meta.ethereum_index))),
+			)
 	}
 }
 

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -181,12 +181,13 @@ pub mod frontier_backend_client {
 			.map_or_else(
 				|| {
 					if !only_canonical && transaction_metadata.len() > 0 {
-						return Ok(Some((
+						Ok(Some((
 							transaction_metadata[0].ethereum_block_hash,
 							transaction_metadata[0].ethereum_index,
 						)));
+					} else {
+						Ok(None)
 					}
-					Ok(None)
 				},
 				|meta| Ok(Some((meta.ethereum_block_hash, meta.ethereum_index))),
 			)

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -162,6 +162,7 @@ pub mod frontier_backend_client {
 		client: &C,
 		backend: &fc_db::Backend<B>,
 		transaction_hash: H256,
+		only_canonical: bool,
 	) -> RpcResult<Option<(H256, u32)>>
 	where
 		B: BlockT,

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -184,7 +184,7 @@ pub mod frontier_backend_client {
 						Ok(Some((
 							transaction_metadata[0].ethereum_block_hash,
 							transaction_metadata[0].ethereum_index,
-						)));
+						)))
 					} else {
 						Ok(None)
 					}


### PR DESCRIPTION
The receipt for a transaction that is not included in the canonical chain should be null
Fixes https://github.com/paritytech/frontier/issues/473