### PR TITLE
Move `find_pre_log` out of `do_transact`

### DIFF
--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -250,7 +250,7 @@ pub mod pallet {
 			Pending::<T>::kill();
 
 			// If the digest contain an existing ethereum block(encoded as PreLog), If contains,
-			// execute the imported block firstly and disable do_transact dispatch function.
+			// execute the imported block firstly and disable transact dispatch function.
 			if let Ok(log) = fp_consensus::find_pre_log(&frame_system::Pallet::<T>::digest()) {
 				let PreLog::Block(block) = log;
 
@@ -281,6 +281,11 @@ pub mod pallet {
 			transaction: Transaction,
 		) -> DispatchResultWithPostInfo {
 			let source = ensure_ethereum_transaction(origin)?;
+			// Disable transact functionality if PreLog exist.
+			ensure!(
+				fp_consensus::find_pre_log(&frame_system::Pallet::<T>::digest()).is_err(),
+				Error::<T>::PreLogExists,
+			);
 
 			Self::do_transact(source, transaction)
 		}
@@ -414,12 +419,6 @@ impl<T: Config> Pallet<T> {
 	}
 
 	fn do_transact(source: H160, transaction: Transaction) -> DispatchResultWithPostInfo {
-		// Disable do transact functionality if PreLog exist.
-		ensure!(
-			fp_consensus::find_pre_log(&frame_system::Pallet::<T>::digest()).is_err(),
-			Error::<T>::PreLogExists,
-		);
-
 		let transaction_hash =
 			H256::from_slice(Keccak256::digest(&rlp::encode(&transaction)).as_slice());
 		let transaction_index = Pending::<T>::get().len() as u32;

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -249,6 +249,8 @@ pub mod pallet {
 		fn on_initialize(_: T::BlockNumber) -> Weight {
 			Pending::<T>::kill();
 
+			// If the digest contain an existing ethereum block(encoded as PreLog), If contains,
+			// execute the imported block firstly and disable do_transact dispatch function.
 			if let Ok(log) = fp_consensus::find_pre_log(&frame_system::Pallet::<T>::digest()) {
 				let PreLog::Block(block) = log;
 
@@ -412,6 +414,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	fn do_transact(source: H160, transaction: Transaction) -> DispatchResultWithPostInfo {
+		// Disable do transact functionality if PreLog exist.
 		ensure!(
 			fp_consensus::find_pre_log(&frame_system::Pallet::<T>::digest()).is_err(),
 			Error::<T>::PreLogExists,


### PR DESCRIPTION
The original `find_pre_log` check causes an unexpected error when PreLog exists.

```rs
// on_initialize(_)
if let Ok(log) = fp_consensus::find_pre_log(&frame_system::Pallet::<T>::digest()) {
    ...
    Self::do_transact(source, transaction).expect("pre-block transaction verification failed; the block cannot be built");
    ....
}

do_transact(_, _) {
     // Always return Ok(...) in the case of PreLog exists, right? 
     // Because this transaction cames from on_initialize()  and digest contains PreLog
    ensure!(fp_consensus::find_pre_log(&frame_system::Pallet::<T>::digest()).is_err(), Error::<T>::PreLogExists);
    ...
}
```

