### PR TITLE
Estimate gas: impl geth algorithm for binary search

### DIFF
--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 use ethereum::{BlockV0 as EthereumBlock, TransactionV0 as EthereumTransaction};
 use ethereum_types::{H160, H256, H512, H64, U256, U64};
+use evm::ExitReason;
 use fc_rpc_core::{
 	types::{
 		Block, BlockNumber, BlockTransactions, Bytes, CallRequest, Filter, FilterChanges,
@@ -942,29 +943,73 @@ where
 	}
 
 	fn estimate_gas(&self, request: CallRequest, _: Option<BlockNumber>) -> Result<U256> {
-		let gas_limit = {
-			// query current block's gas limit
-			let substrate_hash = self.client.info().best_hash;
-			let id = BlockId::Hash(substrate_hash);
-			let schema =
-				frontier_backend_client::onchain_storage_schema::<B, C, BE>(&self.client, id);
-			let handler = self
-				.overrides
-				.schemas
-				.get(&schema)
-				.unwrap_or(&self.overrides.fallback);
+		// Get best hash
+		let best_hash = self.client.info().best_hash;
 
-			let block = self.block_data_cache.current_block(handler, substrate_hash);
-			if let Some(block) = block {
-				block.header.gas_limit
-			} else {
-				return Err(internal_err("block unavailable, cannot query gas limit"));
+		// Get gas price
+		let gas_price = request.gas_price.unwrap_or_default();
+
+		// Determine the highest possible gas limits
+		let mut highest = match request.gas {
+			Some(gas) => gas,
+			None => {
+				// query current block's gas limit
+				let substrate_hash = self.client.info().best_hash;
+				let id = BlockId::Hash(substrate_hash);
+				let schema =
+					frontier_backend_client::onchain_storage_schema::<B, C, BE>(&self.client, id);
+				let handler = self
+					.overrides
+					.schemas
+					.get(&schema)
+					.unwrap_or(&self.overrides.fallback);
+
+				let block = self.block_data_cache.current_block(handler, substrate_hash);
+				if let Some(block) = block {
+					block.header.gas_limit
+				} else {
+					return Err(internal_err("block unavailable, cannot query gas limit"));
+				}
 			}
 		};
 
-		let calculate_gas_used = |request, gas_limit| -> Result<U256> {
-			let hash = self.client.info().best_hash;
+		// Recap the highest gas allowance with account's balance.
+		if let Some(from) = request.from {
+			if gas_price > U256::zero() {
+				let balance = self
+					.client
+					.runtime_api()
+					.account_basic(&BlockId::Hash(best_hash), from)
+					.map_err(|err| internal_err(format!("runtime error: {:?}", err)))?
+					.balance;
+				let mut available = balance;
+				if let Some(value) = request.value {
+					if value > available {
+						return Err(internal_err("insufficient funds for transfer"));
+					}
+					available -= value;
+				}
+				let allowance = available / gas_price;
+				if highest > allowance {
+					log::warn!(
+						"Gas estimation capped by limited funds original {} balance {} sent {} feecap {} fundable {}",
+						highest,
+						balance,
+						request.value.unwrap_or_default(),
+						gas_price,
+						allowance
+					);
+					highest = allowance;
+				}
+			}
+		}
 
+		// Create a helper to check if a gas allowance results in an executable transaction
+		#[cfg(feature = "rpc_binary_search_estimate")]
+		type TrialResult = Result<bool>;
+		#[cfg(not(feature = "rpc_binary_search_estimate"))]
+		type TrialResult = Result<U256>;
+		let executable = move |request: CallRequest, gas_limit| -> TrialResult {
 			let CallRequest {
 				from,
 				to,
@@ -980,13 +1025,13 @@ where
 
 			let data = data.map(|d| d.0).unwrap_or_default();
 
-			let used_gas = match to {
+			let (exit_reason, data, used_gas) = match to {
 				Some(to) => {
 					let info = self
 						.client
 						.runtime_api()
 						.call(
-							&BlockId::Hash(hash),
+							&BlockId::Hash(best_hash),
 							from.unwrap_or_default(),
 							to,
 							data,
@@ -999,16 +1044,14 @@ where
 						.map_err(|err| internal_err(format!("runtime error: {:?}", err)))?
 						.map_err(|err| internal_err(format!("execution fatal: {:?}", err)))?;
 
-					error_on_execution_failure(&info.exit_reason, &info.value)?;
-
-					info.used_gas
+					(info.exit_reason, info.value, info.used_gas)
 				}
 				None => {
 					let info = self
 						.client
 						.runtime_api()
 						.create(
-							&BlockId::Hash(hash),
+							&BlockId::Hash(best_hash),
 							from.unwrap_or_default(),
 							data,
 							value.unwrap_or_default(),
@@ -1020,69 +1063,62 @@ where
 						.map_err(|err| internal_err(format!("runtime error: {:?}", err)))?
 						.map_err(|err| internal_err(format!("execution fatal: {:?}", err)))?;
 
-					error_on_execution_failure(&info.exit_reason, &[])?;
-
-					info.used_gas
+					(info.exit_reason, Vec::new(), info.used_gas)
 				}
 			};
 
-			Ok(used_gas)
-		};
-		if cfg!(feature = "rpc_binary_search_estimate") {
-			const MAX_OOG_PER_ESTIMATE_QUERY: u32 = 2;
-
-			let mut lower = U256::from(21_000);
-			// TODO: get a good upper limit, but below U64::max to operation overflow
-			let mut upper = U256::from(gas_limit);
-			let mut mid = upper;
-			let mut best = mid;
-			let mut old_best: U256;
-			let mut num_oog = 0;
-
-			// if the gas estimation depends on the gas limit, then we want to binary
-			// search until the change is under some threshold. but if not dependent,
-			// we want to stop immediately.
-			let mut change_pct = U256::from(100);
-			let threshold_pct = U256::from(10);
-
-			// invariant: lower <= mid <= upper
-			while change_pct > threshold_pct {
-				let mut test_request = request.clone();
-				test_request.gas = Some(mid);
-				match calculate_gas_used(test_request, gas_limit) {
-					// if Ok -- try to reduce the gas used
-					Ok(used_gas) => {
-						old_best = best;
-						best = used_gas;
-						change_pct = (U256::from(100) * (old_best - best)) / old_best;
-						upper = mid;
-						mid = (lower + upper + 1) / 2;
+			#[cfg(not(feature = "rpc_binary_search_estimate"))]
+			{
+				error_on_execution_failure(&exit_reason, &data).map(|()| used_gas)
+			}
+			#[cfg(feature = "rpc_binary_search_estimate")]
+			{
+				match exit_reason {
+					ExitReason::Succeed(_) => Ok(true),
+					ExitReason::Revert(_) | ExitReason::Error(evm::ExitError::OutOfGas) => {
+						Ok(false)
 					}
-
-					Err(err) => {
-						// if Err == OutofGas, we need more gas
-						if err.code == ErrorCode::ServerError(0) {
-							num_oog += 1;
-							// don't try more than twice if we oog
-							if num_oog >= MAX_OOG_PER_ESTIMATE_QUERY {
-								return Err(err);
-							}
-
-							lower = mid;
-							mid = (lower + upper + 1) / 2;
-							if mid == lower {
-								break;
-							}
-						} else {
-							// Other errors, return directly
-							return Err(err);
-						}
-					}
+					other => error_on_execution_failure(&other, &data).map(|()| true),
 				}
 			}
-			Ok(best)
-		} else {
-			calculate_gas_used(request, gas_limit)
+		};
+
+		#[cfg(not(feature = "rpc_binary_search_estimate"))]
+		{
+			Ok(executable(request.clone(), highest)?)
+		}
+		#[cfg(feature = "rpc_binary_search_estimate")]
+		{
+			// Execute the binary search and hone in on an executable gas limit
+			const MAX_TRIALS: usize = 6; // With 6 trials we have a precision of 1/2^5 = 3,125%.
+			const MIN_GAS_PER_TX: U256 = U256([21_000, 0, 0, 0]);
+			let cap = highest;
+			let mut lowest = MIN_GAS_PER_TX;
+			let mut trials_count = 0;
+			while trials_count < MAX_TRIALS && (highest - lowest) > U256::one() {
+				let mid = (highest + lowest) / 2;
+
+				if executable(request.clone(), mid)? {
+					highest = mid;
+				} else {
+					lowest = mid;
+				}
+				trials_count += 1;
+			}
+
+			// Reject the transaction as invalid if it still fails at the highest allowance
+			if highest == cap {
+				if executable(request.clone(), highest)? {
+					Ok(highest)
+				} else {
+					Err(internal_err(format!(
+						"gas required exceeds allowance {}",
+						cap
+					)))
+				}
+			} else {
+				Ok(highest)
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR is a complete redesign of the binary search algo to implement the geth one: https://github.com/ethereum/go-ethereum/blob/master/accounts/abi/bind/backends/simulated.go#L476-L576

The old frontier implementation was incorrect because it optimized gas used when it should optimize gas limit.
Indeed, the value returned by this RPC call will be used by the user as gas_limit, it is the gas limit that needs to be estimated, not the actual used gas.
Some smart contract calls will fail even if the gas limit provided is higher than the gas used during the estimation, for example this one: https://github.com/gnosis/safe-contracts/blob/34c87b783dfd04ff09ef7c358c3182c3c151e086/contracts/GnosisSafe.sol#L170

However, this PR keeps 2 differences with the implementation of geth:

1. When the feature `rpc_binary_search_estimate` is disabled, only one estimate is done and the gas used is returned, I think this is a bad idea and that a binary search should be done systematically as geth does, I have kept this behavior only for compatibility reasons.
2. The binary search algo of geth continues until the difference between the 2 bounds is one or zero, this guarantees a maximum precision of the estimation but makes the call more expensive. For this PR I chose to limit the binary search to `6` iterations. This already guarantees a precision of `1/2^5` or `3,125%`, the maximum overestimate would be about `3%` (against `10%` for the old implementation), which seems to me more than satisfactory

