### PR TITLE
Add `Pending` tag support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1586,6 +1586,7 @@ dependencies = [
  "sc-transaction-pool-api",
  "sha3 0.8.2",
  "sp-api",
+ "sp-block-builder",
  "sp-blockchain",
  "sp-io",
  "sp-runtime",

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -27,6 +27,7 @@ sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/parityt
 sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }
 sp-storage = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }
 sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }
+sp-block-builder = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }
 sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }
 sc-service = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate" }
 sc-client-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -280,6 +280,41 @@ fn transaction_build(
 	transaction
 }
 
+fn pending_runtime_api<'a, B: BlockT, C, BE, A: ChainApi>(
+	client: &'a C,
+	graph: &'a Pool<A>,
+) -> Result<sp_api::ApiRef<'a, C::Api>>
+where
+	C: ProvideRuntimeApi<B> + StorageProvider<B, BE>,
+	C: HeaderBackend<B> + HeaderMetadata<B, Error = BlockChainError> + 'static,
+	C::Api: EthereumRuntimeRPCApi<B>,
+	C::Api: BlockBuilder<B>,
+	BE: Backend<B> + 'static,
+	BE::State: StateBackend<BlakeTwo256>,
+	B: BlockT<Hash = H256> + Send + Sync + 'static,
+	A: ChainApi<Block = B> + 'static,
+	C: Send + Sync + 'static,
+{
+	// In case of Pending, we need an overlayed state to query over.
+	let api = client.runtime_api();
+	let best = BlockId::Hash(client.info().best_hash);
+	// Get all transactions in the ready queue.
+	let xts: Vec<<B as BlockT>::Extrinsic> = graph
+		.validated_pool()
+		.ready()
+		.map(|in_pool_tx| in_pool_tx.data().clone())
+		.collect::<Vec<<B as BlockT>::Extrinsic>>();
+	// Manually initialize the overlay.
+	let header = client.header(best).unwrap().unwrap();
+	api.initialize_block(&best, &header)
+		.map_err(|e| internal_err(format!("Runtime api access error: {:?}", e)))?;
+	// Apply the ready queue to the best block's state.
+	for xt in xts {
+		let _ = api.apply_extrinsic(&best, xt);
+	}
+	Ok(api)
+}
+
 fn filter_range_logs<B: BlockT, C, BE>(
 	client: &C,
 	backend: &fc_db::Backend<B>,
@@ -601,10 +636,18 @@ where
 	}
 
 	fn balance(&self, address: H160, number: Option<BlockNumber>) -> Result<U256> {
-		if let Ok(Some(id)) = frontier_backend_client::native_block_id::<B, C>(
+		let number = number.unwrap_or(BlockNumber::Latest);
+		if number == BlockNumber::Pending {
+			let api = pending_runtime_api(self.client.as_ref(), self.graph.as_ref())?;
+			return Ok(api
+				.account_basic(&BlockId::Hash(self.client.info().best_hash), address)
+				.map_err(|err| internal_err(format!("fetch runtime chain id failed: {:?}", err)))?
+				.balance
+				.into());
+		} else if let Ok(Some(id)) = frontier_backend_client::native_block_id::<B, C>(
 			self.client.as_ref(),
 			self.backend.as_ref(),
-			number,
+			Some(number),
 		) {
 			return Ok(self
 				.client
@@ -613,15 +656,22 @@ where
 				.map_err(|err| internal_err(format!("fetch runtime chain id failed: {:?}", err)))?
 				.balance
 				.into());
+		} else {
+			Ok(U256::zero())
 		}
-		Ok(U256::zero())
 	}
 
 	fn storage_at(&self, address: H160, index: U256, number: Option<BlockNumber>) -> Result<H256> {
-		if let Ok(Some(id)) = frontier_backend_client::native_block_id::<B, C>(
+		let number = number.unwrap_or(BlockNumber::Latest);
+		if number == BlockNumber::Pending {
+			let api = pending_runtime_api(self.client.as_ref(), self.graph.as_ref())?;
+			return Ok(api
+				.storage_at(&BlockId::Hash(self.client.info().best_hash), address, index)
+				.unwrap_or_default());
+		} else if let Ok(Some(id)) = frontier_backend_client::native_block_id::<B, C>(
 			self.client.as_ref(),
 			self.backend.as_ref(),
-			number,
+			Some(number),
 		) {
 			let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(
 				self.client.as_ref(),
@@ -634,8 +684,9 @@ where
 				.unwrap_or(&self.overrides.fallback)
 				.storage_at(&id, address, index)
 				.unwrap_or_default());
+		} else {
+			Ok(H256::default())
 		}
-		Ok(H256::default())
 	}
 
 	fn block_by_hash(&self, hash: H256, full: bool) -> Result<Option<RichBlock>> {
@@ -831,26 +882,11 @@ where
 	fn code_at(&self, address: H160, number: Option<BlockNumber>) -> Result<Bytes> {
 		let number = number.unwrap_or(BlockNumber::Latest);
 		if number == BlockNumber::Pending {
-			// In case of Pending, we need an overlayed state to query over.
-			let api = self.client.runtime_api();
-			let best = BlockId::Hash(self.client.info().best_hash);
-			// Get all transactions in the ready queue.
-			let xts: Vec<<B as BlockT>::Extrinsic> = self
-				.graph
-				.validated_pool()
-				.ready()
-				.map(|in_pool_tx| in_pool_tx.data().clone())
-				.collect::<Vec<<B as BlockT>::Extrinsic>>();
-			// Manually initialize the overlay.
-			let header = self.client.header(best).unwrap().unwrap();
-			api.initialize_block(&best, &header)
-				.map_err(|e| internal_err(format!("Runtime api access error: {:?}", e)))?;
-			// Apply the ready queue to the best block's state.
-			for xt in xts {
-				let _ = api.apply_extrinsic(&best, xt);
-			}
-			// Now we can get the code, if any.
-			return Ok(api.account_code_at(&best, address).unwrap_or(vec![]).into());
+			let api = pending_runtime_api(self.client.as_ref(), self.graph.as_ref())?;
+			return Ok(api
+				.account_code_at(&BlockId::Hash(self.client.info().best_hash), address)
+				.unwrap_or(vec![])
+				.into());
 		} else if let Ok(Some(id)) = frontier_backend_client::native_block_id::<B, C>(
 			self.client.as_ref(),
 			self.backend.as_ref(),
@@ -1032,11 +1068,7 @@ where
 		)
 	}
 
-	fn call(&self, request: CallRequest, _: Option<BlockNumber>) -> Result<Bytes> {
-		// TODO required support for requests with block parameter instead of defaulting to latest.
-		// That's the main reason for creating a new runtime api version for the `call` and `create` methods.
-		let hash = self.client.info().best_hash;
-
+	fn call(&self, request: CallRequest, number: Option<BlockNumber>) -> Result<Bytes> {
 		let CallRequest {
 			from,
 			to,
@@ -1058,14 +1090,26 @@ where
 			)
 		};
 
-		let api = self.client.runtime_api();
+		let (id, api) = match frontier_backend_client::native_block_id::<B, C>(
+			self.client.as_ref(),
+			self.backend.as_ref(),
+			number,
+		)? {
+			Some(id) => (id, self.client.runtime_api()),
+			None => {
+				// Not mapped in the db, assume pending.
+				let id = BlockId::Hash(self.client.info().best_hash);
+				let api = pending_runtime_api(self.client.as_ref(), self.graph.as_ref())?;
+				(id, api)
+			}
+		};
 
 		// use given gas limit or query current block's limit
 		let gas_limit = match gas {
 			Some(amount) => amount,
 			None => {
 				let block = api
-					.current_block(&BlockId::Hash(hash))
+					.current_block(&id)
 					.map_err(|err| internal_err(format!("runtime error: {:?}", err)))?;
 				if let Some(block) = block {
 					block.header.gas_limit
@@ -1078,21 +1122,20 @@ where
 		};
 		let data = data.map(|d| d.0).unwrap_or_default();
 
-		let api_version = if let Ok(Some(api_version)) =
-			api.api_version::<dyn EthereumRuntimeRPCApi<B>>(&BlockId::Hash(hash))
-		{
-			api_version
-		} else {
-			return Err(internal_err(format!(
-				"failed to retrieve Runtime Api version"
-			)));
-		};
+		let api_version =
+			if let Ok(Some(api_version)) = api.api_version::<dyn EthereumRuntimeRPCApi<B>>(&id) {
+				api_version
+			} else {
+				return Err(internal_err(format!(
+					"failed to retrieve Runtime Api version"
+				)));
+			};
 		match to {
 			Some(to) => {
 				if api_version == 1 {
 					#[allow(deprecated)]
 					let info = api.call_before_version_2(
-						&BlockId::Hash(hash),
+						&id,
 						from.unwrap_or_default(),
 						to,
 						data,
@@ -1110,7 +1153,7 @@ where
 				} else if api_version >= 2 {
 					let info = api
 						.call(
-							&BlockId::Hash(hash),
+							&id,
 							from.unwrap_or_default(),
 							to,
 							data,
@@ -1136,7 +1179,7 @@ where
 				if api_version == 1 {
 					#[allow(deprecated)]
 					let info = api.create_before_version_2(
-						&BlockId::Hash(hash),
+						&id,
 						from.unwrap_or_default(),
 						data,
 						value.unwrap_or_default(),
@@ -1153,7 +1196,7 @@ where
 				} else if api_version >= 2 {
 					let info = api
 						.create(
-							&BlockId::Hash(hash),
+							&id,
 							from.unwrap_or_default(),
 							data,
 							value.unwrap_or_default(),

--- a/ts-tests/tests/test-balance.ts
+++ b/ts-tests/tests/test-balance.ts
@@ -24,9 +24,13 @@ describeWithFrontier("Frontier RPC (Balance)", (context) => {
 			gas: "0x100000",
 		}, GENESIS_ACCOUNT_PRIVATE_KEY);
 		await customRequest(context.web3, "eth_sendRawTransaction", [tx.rawTransaction]);
+		const expectedGenesisBalance = "340282366920938463463374586431768210443";
+		const expectedTestBalance = "12";
+		expect(await context.web3.eth.getBalance(GENESIS_ACCOUNT, "pending")).to.equal(expectedGenesisBalance);
+		expect(await context.web3.eth.getBalance(TEST_ACCOUNT, "pending")).to.equal(expectedTestBalance);
 		await createAndFinalizeBlock(context.web3);
 		// 340282366920938463463374607431768210955 - (21000 * 1000000000) + 512; 
-		expect(await context.web3.eth.getBalance(GENESIS_ACCOUNT)).to.equal("340282366920938463463374586431768210443");
-		expect(await context.web3.eth.getBalance(TEST_ACCOUNT)).to.equal("12");
+		expect(await context.web3.eth.getBalance(GENESIS_ACCOUNT)).to.equal(expectedGenesisBalance);
+		expect(await context.web3.eth.getBalance(TEST_ACCOUNT)).to.equal(expectedTestBalance);
 	});
 });

--- a/ts-tests/tests/test-contract-storage.ts
+++ b/ts-tests/tests/test-contract-storage.ts
@@ -64,6 +64,19 @@ describeWithFrontier("Frontier RPC (Contract)", (context) => {
 		);
 	
 		await customRequest(context.web3, "eth_sendRawTransaction", [tx1.rawTransaction]);
+
+		let getStoragePending = await customRequest(context.web3, "eth_getStorageAt", [
+			contractAddress,
+			"0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc",
+			"pending",
+		]);
+
+		const expectedStorage = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+	
+		expect(getStoragePending.result).to.be.eq(
+			expectedStorage
+		);
+
 		await createAndFinalizeBlock(context.web3);
 		let receip1 = await context.web3.eth.getTransactionReceipt(tx1.transactionHash);
 	
@@ -74,7 +87,7 @@ describeWithFrontier("Frontier RPC (Contract)", (context) => {
 		]);
 	
 		expect(getStorage1.result).to.be.eq(
-			"0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+			expectedStorage
 		);
 	});
 });

--- a/ts-tests/tests/test-contract.ts
+++ b/ts-tests/tests/test-contract.ts
@@ -47,4 +47,29 @@ describeWithFrontier("Frontier RPC (Contract)", (context) => {
 			TEST_CONTRACT_DEPLOYED_BYTECODE,
 		});
 	});
+
+	it("should get contract code on Pending block", async function () {
+		const tx = await context.web3.eth.accounts.signTransaction(
+			{
+				from: GENESIS_ACCOUNT,
+				data: TEST_CONTRACT_BYTECODE,
+				value: "0x00",
+				gasPrice: "0x3B9ACA00",
+				gas: "0x100000",
+			},
+			GENESIS_ACCOUNT_PRIVATE_KEY
+		);
+
+		expect(await customRequest(context.web3, "eth_sendRawTransaction", [tx.rawTransaction])).to.include({
+			id: 1,
+			jsonrpc: "2.0",
+		});
+
+		// Verify the contract is not yet stored
+		expect(await customRequest(context.web3, "eth_getCode", [FIRST_CONTRACT_ADDRESS, "pending"])).to.deep.equal({
+			id: 1,
+			jsonrpc: "2.0",
+			result: TEST_CONTRACT_DEPLOYED_BYTECODE,
+		});
+	});
 });

--- a/ts-tests/tests/test-contract.ts
+++ b/ts-tests/tests/test-contract.ts
@@ -38,6 +38,13 @@ describeWithFrontier("Frontier RPC (Contract)", (context) => {
 			result: "0x",
 		});
 
+		// Verify the contract is in the pending state
+		expect(await customRequest(context.web3, "eth_getCode", [FIRST_CONTRACT_ADDRESS, "pending"])).to.deep.equal({
+			id: 1,
+			jsonrpc: "2.0",
+			result: TEST_CONTRACT_DEPLOYED_BYTECODE,
+		});
+
 		// Verify the contract is stored after the block is produced
 		await createAndFinalizeBlock(context.web3);
 		expect(await customRequest(context.web3, "eth_getCode", [FIRST_CONTRACT_ADDRESS])).to.deep.equal({
@@ -45,31 +52,6 @@ describeWithFrontier("Frontier RPC (Contract)", (context) => {
 			jsonrpc: "2.0",
 			result:
 			TEST_CONTRACT_DEPLOYED_BYTECODE,
-		});
-	});
-
-	it("should get contract code on Pending block", async function () {
-		const tx = await context.web3.eth.accounts.signTransaction(
-			{
-				from: GENESIS_ACCOUNT,
-				data: TEST_CONTRACT_BYTECODE,
-				value: "0x00",
-				gasPrice: "0x3B9ACA00",
-				gas: "0x100000",
-			},
-			GENESIS_ACCOUNT_PRIVATE_KEY
-		);
-
-		expect(await customRequest(context.web3, "eth_sendRawTransaction", [tx.rawTransaction])).to.include({
-			id: 1,
-			jsonrpc: "2.0",
-		});
-
-		// Verify the contract is not yet stored
-		expect(await customRequest(context.web3, "eth_getCode", [FIRST_CONTRACT_ADDRESS, "pending"])).to.deep.equal({
-			id: 1,
-			jsonrpc: "2.0",
-			result: TEST_CONTRACT_DEPLOYED_BYTECODE,
 		});
 	});
 });


### PR DESCRIPTION
This PR adds support for `pending` tag in:

- `eth_getBalance`
- `eth_getCode`
- `eth_getStorageAt`

In addition to adding `pending` tag support to it, `eth_call` uses the `BlockNumber` parameter (previously not used).

**Note:** if the pending contract is a _future_ txn and some of the txns in the ready queue satisfies the requirements of the future one, this PR's approach won't do it because we only apply ready txns. @sorpaas I think current proposal is enough, but please let me know. 