### PR TITLE
Prune unused imports

### DIFF
--- a/frame/evm/precompile/blake2/src/lib.rs
+++ b/frame/evm/precompile/blake2/src/lib.rs
@@ -21,7 +21,6 @@ extern crate alloc;
 
 mod eip_152;
 
-use alloc::vec::Vec;
 use core::mem::size_of;
 use evm::{executor::PrecompileOutput, Context, ExitError, ExitSucceed};
 use fp_evm::Precompile;

--- a/frame/evm/precompile/dispatch/src/lib.rs
+++ b/frame/evm/precompile/dispatch/src/lib.rs
@@ -19,7 +19,6 @@
 
 extern crate alloc;
 
-use alloc::vec::Vec;
 use codec::Decode;
 use core::marker::PhantomData;
 use evm::{executor::PrecompileOutput, Context, ExitError, ExitSucceed};

--- a/frame/evm/test-vector-support/src/lib.rs
+++ b/frame/evm/test-vector-support/src/lib.rs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use evm::{executor::PrecompileOutput, Context, ExitSucceed};
+use evm::{Context, ExitSucceed};
 use fp_evm::Precompile;
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
This PR removes a few unused imports that cause build warnings. This only covers library code, not the template (which is a very noisy build and a separate issue).