### PR TITLE
Add LRU cache for eth block data and transactions statuses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,6 +1565,7 @@ dependencies = [
  "jsonrpc-pubsub",
  "libsecp256k1 0.3.5",
  "log",
+ "lru",
  "pallet-ethereum",
  "pallet-evm",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1569,6 +1569,7 @@ dependencies = [
  "pallet-ethereum",
  "pallet-evm",
  "parity-scale-codec",
+ "parking_lot 0.11.1",
  "rand 0.7.3",
  "rlp",
  "rustc-hex",

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -42,6 +42,7 @@ sha3 = "0.8"
 rustc-hex = { version = "2.1.0", default-features = false }
 libsecp256k1 = "0.3"
 rand = "0.7"
+lru = "0.6.6"
 
 [features]
 rpc_binary_search_estimate = []

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -44,6 +44,7 @@ rustc-hex = { version = "2.1.0", default-features = false }
 libsecp256k1 = "0.3"
 rand = "0.7"
 lru = "0.6.6"
+parking_lot = "0.11.1"
 
 [features]
 rpc_binary_search_estimate = []

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -15,7 +15,10 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
-use crate::{EthSigner, StorageOverride, error_on_execution_failure, frontier_backend_client, internal_err, public_key};
+use crate::{
+	error_on_execution_failure, frontier_backend_client, internal_err, public_key, EthSigner,
+	StorageOverride,
+};
 use ethereum::{BlockV0 as EthereumBlock, TransactionV0 as EthereumTransaction};
 use ethereum_types::{H160, H256, H512, H64, U256, U64};
 use fc_rpc_core::types::{
@@ -295,7 +298,8 @@ where
 
 	while current_number >= from {
 		let id = BlockId::Number(current_number);
-		let substrate_hash = client.expect_block_hash_from_id(&id)
+		let substrate_hash = client
+			.expect_block_hash_from_id(&id)
 			.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
 
 		let schema = match default_schema {
@@ -331,7 +335,8 @@ where
 			if FilteredParams::address_in_bloom(block.header.logs_bloom, &address_bloom_filter)
 				&& FilteredParams::topics_in_bloom(block.header.logs_bloom, &topics_bloom_filter)
 			{
-				let statuses = block_data_cache.current_transaction_statuses(handler, substrate_hash);
+				let statuses =
+					block_data_cache.current_transaction_statuses(handler, substrate_hash);
 				if let Some(statuses) = statuses {
 					filter_block_logs(ret, filter, block, statuses);
 				}
@@ -561,7 +566,9 @@ where
 			Some(hash) => hash,
 			_ => return Ok(None),
 		};
-		let substrate_hash = self.client.expect_block_hash_from_id(&id)
+		let substrate_hash = self
+			.client
+			.expect_block_hash_from_id(&id)
 			.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
 
 		let schema =
@@ -573,7 +580,9 @@ where
 			.unwrap_or(&self.overrides.fallback);
 
 		let block = self.block_data_cache.current_block(handler, substrate_hash);
-		let statuses = self.block_data_cache.current_transaction_statuses(handler, substrate_hash);
+		let statuses = self
+			.block_data_cache
+			.current_transaction_statuses(handler, substrate_hash);
 
 		match (block, statuses) {
 			(Some(block), Some(statuses)) => Ok(Some(rich_block_build(
@@ -595,7 +604,9 @@ where
 			Some(id) => id,
 			None => return Ok(None),
 		};
-		let substrate_hash = self.client.expect_block_hash_from_id(&id)
+		let substrate_hash = self
+			.client
+			.expect_block_hash_from_id(&id)
 			.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
 
 		let schema =
@@ -607,7 +618,9 @@ where
 			.unwrap_or(&self.overrides.fallback);
 
 		let block = self.block_data_cache.current_block(handler, substrate_hash);
-		let statuses = self.block_data_cache.current_transaction_statuses(handler, substrate_hash);
+		let statuses = self
+			.block_data_cache
+			.current_transaction_statuses(handler, substrate_hash);
 
 		match (block, statuses) {
 			(Some(block), Some(statuses)) => {
@@ -1128,7 +1141,9 @@ where
 			Some(hash) => hash,
 			_ => return Ok(None),
 		};
-		let substrate_hash = self.client.expect_block_hash_from_id(&id)
+		let substrate_hash = self
+			.client
+			.expect_block_hash_from_id(&id)
 			.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
 
 		let schema =
@@ -1140,7 +1155,9 @@ where
 			.unwrap_or(&self.overrides.fallback);
 
 		let block = self.block_data_cache.current_block(handler, substrate_hash);
-		let statuses = self.block_data_cache.current_transaction_statuses(handler, substrate_hash);
+		let statuses = self
+			.block_data_cache
+			.current_transaction_statuses(handler, substrate_hash);
 
 		match (block, statuses) {
 			(Some(block), Some(statuses)) => Ok(Some(transaction_build(
@@ -1163,7 +1180,9 @@ where
 			Some(hash) => hash,
 			_ => return Ok(None),
 		};
-		let substrate_hash = self.client.expect_block_hash_from_id(&id)
+		let substrate_hash = self
+			.client
+			.expect_block_hash_from_id(&id)
 			.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
 
 		let index = index.value();
@@ -1177,7 +1196,9 @@ where
 			.unwrap_or(&self.overrides.fallback);
 
 		let block = self.block_data_cache.current_block(handler, substrate_hash);
-		let statuses = self.block_data_cache.current_transaction_statuses(handler, substrate_hash);
+		let statuses = self
+			.block_data_cache
+			.current_transaction_statuses(handler, substrate_hash);
 
 		match (block, statuses) {
 			(Some(block), Some(statuses)) => Ok(Some(transaction_build(
@@ -1202,7 +1223,9 @@ where
 			Some(id) => id,
 			None => return Ok(None),
 		};
-		let substrate_hash = self.client.expect_block_hash_from_id(&id)
+		let substrate_hash = self
+			.client
+			.expect_block_hash_from_id(&id)
 			.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
 
 		let index = index.value();
@@ -1215,7 +1238,9 @@ where
 			.unwrap_or(&self.overrides.fallback);
 
 		let block = self.block_data_cache.current_block(handler, substrate_hash);
-		let statuses = self.block_data_cache.current_transaction_statuses(handler, substrate_hash);
+		let statuses = self
+			.block_data_cache
+			.current_transaction_statuses(handler, substrate_hash);
 
 		match (block, statuses) {
 			(Some(block), Some(statuses)) => Ok(Some(transaction_build(
@@ -1246,7 +1271,9 @@ where
 			Some(hash) => hash,
 			_ => return Ok(None),
 		};
-		let substrate_hash = self.client.expect_block_hash_from_id(&id)
+		let substrate_hash = self
+			.client
+			.expect_block_hash_from_id(&id)
 			.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
 
 		let schema =
@@ -1258,7 +1285,9 @@ where
 			.unwrap_or(&self.overrides.fallback);
 
 		let block = self.block_data_cache.current_block(handler, substrate_hash);
-		let statuses = self.block_data_cache.current_transaction_statuses(handler, substrate_hash);
+		let statuses = self
+			.block_data_cache
+			.current_transaction_statuses(handler, substrate_hash);
 		let receipts = handler.current_receipts(&id);
 
 		match (block, statuses, receipts) {
@@ -1347,7 +1376,9 @@ where
 				Some(hash) => hash,
 				_ => return Ok(Vec::new()),
 			};
-			let substrate_hash = self.client.expect_block_hash_from_id(&id)
+			let substrate_hash = self
+				.client
+				.expect_block_hash_from_id(&id)
 				.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
 
 			let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(
@@ -1361,7 +1392,9 @@ where
 				.unwrap_or(&self.overrides.fallback);
 
 			let block = self.block_data_cache.current_block(handler, substrate_hash);
-			let statuses = self.block_data_cache.current_transaction_statuses(handler, substrate_hash);
+			let statuses = self
+				.block_data_cache
+				.current_transaction_statuses(handler, substrate_hash);
 			if let (Some(block), Some(statuses)) = (block, statuses) {
 				filter_block_logs(&mut ret, &filter, block, statuses);
 			}
@@ -1643,8 +1676,10 @@ where
 						let mut ethereum_hashes: Vec<H256> = Vec::new();
 						for n in last..next {
 							let id = BlockId::Number(n.unique_saturated_into());
-							let substrate_hash = self.client.expect_block_hash_from_id(&id)
-								.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
+							let substrate_hash =
+								self.client.expect_block_hash_from_id(&id).map_err(|_| {
+									internal_err(format!("Expect block number from id: {}", id))
+								})?;
 
 							let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(
 								self.client.as_ref(),
@@ -1656,7 +1691,8 @@ where
 								.get(&schema)
 								.unwrap_or(&self.overrides.fallback);
 
-							let block = self.block_data_cache.current_block(handler, substrate_hash);
+							let block =
+								self.block_data_cache.current_block(handler, substrate_hash);
 							if let Some(block) = block {
 								ethereum_hashes.push(block.header.hash())
 							}
@@ -1947,13 +1983,9 @@ pub struct EthBlockDataCache<B: BlockT> {
 	statuses: parking_lot::Mutex<LruCache<B::Hash, Vec<TransactionStatus>>>,
 }
 
-impl<B: BlockT> EthBlockDataCache<B>
-{
+impl<B: BlockT> EthBlockDataCache<B> {
 	/// Create a new cache with provided cache sizes.
-	pub fn new(
-		blocks_cache_size: usize,
-		statuses_cache_size: usize,
-	) -> Self {
+	pub fn new(blocks_cache_size: usize, statuses_cache_size: usize) -> Self {
 		Self {
 			blocks: parking_lot::Mutex::new(LruCache::new(blocks_cache_size)),
 			statuses: parking_lot::Mutex::new(LruCache::new(statuses_cache_size)),
@@ -1966,7 +1998,6 @@ impl<B: BlockT> EthBlockDataCache<B>
 		handler: &Box<dyn StorageOverride<B> + Send + Sync>,
 		substrate_block_hash: B::Hash,
 	) -> Option<EthereumBlock> {
-
 		{
 			let mut cache = self.blocks.lock();
 			if let Some(block) = cache.get(&substrate_block_hash).cloned() {
@@ -1990,7 +2021,6 @@ impl<B: BlockT> EthBlockDataCache<B>
 		handler: &Box<dyn StorageOverride<B> + Send + Sync>,
 		substrate_block_hash: B::Hash,
 	) -> Option<Vec<TransactionStatus>> {
-
 		{
 			let mut cache = self.statuses.lock();
 			if let Some(statuses) = cache.get(&substrate_block_hash).cloned() {
@@ -1998,7 +2028,9 @@ impl<B: BlockT> EthBlockDataCache<B>
 			}
 		}
 
-		if let Some(statuses) = handler.current_transaction_statuses(&BlockId::Hash(substrate_block_hash)) {
+		if let Some(statuses) =
+			handler.current_transaction_statuses(&BlockId::Hash(substrate_block_hash))
+		{
 			let mut cache = self.statuses.lock();
 			cache.put(substrate_block_hash, statuses.clone());
 

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -15,9 +15,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
-use crate::{
-	error_on_execution_failure, frontier_backend_client, internal_err, public_key, EthSigner,
-};
+use crate::{EthSigner, StorageOverride, error_on_execution_failure, frontier_backend_client, internal_err, public_key};
 use ethereum::{BlockV0 as EthereumBlock, TransactionV0 as EthereumTransaction};
 use ethereum_types::{H160, H256, H512, H64, U256, U64};
 use fc_rpc_core::types::{
@@ -32,6 +30,7 @@ use fc_rpc_core::{
 use fp_rpc::{ConvertTransaction, EthereumRuntimeRPCApi, TransactionStatus};
 use futures::{future::TryFutureExt, StreamExt};
 use jsonrpc_core::{futures::future, BoxFuture, ErrorCode, Result};
+use lru::LruCache;
 use sc_client_api::{
 	backend::{AuxStore, Backend, StateBackend, StorageProvider},
 	client::BlockchainEvents,
@@ -68,6 +67,7 @@ pub struct EthApi<B: BlockT, C, P, CT, BE, H: ExHashT> {
 	pending_transactions: PendingTransactions,
 	backend: Arc<fc_db::Backend<B>>,
 	max_past_logs: u32,
+	block_data_cache: Arc<EthBlockDataCache<B>>,
 	_marker: PhantomData<(B, BE)>,
 }
 
@@ -89,9 +89,10 @@ where
 		backend: Arc<fc_db::Backend<B>>,
 		is_authority: bool,
 		max_past_logs: u32,
+		block_data_cache: Arc<EthBlockDataCache<B>>,
 	) -> Self {
 		Self {
-			client: client.clone(),
+			client,
 			pool,
 			convert_transaction,
 			network,
@@ -101,6 +102,7 @@ where
 			pending_transactions,
 			backend,
 			max_past_logs,
+			block_data_cache,
 			_marker: PhantomData,
 		}
 	}
@@ -240,6 +242,7 @@ fn filter_range_logs<B: BlockT, C, BE>(
 	client: &C,
 	backend: &fc_db::Backend<B>,
 	overrides: &OverrideHandle<B>,
+	block_data_cache: &EthBlockDataCache<B>,
 	ret: &mut Vec<Log>,
 	max_past_logs: u32,
 	filter: &Filter,
@@ -291,6 +294,9 @@ where
 
 	while current_number >= from {
 		let id = BlockId::Number(current_number);
+		let substrate_hash = client.expect_block_hash_from_id(&id)
+			.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
+
 		let schema = match default_schema {
 			// If there is a single schema, we just assign.
 			Some(default_schema) => *default_schema,
@@ -318,13 +324,13 @@ where
 			.get(&schema)
 			.unwrap_or(&overrides.fallback);
 
-		let block = handler.current_block(&id);
+		let block = block_data_cache.current_block(handler, substrate_hash);
 
 		if let Some(block) = block {
 			if FilteredParams::address_in_bloom(block.header.logs_bloom, &address_bloom_filter)
 				&& FilteredParams::topics_in_bloom(block.header.logs_bloom, &topics_bloom_filter)
 			{
-				let statuses = handler.current_transaction_statuses(&id);
+				let statuses = block_data_cache.current_transaction_statuses(handler, substrate_hash);
 				if let Some(statuses) = statuses {
 					filter_block_logs(ret, filter, block, statuses);
 				}
@@ -553,6 +559,9 @@ where
 			Some(hash) => hash,
 			_ => return Ok(None),
 		};
+		let substrate_hash = self.client.expect_block_hash_from_id(&id)
+			.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
+
 		let schema =
 			frontier_backend_client::onchain_storage_schema::<B, C, BE>(self.client.as_ref(), id);
 		let handler = self
@@ -561,8 +570,8 @@ where
 			.get(&schema)
 			.unwrap_or(&self.overrides.fallback);
 
-		let block = handler.current_block(&id);
-		let statuses = handler.current_transaction_statuses(&id);
+		let block = self.block_data_cache.current_block(handler, substrate_hash);
+		let statuses = self.block_data_cache.current_transaction_statuses(handler, substrate_hash);
 
 		match (block, statuses) {
 			(Some(block), Some(statuses)) => Ok(Some(rich_block_build(
@@ -584,6 +593,9 @@ where
 			Some(id) => id,
 			None => return Ok(None),
 		};
+		let substrate_hash = self.client.expect_block_hash_from_id(&id)
+			.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
+
 		let schema =
 			frontier_backend_client::onchain_storage_schema::<B, C, BE>(self.client.as_ref(), id);
 		let handler = self
@@ -592,8 +604,8 @@ where
 			.get(&schema)
 			.unwrap_or(&self.overrides.fallback);
 
-		let block = handler.current_block(&id);
-		let statuses = handler.current_transaction_statuses(&id);
+		let block = self.block_data_cache.current_block(handler, substrate_hash);
+		let statuses = self.block_data_cache.current_transaction_statuses(handler, substrate_hash);
 
 		match (block, statuses) {
 			(Some(block), Some(statuses)) => {
@@ -947,7 +959,8 @@ where
 	fn estimate_gas(&self, request: CallRequest, _: Option<BlockNumber>) -> Result<U256> {
 		let gas_limit = {
 			// query current block's gas limit
-			let id = BlockId::Hash(self.client.info().best_hash);
+			let substrate_hash = self.client.info().best_hash;
+			let id = BlockId::Hash(substrate_hash);
 			let schema =
 				frontier_backend_client::onchain_storage_schema::<B, C, BE>(&self.client, id);
 			let handler = self
@@ -956,7 +969,7 @@ where
 				.get(&schema)
 				.unwrap_or(&self.overrides.fallback);
 
-			let block = handler.current_block(&id);
+			let block = self.block_data_cache.current_block(handler, substrate_hash);
 			if let Some(block) = block {
 				block.header.gas_limit
 			} else {
@@ -1115,6 +1128,9 @@ where
 			Some(hash) => hash,
 			_ => return Ok(None),
 		};
+		let substrate_hash = self.client.expect_block_hash_from_id(&id)
+			.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
+
 		let schema =
 			frontier_backend_client::onchain_storage_schema::<B, C, BE>(self.client.as_ref(), id);
 		let handler = self
@@ -1123,8 +1139,8 @@ where
 			.get(&schema)
 			.unwrap_or(&self.overrides.fallback);
 
-		let block = handler.current_block(&id);
-		let statuses = handler.current_transaction_statuses(&id);
+		let block = self.block_data_cache.current_block(handler, substrate_hash);
+		let statuses = self.block_data_cache.current_transaction_statuses(handler, substrate_hash);
 
 		match (block, statuses) {
 			(Some(block), Some(statuses)) => Ok(Some(transaction_build(
@@ -1147,6 +1163,9 @@ where
 			Some(hash) => hash,
 			_ => return Ok(None),
 		};
+		let substrate_hash = self.client.expect_block_hash_from_id(&id)
+			.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
+
 		let index = index.value();
 
 		let schema =
@@ -1157,8 +1176,8 @@ where
 			.get(&schema)
 			.unwrap_or(&self.overrides.fallback);
 
-		let block = handler.current_block(&id);
-		let statuses = handler.current_transaction_statuses(&id);
+		let block = self.block_data_cache.current_block(handler, substrate_hash);
+		let statuses = self.block_data_cache.current_transaction_statuses(handler, substrate_hash);
 
 		match (block, statuses) {
 			(Some(block), Some(statuses)) => Ok(Some(transaction_build(
@@ -1183,6 +1202,9 @@ where
 			Some(id) => id,
 			None => return Ok(None),
 		};
+		let substrate_hash = self.client.expect_block_hash_from_id(&id)
+			.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
+
 		let index = index.value();
 		let schema =
 			frontier_backend_client::onchain_storage_schema::<B, C, BE>(self.client.as_ref(), id);
@@ -1192,8 +1214,8 @@ where
 			.get(&schema)
 			.unwrap_or(&self.overrides.fallback);
 
-		let block = handler.current_block(&id);
-		let statuses = handler.current_transaction_statuses(&id);
+		let block = self.block_data_cache.current_block(handler, substrate_hash);
+		let statuses = self.block_data_cache.current_transaction_statuses(handler, substrate_hash);
 
 		match (block, statuses) {
 			(Some(block), Some(statuses)) => Ok(Some(transaction_build(
@@ -1223,6 +1245,9 @@ where
 			Some(hash) => hash,
 			_ => return Ok(None),
 		};
+		let substrate_hash = self.client.expect_block_hash_from_id(&id)
+			.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
+
 		let schema =
 			frontier_backend_client::onchain_storage_schema::<B, C, BE>(self.client.as_ref(), id);
 		let handler = self
@@ -1231,8 +1256,8 @@ where
 			.get(&schema)
 			.unwrap_or(&self.overrides.fallback);
 
-		let block = handler.current_block(&id);
-		let statuses = handler.current_transaction_statuses(&id);
+		let block = self.block_data_cache.current_block(handler, substrate_hash);
+		let statuses = self.block_data_cache.current_transaction_statuses(handler, substrate_hash);
 		let receipts = handler.current_receipts(&id);
 
 		match (block, statuses, receipts) {
@@ -1321,6 +1346,8 @@ where
 				Some(hash) => hash,
 				_ => return Ok(Vec::new()),
 			};
+			let substrate_hash = self.client.expect_block_hash_from_id(&id)
+				.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
 
 			let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(
 				self.client.as_ref(),
@@ -1332,8 +1359,8 @@ where
 				.get(&schema)
 				.unwrap_or(&self.overrides.fallback);
 
-			let block = handler.current_block(&id);
-			let statuses = handler.current_transaction_statuses(&id);
+			let block = self.block_data_cache.current_block(handler, substrate_hash);
+			let statuses = self.block_data_cache.current_transaction_statuses(handler, substrate_hash);
 			if let (Some(block), Some(statuses)) = (block, statuses) {
 				filter_block_logs(&mut ret, &filter, block, statuses);
 			}
@@ -1361,6 +1388,7 @@ where
 				self.client.as_ref(),
 				self.backend.as_ref(),
 				&self.overrides,
+				&self.block_data_cache,
 				&mut ret,
 				self.max_past_logs,
 				&filter,
@@ -1497,6 +1525,7 @@ pub struct EthFilterApi<B: BlockT, C, BE> {
 	max_stored_filters: usize,
 	overrides: Arc<OverrideHandle<B>>,
 	max_past_logs: u32,
+	block_data_cache: Arc<EthBlockDataCache<B>>,
 	_marker: PhantomData<(B, BE)>,
 }
 
@@ -1516,14 +1545,16 @@ where
 		max_stored_filters: usize,
 		overrides: Arc<OverrideHandle<B>>,
 		max_past_logs: u32,
+		block_data_cache: Arc<EthBlockDataCache<B>>,
 	) -> Self {
 		Self {
-			client: client.clone(),
-			backend: backend.clone(),
+			client,
+			backend,
 			filter_pool,
 			max_stored_filters,
 			overrides,
 			max_past_logs,
+			block_data_cache,
 			_marker: PhantomData,
 		}
 	}
@@ -1611,6 +1642,8 @@ where
 						let mut ethereum_hashes: Vec<H256> = Vec::new();
 						for n in last..next {
 							let id = BlockId::Number(n.unique_saturated_into());
+							let substrate_hash = self.client.expect_block_hash_from_id(&id)
+								.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
 
 							let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(
 								self.client.as_ref(),
@@ -1622,7 +1655,7 @@ where
 								.get(&schema)
 								.unwrap_or(&self.overrides.fallback);
 
-							let block = handler.current_block(&id);
+							let block = self.block_data_cache.current_block(handler, substrate_hash);
 							if let Some(block) = block {
 								ethereum_hashes.push(block.header.hash())
 							}
@@ -1675,6 +1708,7 @@ where
 							self.client.as_ref(),
 							self.backend.as_ref(),
 							&self.overrides,
+							&self.block_data_cache,
 							&mut ret,
 							self.max_past_logs,
 							&filter,
@@ -1741,6 +1775,7 @@ where
 							self.client.as_ref(),
 							self.backend.as_ref(),
 							&self.overrides,
+							&self.block_data_cache,
 							&mut ret,
 							self.max_past_logs,
 							&filter,
@@ -1935,5 +1970,76 @@ where
 				}
 			}
 		}
+	}
+}
+
+/// Stores an LRU cache for block data and their transaction statuses.
+/// These are large and take a lot of time to fetch from the database.
+/// Storing them in an LRU cache will allow to reduce database accesses
+/// when many subsequent requests are related to the same blocks.
+pub struct EthBlockDataCache<B: BlockT> {
+	blocks: Mutex<LruCache<B::Hash, EthereumBlock>>,
+	statuses: Mutex<LruCache<B::Hash, Vec<TransactionStatus>>>,
+}
+
+impl<B: BlockT> EthBlockDataCache<B>
+{
+	/// Create a new cache with provided cache sizes.
+	pub fn new(
+		blocks_cache_size: usize,
+		statuses_cache_size: usize,
+	) -> Self {
+		Self {
+			blocks: Mutex::new(LruCache::new(blocks_cache_size)),
+			statuses: Mutex::new(LruCache::new(statuses_cache_size)),
+		}
+	}
+
+	/// Cache for `handler.current_block`.
+	pub fn current_block(
+		&self,
+		handler: &Box<dyn StorageOverride<B> + Send + Sync>,
+		substrate_block_hash: B::Hash,
+	) -> Option<EthereumBlock> {
+
+		if let Ok(mut cache) = self.blocks.lock() {
+			if let Some(block) = cache.get(&substrate_block_hash).cloned() {
+				return Some(block);
+			}
+		}
+
+		if let Some(block) = handler.current_block(&BlockId::Hash(substrate_block_hash)) {
+			if let Ok(mut cache) = self.blocks.lock() {
+				cache.put(substrate_block_hash, block.clone());
+			}
+
+			return Some(block);
+		}
+
+		None
+	}
+
+	/// Cache for `handler.current_transaction_statuses`.
+	pub fn current_transaction_statuses(
+		&self,
+		handler: &Box<dyn StorageOverride<B> + Send + Sync>,
+		substrate_block_hash: B::Hash,
+	) -> Option<Vec<TransactionStatus>> {
+
+		if let Ok(mut cache) = self.statuses.lock() {
+			if let Some(statuses) = cache.get(&substrate_block_hash).cloned() {
+				return Some(statuses);
+			}
+		}
+
+		if let Some(statuses) = handler.current_transaction_statuses(&BlockId::Hash(substrate_block_hash)) {
+			if let Ok(mut cache) = self.statuses.lock() {
+				cache.put(substrate_block_hash, statuses.clone());
+			}
+
+			return Some(statuses);
+		}
+
+		None
 	}
 }

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -22,7 +22,7 @@ mod overrides;
 
 pub use eth::{
 	EthApi, EthApiServer, EthFilterApi, EthFilterApiServer, EthTask, NetApi, NetApiServer, Web3Api,
-	Web3ApiServer,
+	Web3ApiServer, EthBlockDataCache,
 };
 pub use eth_pubsub::{EthPubSubApi, EthPubSubApiServer, HexEncodedIdProvider};
 pub use overrides::{OverrideHandle, RuntimeApiStorageOverride, SchemaV1Override, StorageOverride};

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -21,8 +21,8 @@ mod eth_pubsub;
 mod overrides;
 
 pub use eth::{
-	EthApi, EthApiServer, EthFilterApi, EthFilterApiServer, EthTask, NetApi, NetApiServer, Web3Api,
-	Web3ApiServer, EthBlockDataCache,
+	EthApi, EthApiServer, EthBlockDataCache, EthFilterApi, EthFilterApiServer, EthTask, NetApi,
+	NetApiServer, Web3Api, Web3ApiServer,
 };
 pub use eth_pubsub::{EthPubSubApi, EthPubSubApiServer, HexEncodedIdProvider};
 pub use overrides::{OverrideHandle, RuntimeApiStorageOverride, SchemaV1Override, StorageOverride};

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -2,7 +2,9 @@
 
 use std::sync::Arc;
 
-use fc_rpc::{EthBlockDataCache, OverrideHandle, RuntimeApiStorageOverride, SchemaV1Override, StorageOverride};
+use fc_rpc::{
+	EthBlockDataCache, OverrideHandle, RuntimeApiStorageOverride, SchemaV1Override, StorageOverride,
+};
 use fc_rpc_core::types::FilterPool;
 use frontier_template_runtime::{opaque::Block, AccountId, Balance, Hash, Index};
 use jsonrpc_pubsub::manager::SubscriptionManager;

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use fc_rpc::{OverrideHandle, RuntimeApiStorageOverride, SchemaV1Override, StorageOverride};
+use fc_rpc::{EthBlockDataCache, OverrideHandle, RuntimeApiStorageOverride, SchemaV1Override, StorageOverride};
 use fc_rpc_core::types::{FilterPool, PendingTransactions};
 use frontier_template_runtime::{opaque::Block, AccountId, Balance, Hash, Index};
 use jsonrpc_pubsub::manager::SubscriptionManager;
@@ -127,6 +127,8 @@ where
 		fallback: Box::new(RuntimeApiStorageOverride::new(client.clone())),
 	});
 
+	let block_data_cache = Arc::new(EthBlockDataCache::new(50, 50));
+
 	io.extend_with(EthApiServer::to_delegate(EthApi::new(
 		client.clone(),
 		pool.clone(),
@@ -138,6 +140,7 @@ where
 		backend.clone(),
 		is_authority,
 		max_past_logs,
+		block_data_cache.clone(),
 	)));
 
 	if let Some(filter_pool) = filter_pool {
@@ -148,6 +151,7 @@ where
 			500 as usize, // max stored filters
 			overrides.clone(),
 			max_past_logs,
+			block_data_cache.clone(),
 		)));
 	}
 


### PR DESCRIPTION
When calling RPC (mainly related to logs) a lot of time is spent fetching the data from the database.
This PR adds an LRU cache to avoid reaching the database when many requests are related to the same block (this happen a lot with block explorers).

The cache use the substrate block hash as a key, as it won't change in case of reorg (instead of block id/height).

# Followups / alternatives
- Since these RPC apis are not async, this PR doesn't use async. When a block is not cached, it will fetch the database **while not holding the lock**, then obtain the lock only to insert the block data. It means while a block data is fetched other requests will also fetch the database. Only when one of them will put the data into the cache that subsequent requests will use the cache and not reach the DB. This is suboptimal but better than keeping the lock and preventing other blocks to be fetched/cached.
If those RPC were converted to async a background task could manage the actual caching and access to the database, and would send the data back to the request handler through an async oneshot channel. If doing this async convertion is acceptable then I'll work on implementing it.
- This cache have a limit in the number of blocks it keeps. However it doesn't look at their memory size, and the size of blocks can vary a lot. It may be better to put a memory limit to avoid exhausting resources in case of a lot of full blocks.