### PR TITLE
fix estimate-gas

### DIFF
--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -1093,7 +1093,7 @@ where
 			// Execute the binary search and hone in on an executable gas limit.
 			let mut previous_highest = highest;
 			while (highest - lowest) > U256::one() {
-				if executable(request.clone(), mid)?.is_some() {
+				if executable(request.clone(), mid).unwrap_or_default().is_some() {
 					highest = mid;
 					// If the variation in the estimate is less than 10%,
 					// then the estimate is considered sufficiently accurate.


### PR DESCRIPTION
The failure in `rpc_binary_search_estimate` is because the gas is not enough, only break the loop