### PR TITLE
Fix check gas_price failed in dynamic fee case

### DIFF
--- a/frame/dynamic-fee/src/tests.rs
+++ b/frame/dynamic-fee/src/tests.rs
@@ -82,9 +82,11 @@ impl pallet_timestamp::Config for Test {
 
 frame_support::parameter_types! {
 	pub BoundDivision: U256 = 1024.into();
+	pub BaseGasPrice: U256 = 1.into();
 }
 impl Config for Test {
 	type MinGasPriceBoundDivisor = BoundDivision;
+	type BaseGasPrice = BaseGasPrice;
 }
 
 frame_support::construct_runtime!(

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -170,8 +170,7 @@ where
 					return InvalidTransaction::Payment.into();
 				}
 
-				let min_gas_price = T::FeeCalculator::min_gas_price();
-
+				let min_gas_price = T::FeeCalculator::base_gas_price();
 				if transaction.gas_price < min_gas_price {
 					return InvalidTransaction::Payment.into();
 				}

--- a/frame/ethereum/src/mock.rs
+++ b/frame/ethereum/src/mock.rs
@@ -112,7 +112,11 @@ impl pallet_timestamp::Config for Test {
 
 pub struct FixedGasPrice;
 impl FeeCalculator for FixedGasPrice {
-	fn min_gas_price() -> U256 {
+	fn base_gas_price() -> U256 {
+		1.into()
+	}
+
+	fn gas_price() -> U256 {
 		1.into()
 	}
 }

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -342,8 +342,6 @@ pub mod pallet {
 		PaymentOverflow,
 		/// Withdraw fee failed
 		WithdrawFailed,
-		/// Gas price is too low.
-		GasPriceTooLow,
 		/// Nonce is invalid
 		InvalidNonce,
 	}

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -409,11 +409,17 @@ type NegativeImbalanceOf<C, T> =
 /// Trait that outputs the current transaction gas price.
 pub trait FeeCalculator {
 	/// Return the minimal required gas price.
-	fn min_gas_price() -> U256;
+	fn base_gas_price() -> U256;
+	/// Return the gas price provided by the dynamic_fee
+	fn gas_price() -> U256;
 }
 
 impl FeeCalculator for () {
-	fn min_gas_price() -> U256 {
+	fn base_gas_price() -> U256 {
+		U256::zero()
+	}
+
+	fn gas_price() -> U256 {
 		U256::zero()
 	}
 }

--- a/frame/evm/src/mock.rs
+++ b/frame/evm/src/mock.rs
@@ -16,9 +16,9 @@
 // limitations under the License.
 
 //! Test mock for unit tests and benchmarking
-use crate::{EnsureAddressNever, EnsureAddressRoot, FeeCalculator, IdentityAddressMapping};
+use crate::{EnsureAddressNever, EnsureAddressRoot, IdentityAddressMapping};
 use frame_support::{parameter_types, traits::FindAuthor, ConsensusEngineId};
-use sp_core::{H160, H256, U256};
+use sp_core::{H160, H256};
 use sp_runtime::{
 	generic,
 	traits::{BlakeTwo256, IdentityLookup},
@@ -97,14 +97,6 @@ impl pallet_timestamp::Config for Test {
 	type WeightInfo = ();
 }
 
-/// Fixed gas price of `0`.
-pub struct FixedGasPrice;
-impl FeeCalculator for FixedGasPrice {
-	fn min_gas_price() -> U256 {
-		0.into()
-	}
-}
-
 pub struct FindAuthorTruncated;
 impl FindAuthor<H160> for FindAuthorTruncated {
 	fn find_author<'a, I>(_digests: I) -> Option<H160>
@@ -116,7 +108,7 @@ impl FindAuthor<H160> for FindAuthorTruncated {
 }
 
 impl crate::Config for Test {
-	type FeeCalculator = FixedGasPrice;
+	type FeeCalculator = ();
 	type GasWeightMapping = ();
 
 	type CallOrigin = EnsureAddressRoot<Self::AccountId>;

--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -19,7 +19,7 @@
 
 use crate::{
 	runner::Runner as RunnerT, AccountCodes, AccountStorages, AddressMapping, BlockHashMapping,
-	Config, Error, Event, FeeCalculator, OnChargeEVMTransaction, Pallet, PrecompileSet,
+	Config, Error, Event, OnChargeEVMTransaction, Pallet, PrecompileSet,
 };
 use evm::{
 	backend::Backend as BackendT,
@@ -57,17 +57,8 @@ impl<T: Config> Runner<T> {
 			&mut StackExecutor<'config, SubstrateStackState<'_, 'config, T>>,
 		) -> (ExitReason, R),
 	{
-		// Gas price check is skipped when performing a gas estimation.
-		let gas_price = match gas_price {
-			Some(gas_price) => {
-				ensure!(
-					gas_price >= T::FeeCalculator::min_gas_price(),
-					Error::<T>::GasPriceTooLow
-				);
-				gas_price
-			}
-			None => Default::default(),
-		};
+		// Gas price is default when performing a gas estimation.
+		let gas_price = gas_price.unwrap_or_default();
 
 		let vicinity = Vicinity {
 			gas_price,

--- a/primitives/rpc/src/lib.rs
+++ b/primitives/rpc/src/lib.rs
@@ -56,7 +56,7 @@ sp_api::decl_runtime_apis! {
 		fn chain_id() -> u64;
 		/// Returns pallet_evm::Accounts by address.
 		fn account_basic(address: H160) -> fp_evm::Account;
-		/// Returns FixedGasPrice::min_gas_price
+		/// Returns gas price
 		fn gas_price() -> U256;
 		/// For a given account address, returns pallet_evm::AccountCodes.
 		fn account_code_at(address: H160) -> Vec<u8>;

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -45,7 +45,9 @@ pub use frame_support::{
 };
 pub use pallet_balances::Call as BalancesCall;
 use pallet_ethereum::{Call::transact, Transaction as EthereumTransaction};
-use pallet_evm::{Account as EVMAccount, EnsureAddressTruncated, HashedAddressMapping, Runner};
+use pallet_evm::{
+	Account as EVMAccount, EnsureAddressTruncated, FeeCalculator, HashedAddressMapping, Runner,
+};
 pub use pallet_timestamp::Call as TimestampCall;
 use pallet_transaction_payment::CurrencyAdapter;
 #[cfg(any(feature = "std", test))]
@@ -329,10 +331,12 @@ impl pallet_ethereum::Config for Runtime {
 
 frame_support::parameter_types! {
 	pub BoundDivision: U256 = U256::from(1024);
+	pub BaseGasPrice: U256 = 1.into();
 }
 
 impl pallet_dynamic_fee::Config for Runtime {
 	type MinGasPriceBoundDivisor = BoundDivision;
+	type BaseGasPrice = BaseGasPrice;
 }
 
 impl pallet_randomness_collective_flip::Config for Runtime {}
@@ -537,7 +541,7 @@ impl_runtime_apis! {
 		}
 
 		fn gas_price() -> U256 {
-			<Runtime as pallet_evm::Config>::FeeCalculator::min_gas_price()
+			<Runtime as pallet_evm::Config>::FeeCalculator::gas_price()
 		}
 
 		fn account_code_at(address: H160) -> Vec<u8> {


### PR DESCRIPTION
There is such a issue related to the gas_price check with dynamic-fee armed.

The ethereum checks gas price in `validate_self_contained` before enter tx pool:

```rs
// ethereum pallet validate_self_contained()
let min_gas_price = T::FeeCalculator::min_gas_price();
if transaction.gas_price < min_gas_price {
	return InvalidTransaction::Payment.into();
}
```

Fee the metamask gas price in runtime:

```rs
// runtime/src/lib.rs
impl fp_rpc::EthereumRuntimeRPCApi<Block> for Runtime {
	fn gas_price() -> U256 {
		<Runtime as pallet_evm::Config>::FeeCalculator::min_gas_price()
	}
}
```

Considering the case that when someone tries to send messages using the Matamask, the Metamask will get `min_gas_price`  at block A automatically, After the user fill in with other transaction fields in the Metamask at block A+2, click send button, We assume that the `min_gas_price` may have increased(dynamic). This resulted in the transaction gas price check failing.

The solution:

1. Introduce a `BaseGasPrice` fixed minimal gas price in dynamic-fee pallet runtime level,  Then check the transaction gas price with fixed `BaseGasPrice` in ethereum pallet, feed the Metamask with the original adjustable `MinGasPrice` in runtime RPC.
2. Remove the gas_price validation in stack runner in the evm pallet, since we have verified the gas price in ethereum pallet.