### PR TITLE
Use `mid` instead of `highest` for estimate_gas binary search

### DIFF
--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -1399,7 +1399,7 @@ where
 					data,
 					exit_reason,
 					used_gas: _,
-				} = executable(request.clone(), highest, api_version)?;
+				} = executable(request.clone(), mid, api_version)?;
 				match exit_reason {
 					ExitReason::Succeed(_) => {
 						highest = mid;


### PR DESCRIPTION
This tiny change prevents an issue where the returned value from `estimate_gas` can be below the amount actually used.

Note that this matches the Geth implementation: https://github.com/ethereum/go-ethereum/blob/master/accounts/abi/bind/backends/simulated.go#L550