### PR TITLE
Fix bug in `pallet-evm` genesis account creation

### DIFF
--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -391,8 +391,8 @@ pub mod pallet {
 					account.balance.low_u128().unique_saturated_into(),
 				);
 
-				Pallet::<T>::create_account(*address, account.code.clone());
 				let _ = frame_system::Pallet::<T>::inc_providers(&account_id);
+				Pallet::<T>::create_account(*address, account.code.clone());
 
 				for (index, value) in &account.storage {
 					<AccountStorages<T>>::insert(address, index, value);

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -391,7 +391,7 @@ pub mod pallet {
 					account.balance.low_u128().unique_saturated_into(),
 				);
 
-				<AccountCodes<T>>::insert(address, &account.code);
+				Pallet::<T>::create_account(*address, account.code.clone());
 
 				for (index, value) in &account.storage {
 					<AccountStorages<T>>::insert(address, index, value);

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -392,6 +392,7 @@ pub mod pallet {
 				);
 
 				Pallet::<T>::create_account(*address, account.code.clone());
+				let _ = frame_system::Pallet::<T>::inc_providers(&account_id);
 
 				for (index, value) in &account.storage {
 					<AccountStorages<T>>::insert(address, index, value);
@@ -607,7 +608,6 @@ impl<T: Config> Pallet<T> {
 	pub fn remove_account(address: &H160) {
 		if <AccountCodes<T>>::contains_key(address) {
 			let account_id = T::AddressMapping::into_account_id(*address);
-			let _ = frame_system::Pallet::<T>::dec_providers(&account_id);
 			let _ = frame_system::Pallet::<T>::dec_consumers(&account_id);
 		}
 
@@ -623,7 +623,6 @@ impl<T: Config> Pallet<T> {
 
 		if !<AccountCodes<T>>::contains_key(&address) {
 			let account_id = T::AddressMapping::into_account_id(address);
-			let _ = frame_system::Pallet::<T>::inc_providers(&account_id);
 			let _ = frame_system::Pallet::<T>::inc_consumers(&account_id);
 		}
 

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -607,6 +607,7 @@ impl<T: Config> Pallet<T> {
 	pub fn remove_account(address: &H160) {
 		if <AccountCodes<T>>::contains_key(address) {
 			let account_id = T::AddressMapping::into_account_id(*address);
+			let _ = frame_system::Pallet::<T>::dec_providers(&account_id);
 			let _ = frame_system::Pallet::<T>::dec_consumers(&account_id);
 		}
 
@@ -622,6 +623,7 @@ impl<T: Config> Pallet<T> {
 
 		if !<AccountCodes<T>>::contains_key(&address) {
 			let account_id = T::AddressMapping::into_account_id(address);
+			let _ = frame_system::Pallet::<T>::inc_providers(&account_id);
 			let _ = frame_system::Pallet::<T>::inc_consumers(&account_id);
 		}
 

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -391,7 +391,6 @@ pub mod pallet {
 					account.balance.low_u128().unique_saturated_into(),
 				);
 
-				let _ = frame_system::Pallet::<T>::inc_providers(&account_id);
 				Pallet::<T>::create_account(*address, account.code.clone());
 
 				for (index, value) in &account.storage {
@@ -608,7 +607,7 @@ impl<T: Config> Pallet<T> {
 	pub fn remove_account(address: &H160) {
 		if <AccountCodes<T>>::contains_key(address) {
 			let account_id = T::AddressMapping::into_account_id(*address);
-			let _ = frame_system::Pallet::<T>::dec_consumers(&account_id);
+			let _ = frame_system::Pallet::<T>::dec_sufficients(&account_id);
 		}
 
 		<AccountCodes<T>>::remove(address);
@@ -623,7 +622,7 @@ impl<T: Config> Pallet<T> {
 
 		if !<AccountCodes<T>>::contains_key(&address) {
 			let account_id = T::AddressMapping::into_account_id(address);
-			let _ = frame_system::Pallet::<T>::inc_consumers(&account_id);
+			let _ = frame_system::Pallet::<T>::inc_sufficients(&account_id);
 		}
 
 		<AccountCodes<T>>::insert(address, code);

--- a/frame/evm/src/tests.rs
+++ b/frame/evm/src/tests.rs
@@ -358,6 +358,8 @@ fn handle_consumer_reference() {
 		// Using storage is not correct as it leads to a consumer reference mismatch.
 		assert_eq!(account.consumers, 0);
 
+		// Assume accounts have at least one provider after some funds have been transfered.
+		let _ = frame_system::Pallet::<Test>::inc_providers(&substrate_addr_2);
 		// Using the create / remove account functions is the correct way to handle it.
 		EVM::create_account(addr_2, vec![1, 2, 3]);
 		let account_2 = frame_system::Account::<Test>::get(substrate_addr_2);

--- a/frame/evm/src/tests.rs
+++ b/frame/evm/src/tests.rs
@@ -328,3 +328,44 @@ fn refunds_and_priority_should_work() {
 		assert_eq!(after_tip, (before_tip + tip));
 	});
 }
+
+#[test]
+fn must_increase_providers() {
+	new_test_ext().execute_with(|| {
+		let addr = H160::from_str("1230000000000000000000000000000000000001").unwrap();
+		let substrate_addr = <Test as Config>::AddressMapping::into_account_id(addr);
+
+		let r = frame_system::Pallet::<Test>::inc_consumers(&substrate_addr);
+		assert_eq!(r, Err(sp_runtime::DispatchError::NoProviders));
+
+		let _ = frame_system::Pallet::<Test>::inc_providers(&substrate_addr);
+		let r = frame_system::Pallet::<Test>::inc_consumers(&substrate_addr);
+		assert_eq!(r, Ok(()));
+	});
+}
+
+#[test]
+fn handle_consumer_reference() {
+	new_test_ext().execute_with(|| {
+		let addr = H160::from_str("1230000000000000000000000000000000000001").unwrap();
+		let addr_2 = H160::from_str("1234000000000000000000000000000000000001").unwrap();
+		let substrate_addr = <Test as Config>::AddressMapping::into_account_id(addr);
+		let substrate_addr_2 = <Test as Config>::AddressMapping::into_account_id(addr_2);
+
+		// Consumers should increase when creating EVM accounts.
+		let _ = <crate::AccountCodes<Test>>::insert(addr, &vec![0]);
+		let account = frame_system::Account::<Test>::get(substrate_addr);
+		// Using storage is not correct as it leads to a consumer reference mismatch.
+		assert_eq!(account.consumers, 0);
+
+		// Using the create / remove account functions is the correct way to handle it.
+		EVM::create_account(addr_2, vec![1, 2, 3]);
+		let account_2 = frame_system::Account::<Test>::get(substrate_addr_2);
+		// We increased the consumer reference by 1.
+		assert_eq!(account_2.consumers, 1);
+		EVM::remove_account(&addr_2);
+		let account_2 = frame_system::Account::<Test>::get(substrate_addr_2);
+		// We decreased the consumer reference by 1 on removing the account.
+		assert_eq!(account_2.consumers, 0);
+	});
+}

--- a/frame/evm/src/tests.rs
+++ b/frame/evm/src/tests.rs
@@ -330,44 +330,27 @@ fn refunds_and_priority_should_work() {
 }
 
 #[test]
-fn must_increase_providers() {
-	new_test_ext().execute_with(|| {
-		let addr = H160::from_str("1230000000000000000000000000000000000001").unwrap();
-		let substrate_addr = <Test as Config>::AddressMapping::into_account_id(addr);
-
-		let r = frame_system::Pallet::<Test>::inc_consumers(&substrate_addr);
-		assert_eq!(r, Err(sp_runtime::DispatchError::NoProviders));
-
-		let _ = frame_system::Pallet::<Test>::inc_providers(&substrate_addr);
-		let r = frame_system::Pallet::<Test>::inc_consumers(&substrate_addr);
-		assert_eq!(r, Ok(()));
-	});
-}
-
-#[test]
-fn handle_consumer_reference() {
+fn handle_sufficient_reference() {
 	new_test_ext().execute_with(|| {
 		let addr = H160::from_str("1230000000000000000000000000000000000001").unwrap();
 		let addr_2 = H160::from_str("1234000000000000000000000000000000000001").unwrap();
 		let substrate_addr = <Test as Config>::AddressMapping::into_account_id(addr);
 		let substrate_addr_2 = <Test as Config>::AddressMapping::into_account_id(addr_2);
 
-		// Consumers should increase when creating EVM accounts.
+		// Sufficients should increase when creating EVM accounts.
 		let _ = <crate::AccountCodes<Test>>::insert(addr, &vec![0]);
 		let account = frame_system::Account::<Test>::get(substrate_addr);
-		// Using storage is not correct as it leads to a consumer reference mismatch.
-		assert_eq!(account.consumers, 0);
+		// Using storage is not correct as it leads to a sufficient reference mismatch.
+		assert_eq!(account.sufficients, 0);
 
-		// Assume accounts have at least one provider after some funds have been transfered.
-		let _ = frame_system::Pallet::<Test>::inc_providers(&substrate_addr_2);
 		// Using the create / remove account functions is the correct way to handle it.
 		EVM::create_account(addr_2, vec![1, 2, 3]);
 		let account_2 = frame_system::Account::<Test>::get(substrate_addr_2);
-		// We increased the consumer reference by 1.
-		assert_eq!(account_2.consumers, 1);
+		// We increased the sufficient reference by 1.
+		assert_eq!(account_2.sufficients, 1);
 		EVM::remove_account(&addr_2);
 		let account_2 = frame_system::Account::<Test>::get(substrate_addr_2);
-		// We decreased the consumer reference by 1 on removing the account.
-		assert_eq!(account_2.consumers, 0);
+		// We decreased the sufficient reference by 1 on removing the account.
+		assert_eq!(account_2.sufficients, 0);
 	});
 }


### PR DESCRIPTION
Inserting to `AccountCodes` directly without increasing Account reference (`inc_consumers`) leads to errors if that account is removed later on using the `remove_account` function:

```
pub fn remove_account(address: &H160) {
	if <AccountCodes<T>>::contains_key(address) {
		let account_id = T::AddressMapping::into_account_id(*address);
		let _ = frame_system::Pallet::<T>::dec_consumers(&account_id);
	}

	<AccountCodes<T>>::remove(address);
	<AccountStorages<T>>::remove_prefix(address, None);
}
```

Above `AccountCodes` key will exists, but never increased the consumers:

```
/// Decrement the reference counter on an account. This *MUST* only be done once for every time
/// you called `inc_consumers` on `who`.
pub fn dec_consumers(who: &T::AccountId)
```

In addition to that, in order to increase the consumer reference count the Account must have increased the providers. Otherwise it fails with `DispatchError::NoProviders`.