### PR TITLE
Sync EtheruemStorageSchema on runtime upgrade

### DIFF
--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -229,6 +229,13 @@ pub mod pallet {
 
 			0
 		}
+
+		fn on_runtime_upgrade() -> Weight {
+			frame_support::storage::unhashed::put::<EthereumStorageSchema>(
+				&PALLET_ETHEREUM_SCHEMA,
+				&EthereumStorageSchema::V2,
+			);
+		}
 	}
 
 	#[pallet::call]

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -235,6 +235,8 @@ pub mod pallet {
 				&PALLET_ETHEREUM_SCHEMA,
 				&EthereumStorageSchema::V2,
 			);
+
+			0
 		}
 	}
 


### PR DESCRIPTION
`EthereumStorageSchema` always goes with the runtime. So we should always sync its value on runtime upgrade.