### PR TITLE
fix estimate-gas

### DIFF
--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -1065,7 +1065,7 @@ where
 
 			match exit_reason {
 				ExitReason::Succeed(_) => Ok(Some(used_gas)),
-				ExitReason::Revert(_) | ExitReason::Error(evm::ExitError::OutOfGas) => Ok(None),
+				ExitReason::Error(evm::ExitError::OutOfGas) => Ok(None),
 				other => error_on_execution_failure(&other, &data).map(|()| Some(used_gas)),
 			}
 		};


### PR DESCRIPTION
When the contract returns revert, it should not return an error message with `gas required exceeds allowance ...`
