### PR TITLE
Switch to `ReceiptsV3` to properly encode and store receipts data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1378,9 +1378,9 @@ dependencies = [
 
 [[package]]
 name = "ethereum"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04b864b7fc48e8eaa89976b00dbeed860665f8778e2567fcb8f4530fdefdd95e"
+checksum = "34c90e0a755da706ce0970ec0fa8cc48aabcc8e8efa1245336acf718dab06ffe"
 dependencies = [
  "bytes 1.0.1",
  "ethereum-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,6 +1384,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethereum"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04b864b7fc48e8eaa89976b00dbeed860665f8778e2567fcb8f4530fdefdd95e"
+dependencies = [
+ "bytes 1.0.1",
+ "ethereum-types",
+ "hash-db",
+ "hash256-std-hasher",
+ "parity-scale-codec",
+ "rlp",
+ "rlp-derive",
+ "scale-info",
+ "serde",
+ "sha3 0.9.1",
+ "triehash",
+]
+
+[[package]]
 name = "ethereum-types"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,7 +1431,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2068bbfe82315b76637b601c73810ec7e92d542bad02f0155182915e832c6357"
 dependencies = [
  "environmental",
- "ethereum",
+ "ethereum 0.10.0",
  "evm-core",
  "evm-gasometer",
  "evm-runtime",
@@ -1553,7 +1572,7 @@ dependencies = [
 name = "fc-rpc"
 version = "2.0.0-dev"
 dependencies = [
- "ethereum",
+ "ethereum 0.11.0",
  "ethereum-types",
  "evm",
  "fc-consensus",
@@ -1598,7 +1617,7 @@ dependencies = [
 name = "fc-rpc-core"
 version = "1.1.0-dev"
 dependencies = [
- "ethereum",
+ "ethereum 0.11.0",
  "ethereum-types",
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -1705,7 +1724,7 @@ dependencies = [
 name = "fp-consensus"
 version = "2.0.0-dev"
 dependencies = [
- "ethereum",
+ "ethereum 0.11.0",
  "parity-scale-codec",
  "rlp",
  "sha3 0.8.2",
@@ -1729,7 +1748,7 @@ dependencies = [
 name = "fp-rpc"
 version = "3.0.0-dev"
 dependencies = [
- "ethereum",
+ "ethereum 0.11.0",
  "ethereum-types",
  "fp-evm",
  "parity-scale-codec",
@@ -1745,7 +1764,7 @@ dependencies = [
 name = "fp-self-contained"
 version = "1.0.0-dev"
 dependencies = [
- "ethereum",
+ "ethereum 0.11.0",
  "frame-support",
  "parity-scale-codec",
  "parity-util-mem",
@@ -4230,7 +4249,7 @@ dependencies = [
 name = "pallet-ethereum"
 version = "4.0.0-dev"
 dependencies = [
- "ethereum",
+ "ethereum 0.11.0",
  "ethereum-types",
  "evm",
  "fp-consensus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto_impl"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7862e21c893d65a1650125d157eaeec691439379a1cee17ee49031b79236ada4"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1366,25 +1378,6 @@ dependencies = [
 
 [[package]]
 name = "ethereum"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fb916554a4dba293ea69c69ad5653e21d770a9d0c2496b5fa0a1f5a3946d87"
-dependencies = [
- "bytes 1.0.1",
- "ethereum-types",
- "hash-db",
- "hash256-std-hasher",
- "parity-scale-codec",
- "rlp",
- "rlp-derive",
- "scale-info",
- "serde",
- "sha3 0.9.1",
- "triehash",
-]
-
-[[package]]
-name = "ethereum"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04b864b7fc48e8eaa89976b00dbeed860665f8778e2567fcb8f4530fdefdd95e"
@@ -1426,12 +1419,13 @@ checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 
 [[package]]
 name = "evm"
-version = "0.33.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2068bbfe82315b76637b601c73810ec7e92d542bad02f0155182915e832c6357"
+checksum = "408ffdd509e16de15ea9b51f5333748f6086601f29d445d2ba53dd7e95565574"
 dependencies = [
+ "auto_impl",
  "environmental",
- "ethereum 0.10.0",
+ "ethereum",
  "evm-core",
  "evm-gasometer",
  "evm-runtime",
@@ -1572,7 +1566,7 @@ dependencies = [
 name = "fc-rpc"
 version = "2.0.0-dev"
 dependencies = [
- "ethereum 0.11.0",
+ "ethereum",
  "ethereum-types",
  "evm",
  "fc-consensus",
@@ -1617,7 +1611,7 @@ dependencies = [
 name = "fc-rpc-core"
 version = "1.1.0-dev"
 dependencies = [
- "ethereum 0.11.0",
+ "ethereum",
  "ethereum-types",
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -1724,7 +1718,7 @@ dependencies = [
 name = "fp-consensus"
 version = "2.0.0-dev"
 dependencies = [
- "ethereum 0.11.0",
+ "ethereum",
  "parity-scale-codec",
  "rlp",
  "sha3 0.8.2",
@@ -1748,7 +1742,7 @@ dependencies = [
 name = "fp-rpc"
 version = "3.0.0-dev"
 dependencies = [
- "ethereum 0.11.0",
+ "ethereum",
  "ethereum-types",
  "fp-evm",
  "parity-scale-codec",
@@ -1764,7 +1758,7 @@ dependencies = [
 name = "fp-self-contained"
 version = "1.0.0-dev"
 dependencies = [
- "ethereum 0.11.0",
+ "ethereum",
  "frame-support",
  "parity-scale-codec",
  "parity-util-mem",
@@ -4249,7 +4243,7 @@ dependencies = [
 name = "pallet-ethereum"
 version = "4.0.0-dev"
 dependencies = [
- "ethereum 0.11.0",
+ "ethereum",
  "ethereum-types",
  "evm",
  "fp-consensus",

--- a/client/rpc-core/Cargo.toml
+++ b/client/rpc-core/Cargo.toml
@@ -12,7 +12,7 @@ jsonrpc-core-client = "18.0"
 jsonrpc-derive = "18.0"
 jsonrpc-pubsub = "18.0"
 rustc-hex = "2.1.0"
-ethereum = { version = "0.10.0", features = ["with-codec"] }
+ethereum = { version = "0.11.0", features = ["with-codec"] }
 sha3 = "0.8"
 ethereum-types = "0.12"
 serde = { version = "1.0", features = ["derive"] }

--- a/client/rpc-core/Cargo.toml
+++ b/client/rpc-core/Cargo.toml
@@ -12,7 +12,7 @@ jsonrpc-core-client = "18.0"
 jsonrpc-derive = "18.0"
 jsonrpc-pubsub = "18.0"
 rustc-hex = "2.1.0"
-ethereum = { version = "0.11.0", features = ["with-codec"] }
+ethereum = { version = "0.11.1", features = ["with-codec"] }
 sha3 = "0.8"
 ethereum-types = "0.12"
 serde = { version = "1.0", features = ["derive"] }

--- a/client/rpc-core/src/types/call_request.rs
+++ b/client/rpc-core/src/types/call_request.rs
@@ -17,7 +17,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::types::Bytes;
-use ethereum_types::{H160, U256};
+use ethereum_types::{H160, H256, U256};
 use serde::Deserialize;
 
 /// Call request
@@ -43,4 +43,6 @@ pub struct CallRequest {
 	pub data: Option<Bytes>,
 	/// Nonce
 	pub nonce: Option<U256>,
+	/// AccessList
+	pub access_list: Option<Vec<(H160, Vec<H256>)>>,
 }

--- a/client/rpc-core/src/types/call_request.rs
+++ b/client/rpc-core/src/types/call_request.rs
@@ -17,7 +17,8 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::types::Bytes;
-use ethereum_types::{H160, H256, U256};
+use ethereum::AccessListItem;
+use ethereum_types::{H160, U256};
 use serde::Deserialize;
 
 /// Call request
@@ -44,5 +45,5 @@ pub struct CallRequest {
 	/// Nonce
 	pub nonce: Option<U256>,
 	/// AccessList
-	pub access_list: Option<Vec<(H160, Vec<H256>)>>,
+	pub access_list: Option<Vec<AccessListItem>>,
 }

--- a/client/rpc-core/src/types/transaction_request.rs
+++ b/client/rpc-core/src/types/transaction_request.rs
@@ -57,7 +57,7 @@ pub struct TransactionRequest {
 	pub data: Option<Bytes>,
 	/// Transaction's nonce
 	pub nonce: Option<U256>,
-	/// TODO! Pre-pay to warm storage access.
+	/// Pre-pay to warm storage access.
 	#[serde(default)]
 	pub access_list: Option<Vec<(H160, Vec<H256>)>>,
 }

--- a/client/rpc-core/src/types/transaction_request.rs
+++ b/client/rpc-core/src/types/transaction_request.rs
@@ -22,7 +22,7 @@ use crate::types::Bytes;
 use ethereum::{
 	AccessListItem, EIP1559TransactionMessage, EIP2930TransactionMessage, LegacyTransactionMessage,
 };
-use ethereum_types::{H160, H256, U256};
+use ethereum_types::{H160, U256};
 use serde::{Deserialize, Serialize};
 
 pub enum TransactionMessage {
@@ -32,7 +32,7 @@ pub enum TransactionMessage {
 }
 
 /// Transaction request coming from RPC
-#[derive(Debug, Clone, Default, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 pub struct TransactionRequest {
@@ -59,7 +59,7 @@ pub struct TransactionRequest {
 	pub nonce: Option<U256>,
 	/// Pre-pay to warm storage access.
 	#[serde(default)]
-	pub access_list: Option<Vec<(H160, Vec<H256>)>>,
+	pub access_list: Option<Vec<AccessListItem>>,
 }
 
 impl Into<Option<TransactionMessage>> for TransactionRequest {
@@ -98,7 +98,7 @@ impl Into<Option<TransactionMessage>> for TransactionRequest {
 					.access_list
 					.unwrap()
 					.into_iter()
-					.map(|(address, slots)| AccessListItem { address, slots })
+					.map(|item| item)
 					.collect(),
 			})),
 			// EIP1559
@@ -122,7 +122,7 @@ impl Into<Option<TransactionMessage>> for TransactionRequest {
 						.access_list
 						.unwrap_or(Vec::new())
 						.into_iter()
-						.map(|(address, slots)| AccessListItem { address, slots })
+						.map(|item| item)
 						.collect(),
 				}))
 			}

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -36,7 +36,7 @@ sc-network = { version = "0.10.0-dev", git = "https://github.com/paritytech/subs
 pallet-evm = { version = "6.0.0-dev", path = "../../frame/evm" }
 fp-evm = { version = "3.0.0-dev", path = "../../primitives/evm" }
 pallet-ethereum = { version = "4.0.0-dev", path = "../../frame/ethereum" }
-ethereum = { version = "0.10.0", features = ["with-codec"] }
+ethereum = { version = "0.11.0", features = ["with-codec"] }
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 rlp = "0.5"
 futures = { version = "0.3.1", features = ["compat"] }

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -36,7 +36,7 @@ sc-network = { version = "0.10.0-dev", git = "https://github.com/paritytech/subs
 pallet-evm = { version = "6.0.0-dev", path = "../../frame/evm" }
 fp-evm = { version = "3.0.0-dev", path = "../../primitives/evm" }
 pallet-ethereum = { version = "4.0.0-dev", path = "../../frame/ethereum" }
-ethereum = { version = "0.11.0", features = ["with-codec"] }
+ethereum = { version = "0.11.1", features = ["with-codec"] }
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 rlp = "0.5"
 futures = { version = "0.3.1", features = ["compat"] }

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -13,7 +13,7 @@ jsonrpc-core-client = "18.0"
 jsonrpc-pubsub = "18.0"
 log = "0.4.8"
 ethereum-types = "0.12"
-evm = "0.33.0"
+evm = "0.33.1"
 fc-consensus = { version = "2.0.0-dev", path = "../consensus" }
 fc-db = { version = "2.0.0-dev", path = "../db" }
 fc-rpc-core = { version = "1.1.0-dev", path = "../rpc-core" }

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -1762,15 +1762,15 @@ where
 					H256::from_slice(Keccak256::digest(&rlp::encode(&block.header)).as_slice());
 				let receipt = receipts[index].clone();
 
-				let (logs, logs_bloom, state_root, cumulative_gas_used) = match receipt {
-					ethereum::ReceiptV2::Legacy(d) => {
-						(d.logs, d.logs_bloom, d.state_root, d.used_gas)
+				let (logs, logs_bloom, status_code, cumulative_gas_used) = match receipt {
+					ethereum::ReceiptV3::Legacy(d) => {
+						(d.logs, d.logs_bloom, d.status_code, d.used_gas)
 					}
-					ethereum::ReceiptV2::EIP2930(d) => {
-						(d.logs, d.logs_bloom, d.state_root, d.used_gas)
+					ethereum::ReceiptV3::EIP2930(d) => {
+						(d.logs, d.logs_bloom, d.status_code, d.used_gas)
 					}
-					ethereum::ReceiptV2::EIP1559(d) => {
-						(d.logs, d.logs_bloom, d.state_root, d.used_gas)
+					ethereum::ReceiptV3::EIP1559(d) => {
+						(d.logs, d.logs_bloom, d.status_code, d.used_gas)
 					}
 				};
 
@@ -1780,9 +1780,9 @@ where
 				let gas_used = if index > 0 {
 					let previous_receipt = receipts[index - 1].clone();
 					let previous_gas_used = match previous_receipt {
-						ethereum::ReceiptV2::Legacy(d) => d.used_gas,
-						ethereum::ReceiptV2::EIP2930(d) => d.used_gas,
-						ethereum::ReceiptV2::EIP1559(d) => d.used_gas,
+						ethereum::ReceiptV3::Legacy(d) => d.used_gas,
+						ethereum::ReceiptV3::EIP2930(d) => d.used_gas,
+						ethereum::ReceiptV3::EIP1559(d) => d.used_gas,
 					};
 					cumulative_gas_used.saturating_sub(previous_gas_used)
 				} else {
@@ -1818,9 +1818,9 @@ where
 								cumulative_receipts
 									.iter()
 									.map(|r| match r {
-										ethereum::ReceiptV2::Legacy(d) => d.logs.len() as u32,
-										ethereum::ReceiptV2::EIP2930(d) => d.logs.len() as u32,
-										ethereum::ReceiptV2::EIP1559(d) => d.logs.len() as u32,
+										ethereum::ReceiptV3::Legacy(d) => d.logs.len() as u32,
+										ethereum::ReceiptV3::EIP2930(d) => d.logs.len() as u32,
+										ethereum::ReceiptV3::EIP1559(d) => d.logs.len() as u32,
 									})
 									.sum::<u32>(),
 							);
@@ -1843,7 +1843,7 @@ where
 							})
 							.collect()
 					},
-					status_code: Some(U64::from(state_root.to_low_u64_be())),
+					status_code: Some(U64::from(status_code)),
 					logs_bloom: logs_bloom,
 					state_root: None,
 					effective_gas_price,
@@ -2684,9 +2684,9 @@ where
 					.enumerate()
 					.map(|(i, receipt)| TransactionHelper {
 						gas_used: match receipt {
-							ethereum::ReceiptV2::Legacy(d) => used_gas(d.used_gas, &mut previous_cumulative_gas),
-							ethereum::ReceiptV2::EIP2930(d) => used_gas(d.used_gas, &mut previous_cumulative_gas),
-							ethereum::ReceiptV2::EIP1559(d) => used_gas(d.used_gas, &mut previous_cumulative_gas),
+							ethereum::ReceiptV3::Legacy(d) => used_gas(d.used_gas, &mut previous_cumulative_gas),
+							ethereum::ReceiptV3::EIP2930(d) => used_gas(d.used_gas, &mut previous_cumulative_gas),
+							ethereum::ReceiptV3::EIP1559(d) => used_gas(d.used_gas, &mut previous_cumulative_gas),
 						},
 						effective_reward: match block.transactions.get(i) {
 							Some(&ethereum::TransactionV2::Legacy(ref t)) => {

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -1174,6 +1174,7 @@ where
 					Ok(Bytes(info.value))
 				} else if api_version == 4 {
 					// Post-london + access list support
+					let access_list = access_list.unwrap_or_default();
 					let info = api
 						.call(
 							&id,
@@ -1186,7 +1187,12 @@ where
 							max_priority_fee_per_gas,
 							nonce,
 							false,
-							access_list,
+							Some(
+								access_list
+									.into_iter()
+									.map(|item| (item.address, item.slots))
+									.collect(),
+							),
 						)
 						.map_err(|err| internal_err(format!("runtime error: {:?}", err)))?
 						.map_err(|err| internal_err(format!("execution fatal: {:?}", err)))?;
@@ -1239,6 +1245,7 @@ where
 					Ok(Bytes(info.value[..].to_vec()))
 				} else if api_version == 4 {
 					// Post-london + access list support
+					let access_list = access_list.unwrap_or_default();
 					let info = api
 						.create(
 							&id,
@@ -1250,7 +1257,12 @@ where
 							max_priority_fee_per_gas,
 							nonce,
 							false,
-							access_list,
+							Some(
+								access_list
+									.into_iter()
+									.map(|item| (item.address, item.slots))
+									.collect(),
+							),
 						)
 						.map_err(|err| internal_err(format!("runtime error: {:?}", err)))?
 						.map_err(|err| internal_err(format!("execution fatal: {:?}", err)))?;
@@ -1425,6 +1437,7 @@ where
 							.map_err(|err| internal_err(format!("execution fatal: {:?}", err)))?
 						} else {
 							// Post-london + access list support
+							let access_list = access_list.unwrap_or_default();
 							api.call(
 								&BlockId::Hash(best_hash),
 								from.unwrap_or_default(),
@@ -1436,7 +1449,12 @@ where
 								max_priority_fee_per_gas,
 								nonce,
 								true,
-								access_list,
+								Some(
+									access_list
+										.into_iter()
+										.map(|item| (item.address, item.slots))
+										.collect(),
+								),
 							)
 							.map_err(|err| internal_err(format!("runtime error: {:?}", err)))?
 							.map_err(|err| internal_err(format!("execution fatal: {:?}", err)))?
@@ -1478,6 +1496,7 @@ where
 							.map_err(|err| internal_err(format!("execution fatal: {:?}", err)))?
 						} else {
 							// Post-london + access list support
+							let access_list = access_list.unwrap_or_default();
 							api.create(
 								&BlockId::Hash(best_hash),
 								from.unwrap_or_default(),
@@ -1488,7 +1507,12 @@ where
 								max_priority_fee_per_gas,
 								nonce,
 								true,
-								access_list,
+								Some(
+									access_list
+										.into_iter()
+										.map(|item| (item.address, item.slots))
+										.collect(),
+								),
 							)
 							.map_err(|err| internal_err(format!("runtime error: {:?}", err)))?
 							.map_err(|err| internal_err(format!("execution fatal: {:?}", err)))?

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -1873,15 +1873,9 @@ where
 				let receipt = receipts[index].clone();
 
 				let (logs, logs_bloom, status_code, cumulative_gas_used) = match receipt {
-					ethereum::ReceiptV3::Legacy(d) => {
-						(d.logs, d.logs_bloom, d.status_code, d.used_gas)
-					}
-					ethereum::ReceiptV3::EIP2930(d) => {
-						(d.logs, d.logs_bloom, d.status_code, d.used_gas)
-					}
-					ethereum::ReceiptV3::EIP1559(d) => {
-						(d.logs, d.logs_bloom, d.status_code, d.used_gas)
-					}
+					ethereum::ReceiptV3::Legacy(d)
+					| ethereum::ReceiptV3::EIP2930(d)
+					| ethereum::ReceiptV3::EIP1559(d) => (d.logs, d.logs_bloom, d.status_code, d.used_gas),
 				};
 
 				let status = statuses[index].clone();
@@ -1890,9 +1884,9 @@ where
 				let gas_used = if index > 0 {
 					let previous_receipt = receipts[index - 1].clone();
 					let previous_gas_used = match previous_receipt {
-						ethereum::ReceiptV3::Legacy(d) => d.used_gas,
-						ethereum::ReceiptV3::EIP2930(d) => d.used_gas,
-						ethereum::ReceiptV3::EIP1559(d) => d.used_gas,
+						ethereum::ReceiptV3::Legacy(d)
+						| ethereum::ReceiptV3::EIP2930(d)
+						| ethereum::ReceiptV3::EIP1559(d) => d.used_gas,
 					};
 					cumulative_gas_used.saturating_sub(previous_gas_used)
 				} else {
@@ -1928,9 +1922,9 @@ where
 								cumulative_receipts
 									.iter()
 									.map(|r| match r {
-										ethereum::ReceiptV3::Legacy(d) => d.logs.len() as u32,
-										ethereum::ReceiptV3::EIP2930(d) => d.logs.len() as u32,
-										ethereum::ReceiptV3::EIP1559(d) => d.logs.len() as u32,
+										ethereum::ReceiptV3::Legacy(d)
+										| ethereum::ReceiptV3::EIP2930(d)
+										| ethereum::ReceiptV3::EIP1559(d) => d.logs.len() as u32,
 									})
 									.sum::<u32>(),
 							);
@@ -2794,9 +2788,7 @@ where
 					.enumerate()
 					.map(|(i, receipt)| TransactionHelper {
 						gas_used: match receipt {
-							ethereum::ReceiptV3::Legacy(d) => used_gas(d.used_gas, &mut previous_cumulative_gas),
-							ethereum::ReceiptV3::EIP2930(d) => used_gas(d.used_gas, &mut previous_cumulative_gas),
-							ethereum::ReceiptV3::EIP1559(d) => used_gas(d.used_gas, &mut previous_cumulative_gas),
+							ethereum::ReceiptV3::Legacy(d) | ethereum::ReceiptV3::EIP2930(d) | ethereum::ReceiptV3::EIP1559(d) => used_gas(d.used_gas, &mut previous_cumulative_gas),
 						},
 						effective_reward: match block.transactions.get(i) {
 							Some(&ethereum::TransactionV2::Legacy(ref t)) => {

--- a/client/rpc/src/eth_pubsub.rs
+++ b/client/rpc/src/eth_pubsub.rs
@@ -161,9 +161,9 @@ impl SubscriptionResult {
 		let mut log_index: u32 = 0;
 		for (receipt_index, receipt) in receipts.into_iter().enumerate() {
 			let receipt_logs = match receipt {
-				ethereum::ReceiptV3::Legacy(d) => d.logs,
-				ethereum::ReceiptV3::EIP2930(d) => d.logs,
-				ethereum::ReceiptV3::EIP1559(d) => d.logs,
+				ethereum::ReceiptV3::Legacy(d)
+				| ethereum::ReceiptV3::EIP2930(d)
+				| ethereum::ReceiptV3::EIP1559(d) => d.logs,
 			};
 			let mut transaction_log_index: u32 = 0;
 			let transaction_hash: Option<H256> = if receipt_logs.len() > 0 {

--- a/client/rpc/src/eth_pubsub.rs
+++ b/client/rpc/src/eth_pubsub.rs
@@ -151,7 +151,7 @@ impl SubscriptionResult {
 	pub fn logs(
 		&self,
 		block: EthereumBlock,
-		receipts: Vec<ethereum::Receipt>,
+		receipts: Vec<ethereum::ReceiptV2>,
 		params: &FilteredParams,
 	) -> Vec<Log> {
 		let block_hash = Some(H256::from_slice(
@@ -160,13 +160,18 @@ impl SubscriptionResult {
 		let mut logs: Vec<Log> = vec![];
 		let mut log_index: u32 = 0;
 		for (receipt_index, receipt) in receipts.into_iter().enumerate() {
+			let receipt_logs = match receipt {
+				ethereum::ReceiptV2::Legacy(d) => d.logs,
+				ethereum::ReceiptV2::EIP2930(d) => d.logs,
+				ethereum::ReceiptV2::EIP1559(d) => d.logs,
+			};
 			let mut transaction_log_index: u32 = 0;
-			let transaction_hash: Option<H256> = if receipt.logs.len() > 0 {
+			let transaction_hash: Option<H256> = if receipt_logs.len() > 0 {
 				Some(block.transactions[receipt_index as usize].hash())
 			} else {
 				None
 			};
-			for log in receipt.logs {
+			for log in receipt_logs {
 				if self.add_log(block_hash.unwrap(), &log, &block, params) {
 					logs.push(Log {
 						address: log.address,

--- a/client/rpc/src/eth_pubsub.rs
+++ b/client/rpc/src/eth_pubsub.rs
@@ -151,7 +151,7 @@ impl SubscriptionResult {
 	pub fn logs(
 		&self,
 		block: EthereumBlock,
-		receipts: Vec<ethereum::ReceiptV2>,
+		receipts: Vec<ethereum::ReceiptV3>,
 		params: &FilteredParams,
 	) -> Vec<Log> {
 		let block_hash = Some(H256::from_slice(
@@ -161,9 +161,9 @@ impl SubscriptionResult {
 		let mut log_index: u32 = 0;
 		for (receipt_index, receipt) in receipts.into_iter().enumerate() {
 			let receipt_logs = match receipt {
-				ethereum::ReceiptV2::Legacy(d) => d.logs,
-				ethereum::ReceiptV2::EIP2930(d) => d.logs,
-				ethereum::ReceiptV2::EIP1559(d) => d.logs,
+				ethereum::ReceiptV3::Legacy(d) => d.logs,
+				ethereum::ReceiptV3::EIP2930(d) => d.logs,
+				ethereum::ReceiptV3::EIP1559(d) => d.logs,
 			};
 			let mut transaction_log_index: u32 = 0;
 			let transaction_hash: Option<H256> = if receipt_logs.len() > 0 {

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -27,7 +27,8 @@ pub use eth::{
 pub use eth_pubsub::{EthPubSubApi, EthPubSubApiServer, HexEncodedIdProvider};
 pub use ethereum::TransactionV2 as EthereumTransaction;
 pub use overrides::{
-	OverrideHandle, RuntimeApiStorageOverride, SchemaV1Override, SchemaV2Override, StorageOverride,
+	OverrideHandle, RuntimeApiStorageOverride, SchemaV1Override, SchemaV2Override,
+	SchemaV3Override, StorageOverride,
 };
 
 use ethereum_types::{H160, H256};

--- a/client/rpc/src/overrides/mod.rs
+++ b/client/rpc/src/overrides/mod.rs
@@ -25,11 +25,13 @@ use std::{marker::PhantomData, sync::Arc};
 
 mod schema_v1_override;
 mod schema_v2_override;
+mod schema_v3_override;
 
 pub use fc_rpc_core::{EthApiServer, NetApiServer};
 use pallet_ethereum::EthereumStorageSchema;
 pub use schema_v1_override::SchemaV1Override;
 pub use schema_v2_override::SchemaV2Override;
+pub use schema_v3_override::SchemaV3Override;
 
 pub struct OverrideHandle<Block: BlockT> {
 	pub schemas: BTreeMap<EthereumStorageSchema, Box<dyn StorageOverride<Block> + Send + Sync>>,

--- a/client/rpc/src/overrides/schema_v1_override.rs
+++ b/client/rpc/src/overrides/schema_v1_override.rs
@@ -111,11 +111,17 @@ where
 	}
 
 	/// Return the current receipt.
-	fn current_receipts(&self, block: &BlockId<Block>) -> Option<Vec<ethereum::Receipt>> {
-		self.query_storage::<Vec<ethereum::Receipt>>(
+	fn current_receipts(&self, block: &BlockId<Block>) -> Option<Vec<ethereum::ReceiptV2>> {
+		self.query_storage::<Vec<ethereum::ReceiptV0>>(
 			block,
 			&StorageKey(storage_prefix_build(b"Ethereum", b"CurrentReceipts")),
 		)
+		.map(|receipts| {
+			receipts
+				.into_iter()
+				.map(|r| ethereum::ReceiptV2::Legacy(r))
+				.collect()
+		})
 	}
 
 	/// Return the current transaction status.

--- a/client/rpc/src/overrides/schema_v1_override.rs
+++ b/client/rpc/src/overrides/schema_v1_override.rs
@@ -53,14 +53,6 @@ where
 	B: BlockT<Hash = H256> + Send + Sync + 'static,
 	C: Send + Sync + 'static,
 {
-	// My attempt using result
-	// fn query_storage<T: Decode>(&self, id: &BlockId<B>, key: &StorageKey) -> Result<T> {
-	// 	let raw_data = self.client.storage(id, key)?
-	// 		.ok_or("Storage provider returned Ok(None)")?;
-	//
-	// 	Decode::decode(&mut &raw_data.0[..]).map_err(|_| "Could not decode data".into())
-	// }
-
 	fn query_storage<T: Decode>(&self, id: &BlockId<B>, key: &StorageKey) -> Option<T> {
 		if let Ok(Some(data)) = self.client.storage(id, key) {
 			if let Ok(result) = Decode::decode(&mut &data.0[..]) {

--- a/client/rpc/src/overrides/schema_v1_override.rs
+++ b/client/rpc/src/overrides/schema_v1_override.rs
@@ -111,7 +111,7 @@ where
 	}
 
 	/// Return the current receipt.
-	fn current_receipts(&self, block: &BlockId<Block>) -> Option<Vec<ethereum::ReceiptV2>> {
+	fn current_receipts(&self, block: &BlockId<Block>) -> Option<Vec<ethereum::ReceiptV3>> {
 		self.query_storage::<Vec<ethereum::ReceiptV0>>(
 			block,
 			&StorageKey(storage_prefix_build(b"Ethereum", b"CurrentReceipts")),
@@ -119,7 +119,14 @@ where
 		.map(|receipts| {
 			receipts
 				.into_iter()
-				.map(|r| ethereum::ReceiptV2::Legacy(r))
+				.map(|r| {
+					ethereum::ReceiptV3::Legacy(ethereum::EIP658ReceiptData {
+						status_code: r.state_root.to_low_u64_be() as u8,
+						used_gas: r.used_gas,
+						logs_bloom: r.logs_bloom,
+						logs: r.logs,
+					})
+				})
 				.collect()
 		})
 	}

--- a/client/rpc/src/overrides/schema_v2_override.rs
+++ b/client/rpc/src/overrides/schema_v2_override.rs
@@ -110,8 +110,8 @@ where
 	}
 
 	/// Return the current receipt.
-	fn current_receipts(&self, block: &BlockId<Block>) -> Option<Vec<ethereum::Receipt>> {
-		self.query_storage::<Vec<ethereum::Receipt>>(
+	fn current_receipts(&self, block: &BlockId<Block>) -> Option<Vec<ethereum::ReceiptV2>> {
+		self.query_storage::<Vec<ethereum::ReceiptV2>>(
 			block,
 			&StorageKey(storage_prefix_build(b"Ethereum", b"CurrentReceipts")),
 		)

--- a/client/rpc/src/overrides/schema_v2_override.rs
+++ b/client/rpc/src/overrides/schema_v2_override.rs
@@ -53,14 +53,6 @@ where
 	B: BlockT<Hash = H256> + Send + Sync + 'static,
 	C: Send + Sync + 'static,
 {
-	// My attempt using result
-	// fn query_storage<T: Decode>(&self, id: &BlockId<B>, key: &StorageKey) -> Result<T> {
-	// 	let raw_data = self.client.storage(id, key)?
-	// 		.ok_or("Storage provider returned Ok(None)")?;
-	//
-	// 	Decode::decode(&mut &raw_data.0[..]).map_err(|_| "Could not decode data".into())
-	// }
-
 	fn query_storage<T: Decode>(&self, id: &BlockId<B>, key: &StorageKey) -> Option<T> {
 		if let Ok(Some(data)) = self.client.storage(id, key) {
 			if let Ok(result) = Decode::decode(&mut &data.0[..]) {

--- a/client/rpc/src/overrides/schema_v2_override.rs
+++ b/client/rpc/src/overrides/schema_v2_override.rs
@@ -110,8 +110,8 @@ where
 	}
 
 	/// Return the current receipt.
-	fn current_receipts(&self, block: &BlockId<Block>) -> Option<Vec<ethereum::ReceiptV2>> {
-		self.query_storage::<Vec<ethereum::ReceiptV2>>(
+	fn current_receipts(&self, block: &BlockId<Block>) -> Option<Vec<ethereum::ReceiptV3>> {
+		self.query_storage::<Vec<ethereum::ReceiptV3>>(
 			block,
 			&StorageKey(storage_prefix_build(b"Ethereum", b"CurrentReceipts")),
 		)

--- a/client/rpc/src/overrides/schema_v3_override.rs
+++ b/client/rpc/src/overrides/schema_v3_override.rs
@@ -53,14 +53,6 @@ where
 	B: BlockT<Hash = H256> + Send + Sync + 'static,
 	C: Send + Sync + 'static,
 {
-	// My attempt using result
-	// fn query_storage<T: Decode>(&self, id: &BlockId<B>, key: &StorageKey) -> Result<T> {
-	// 	let raw_data = self.client.storage(id, key)?
-	// 		.ok_or("Storage provider returned Ok(None)")?;
-	//
-	// 	Decode::decode(&mut &raw_data.0[..]).map_err(|_| "Could not decode data".into())
-	// }
-
 	fn query_storage<T: Decode>(&self, id: &BlockId<B>, key: &StorageKey) -> Option<T> {
 		if let Ok(Some(data)) = self.client.storage(id, key) {
 			if let Ok(result) = Decode::decode(&mut &data.0[..]) {

--- a/frame/ethereum/Cargo.toml
+++ b/frame/ethereum/Cargo.toml
@@ -21,7 +21,7 @@ sp-std = { version = "4.0.0-dev", default-features = false, git = "https://githu
 sp-io = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate" }
 fp-evm = { version = "3.0.0-dev", default-features = false, path = "../../primitives/evm" }
 evm = { version = "0.33.1", features = ["with-codec"], default-features = false }
-ethereum = { version = "0.11.0", default-features = false, features = ["with-codec"] }
+ethereum = { version = "0.11.1", default-features = false, features = ["with-codec"] }
 ethereum-types = { version = "0.12", default-features = false }
 rlp = { version = "0.5", default-features = false }
 sha3 = { version = "0.8", default-features = false }

--- a/frame/ethereum/Cargo.toml
+++ b/frame/ethereum/Cargo.toml
@@ -20,7 +20,7 @@ sp-runtime = { version = "4.0.0-dev", default-features = false, git = "https://g
 sp-std = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate" }
 sp-io = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate" }
 fp-evm = { version = "3.0.0-dev", default-features = false, path = "../../primitives/evm" }
-evm = { version = "0.33.0", features = ["with-codec"], default-features = false }
+evm = { version = "0.33.1", features = ["with-codec"], default-features = false }
 ethereum = { version = "0.11.0", default-features = false, features = ["with-codec"] }
 ethereum-types = { version = "0.12", default-features = false }
 rlp = { version = "0.5", default-features = false }

--- a/frame/ethereum/Cargo.toml
+++ b/frame/ethereum/Cargo.toml
@@ -21,7 +21,7 @@ sp-std = { version = "4.0.0-dev", default-features = false, git = "https://githu
 sp-io = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate" }
 fp-evm = { version = "3.0.0-dev", default-features = false, path = "../../primitives/evm" }
 evm = { version = "0.33.0", features = ["with-codec"], default-features = false }
-ethereum = { version = "0.10.0", default-features = false, features = ["with-codec"] }
+ethereum = { version = "0.11.0", default-features = false, features = ["with-codec"] }
 ethereum-types = { version = "0.12", default-features = false }
 rlp = { version = "0.5", default-features = false }
 sha3 = { version = "0.8", default-features = false }

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -646,7 +646,9 @@ impl<T: Config> Pallet<T> {
 			let logs = status.clone().logs;
 			let cumulative_gas_used = if let Some((_, _, receipt)) = pending.last() {
 				match receipt {
-					Receipt::Legacy(d) | Receipt::EIP2930(d) | Receipt::EIP1559(d) => d.used_gas.saturating_add(used_gas),
+					Receipt::Legacy(d) | Receipt::EIP2930(d) | Receipt::EIP1559(d) => {
+						d.used_gas.saturating_add(used_gas)
+					}
 				}
 			} else {
 				used_gas

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -48,7 +48,7 @@ use sp_runtime::{
 use sp_std::{marker::PhantomData, prelude::*};
 
 pub use ethereum::{
-	BlockV2 as Block, LegacyTransactionMessage, Log, Receipt, TransactionAction,
+	BlockV2 as Block, LegacyTransactionMessage, Log, ReceiptV2 as Receipt, TransactionAction,
 	TransactionV2 as Transaction,
 };
 pub use fp_rpc::TransactionStatus;
@@ -85,35 +85,6 @@ struct TransactionData {
 	value: U256,
 	chain_id: Option<u64>,
 	access_list: Vec<(H160, Vec<H256>)>,
-}
-
-struct EncodeableReceipt<'a> {
-	transaction_type: u8,
-	status: U64,
-	cumulative_gas_used: U256,
-	bloom: Bloom,
-	logs: &'a Vec<Log>,
-}
-
-impl<'a> rlp::Encodable for EncodeableReceipt<'a> {
-	fn rlp_append(&self, s: &mut rlp::RlpStream) {
-		if self.transaction_type == 0 {
-			// Legacy
-			s.begin_list(4);
-			s.append(&self.status);
-			s.append(&self.cumulative_gas_used);
-			s.append(&self.bloom);
-			s.append_list(&self.logs);
-		} else {
-			// Typed transactions are prepended with the envelope byte.
-			s.begin_list(5);
-			s.append(&self.transaction_type);
-			s.append(&self.status);
-			s.append(&self.cumulative_gas_used);
-			s.append(&self.bloom);
-			s.append_list(&self.logs);
-		}
-	}
 }
 
 pub struct EnsureEthereumTransaction;
@@ -317,7 +288,7 @@ pub mod pallet {
 	/// Current building block's transactions and receipts.
 	#[pallet::storage]
 	pub(super) type Pending<T: Config> =
-		StorageValue<_, Vec<(Transaction, TransactionStatus, ethereum::Receipt)>, ValueQuery>;
+		StorageValue<_, Vec<(Transaction, TransactionStatus, Receipt)>, ValueQuery>;
 
 	/// The current Ethereum block.
 	#[pallet::storage]
@@ -325,7 +296,7 @@ pub mod pallet {
 
 	/// The current Ethereum receipts.
 	#[pallet::storage]
-	pub(super) type CurrentReceipts<T: Config> = StorageValue<_, Vec<ethereum::Receipt>>;
+	pub(super) type CurrentReceipts<T: Config> = StorageValue<_, Vec<Receipt>>;
 
 	/// The current transaction statuses.
 	#[pallet::storage]
@@ -441,31 +412,23 @@ impl<T: Config> Pallet<T> {
 		let mut statuses = Vec::new();
 		let mut receipts = Vec::new();
 		let mut logs_bloom = Bloom::default();
+		let mut cumulative_gas_used = U256::zero();
 		for (transaction, status, receipt) in Pending::<T>::get() {
 			transactions.push(transaction);
 			statuses.push(status);
 			receipts.push(receipt.clone());
-			Self::logs_bloom(receipt.logs.clone(), &mut logs_bloom);
+			let (logs, used_gas) = match receipt {
+				Receipt::Legacy(d) => (d.logs.clone(), d.used_gas),
+				Receipt::EIP2930(d) => (d.logs.clone(), d.used_gas),
+				Receipt::EIP1559(d) => (d.logs.clone(), d.used_gas),
+			};
+			cumulative_gas_used = used_gas;
+			Self::logs_bloom(logs, &mut logs_bloom);
 		}
 
 		let ommers = Vec::<ethereum::Header>::new();
-		let mut cumulative_gas_used = U256::zero();
 		let receipts_root =
-			ethereum::util::ordered_trie_root(receipts.iter().enumerate().map(|(i, r)| {
-				cumulative_gas_used = cumulative_gas_used.saturating_add(r.used_gas);
-				let receipt = EncodeableReceipt {
-					transaction_type: match transactions[i] {
-						Transaction::Legacy(_) => 0,
-						Transaction::EIP2930(_) => 1,
-						Transaction::EIP1559(_) => 2,
-					},
-					status: U64::from(r.state_root.to_low_u64_be()),
-					cumulative_gas_used,
-					bloom: r.logs_bloom,
-					logs: &r.logs,
-				};
-				rlp::encode(&receipt)
-			}));
+			ethereum::util::ordered_trie_root(receipts.iter().map(|r| rlp::encode(r)));
 		let partial_header = ethereum::PartialHeader {
 			parent_hash: Self::current_block_hash().unwrap_or_default(),
 			beneficiary: pallet_evm::Pallet::<T>::find_author(),
@@ -475,10 +438,7 @@ impl<T: Config> Pallet<T> {
 			difficulty: U256::zero(),
 			number: block_number,
 			gas_limit: T::BlockGasLimit::get(),
-			gas_used: receipts
-				.clone()
-				.into_iter()
-				.fold(U256::zero(), |acc, r| acc + r.used_gas),
+			gas_used: cumulative_gas_used,
 			timestamp: UniqueSaturatedInto::<u64>::unique_saturated_into(
 				pallet_timestamp::Pallet::<T>::get(),
 			),
@@ -631,8 +591,9 @@ impl<T: Config> Pallet<T> {
 	}
 
 	fn apply_validated_transaction(source: H160, transaction: Transaction) -> PostDispatchInfo {
+		let pending = Pending::<T>::get();
 		let transaction_hash = transaction.hash();
-		let transaction_index = Pending::<T>::get().len() as u32;
+		let transaction_index = pending.len() as u32;
 
 		let (to, _, info) = Self::execute(source, &transaction, None)
 			.expect("transaction is already validated; error indicates that the block is invalid");
@@ -676,16 +637,44 @@ impl<T: Config> Pallet<T> {
 			),
 		};
 
-		let receipt = ethereum::Receipt {
-			state_root: match reason {
+		let receipt = {
+			let state_root = match reason {
 				ExitReason::Succeed(_) => H256::from_low_u64_be(1),
 				ExitReason::Error(_) => H256::from_low_u64_le(0),
 				ExitReason::Revert(_) => H256::from_low_u64_le(0),
 				ExitReason::Fatal(_) => H256::from_low_u64_le(0),
-			},
-			used_gas,
-			logs_bloom: status.clone().logs_bloom,
-			logs: status.clone().logs,
+			};
+			let logs_bloom = status.clone().logs_bloom;
+			let logs = status.clone().logs;
+			let cumulative_gas_used = if let Some((_, _, receipt)) = pending.last() {
+				match receipt {
+					Receipt::Legacy(d) => d.used_gas.saturating_add(used_gas),
+					Receipt::EIP2930(d) => d.used_gas.saturating_add(used_gas),
+					Receipt::EIP1559(d) => d.used_gas.saturating_add(used_gas),
+				}
+			} else {
+				used_gas
+			};
+			match &transaction {
+				Transaction::Legacy(_) => Receipt::Legacy(ethereum::ReceiptData {
+					state_root,
+					used_gas: cumulative_gas_used,
+					logs_bloom,
+					logs,
+				}),
+				Transaction::EIP2930(_) => Receipt::EIP2930(ethereum::ReceiptData {
+					state_root,
+					used_gas: cumulative_gas_used,
+					logs_bloom,
+					logs,
+				}),
+				Transaction::EIP1559(_) => Receipt::EIP1559(ethereum::ReceiptData {
+					state_root,
+					used_gas: cumulative_gas_used.saturating_add(used_gas),
+					logs_bloom,
+					logs,
+				}),
+			}
 		};
 
 		Pending::<T>::append((transaction, status, receipt));
@@ -721,7 +710,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// Get receipts by number.
-	pub fn current_receipts() -> Option<Vec<ethereum::Receipt>> {
+	pub fn current_receipts() -> Option<Vec<Receipt>> {
 		CurrentReceipts::<T>::get()
 	}
 

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -418,9 +418,9 @@ impl<T: Config> Pallet<T> {
 			statuses.push(status);
 			receipts.push(receipt.clone());
 			let (logs, used_gas) = match receipt {
-				Receipt::Legacy(d) => (d.logs.clone(), d.used_gas),
-				Receipt::EIP2930(d) => (d.logs.clone(), d.used_gas),
-				Receipt::EIP1559(d) => (d.logs.clone(), d.used_gas),
+				Receipt::Legacy(d) | Receipt::EIP2930(d) | Receipt::EIP1559(d) => {
+					(d.logs.clone(), d.used_gas)
+				}
 			};
 			cumulative_gas_used = used_gas;
 			Self::logs_bloom(logs, &mut logs_bloom);

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -239,7 +239,7 @@ pub mod pallet {
 		fn on_runtime_upgrade() -> Weight {
 			frame_support::storage::unhashed::put::<EthereumStorageSchema>(
 				&PALLET_ETHEREUM_SCHEMA,
-				&EthereumStorageSchema::V2,
+				&EthereumStorageSchema::V3,
 			);
 
 			T::DbWeight::get().write
@@ -316,7 +316,7 @@ pub mod pallet {
 			<Pallet<T>>::store_block(false, U256::zero());
 			frame_support::storage::unhashed::put::<EthereumStorageSchema>(
 				&PALLET_ETHEREUM_SCHEMA,
-				&EthereumStorageSchema::V2,
+				&EthereumStorageSchema::V3,
 			);
 		}
 	}
@@ -865,6 +865,7 @@ pub enum EthereumStorageSchema {
 	Undefined,
 	V1,
 	V2,
+	V3,
 }
 
 impl Default for EthereumStorageSchema {

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -48,8 +48,8 @@ use sp_runtime::{
 use sp_std::{marker::PhantomData, prelude::*};
 
 pub use ethereum::{
-	BlockV2 as Block, LegacyTransactionMessage, Log, ReceiptV3 as Receipt, TransactionAction,
-	TransactionV2 as Transaction,
+	AccessListItem, BlockV2 as Block, LegacyTransactionMessage, Log, ReceiptV3 as Receipt,
+	TransactionAction, TransactionV2 as Transaction,
 };
 pub use fp_rpc::TransactionStatus;
 

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -646,9 +646,7 @@ impl<T: Config> Pallet<T> {
 			let logs = status.clone().logs;
 			let cumulative_gas_used = if let Some((_, _, receipt)) = pending.last() {
 				match receipt {
-					Receipt::Legacy(d) => d.used_gas.saturating_add(used_gas),
-					Receipt::EIP2930(d) => d.used_gas.saturating_add(used_gas),
-					Receipt::EIP1559(d) => d.used_gas.saturating_add(used_gas),
+					Receipt::Legacy(d) | Receipt::EIP2930(d) | Receipt::EIP1559(d) => d.used_gas.saturating_add(used_gas),
 				}
 			} else {
 				used_gas

--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -27,7 +27,7 @@ frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/parityte
 fp-evm = { version = "3.0.0-dev", default-features = false, path = "../../primitives/evm" }
 primitive-types = { version = "0.10.0", default-features = false, features = ["rlp", "byteorder"] }
 rlp = { version = "0.5", default-features = false }
-evm = { version = "0.33.0", default-features = false, features = ["with-codec"] }
+evm = { version = "0.33.1", default-features = false, features = ["with-codec"] }
 evm-runtime = { version = "0.33.0", default-features = false }
 evm-gasometer = { version = "0.33.0", default-features = false }
 sha3 = { version = "0.8", default-features = false }

--- a/frame/evm/test-vector-support/Cargo.toml
+++ b/frame/evm/test-vector-support/Cargo.toml
@@ -12,7 +12,7 @@ description = "Test vector support for EVM pallet."
 hex = { version = "0.4.0", optional = true }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
-evm = { version = "0.33.0", default-features = false, features = ["with-codec"] }
+evm = { version = "0.33.1", default-features = false, features = ["with-codec"] }
 fp-evm = { version = "3.0.0-dev", default-features = false, path = "../../../primitives/evm" }
 
 [features]

--- a/primitives/consensus/Cargo.toml
+++ b/primitives/consensus/Cargo.toml
@@ -13,7 +13,7 @@ sp-std = { version = "4.0.0-dev", default-features = false, git = "https://githu
 sp-runtime = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate" }
 sp-core = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
-ethereum = { version = "0.11.0", default-features = false, features = ["with-codec"] }
+ethereum = { version = "0.11.1", default-features = false, features = ["with-codec"] }
 rlp = { version = "0.5", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 

--- a/primitives/consensus/Cargo.toml
+++ b/primitives/consensus/Cargo.toml
@@ -13,7 +13,7 @@ sp-std = { version = "4.0.0-dev", default-features = false, git = "https://githu
 sp-runtime = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate" }
 sp-core = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
-ethereum = { version = "0.10.0", default-features = false, features = ["with-codec"] }
+ethereum = { version = "0.11.0", default-features = false, features = ["with-codec"] }
 rlp = { version = "0.5", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 

--- a/primitives/evm/Cargo.toml
+++ b/primitives/evm/Cargo.toml
@@ -17,7 +17,7 @@ sp-core = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrat
 sp-std = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", default-features = false }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
-evm = { version = "0.33.0", default-features = false, features = ["with-codec"] }
+evm = { version = "0.33.1", default-features = false, features = ["with-codec"] }
 
 [features]
 default = ["std"]

--- a/primitives/rpc/Cargo.toml
+++ b/primitives/rpc/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 sp-core = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate" }
 sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate" }
 fp-evm = { version = "3.0.0-dev", default-features = false, path = "../../primitives/evm" }
-ethereum = { version = "0.10.0", default-features = false, features = ["with-codec"] }
+ethereum = { version = "0.11.0", default-features = false, features = ["with-codec"] }
 ethereum-types = { version = "0.12", default-features = false }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 sp-runtime = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate" }

--- a/primitives/rpc/Cargo.toml
+++ b/primitives/rpc/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 sp-core = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate" }
 sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate" }
 fp-evm = { version = "3.0.0-dev", default-features = false, path = "../../primitives/evm" }
-ethereum = { version = "0.11.0", default-features = false, features = ["with-codec"] }
+ethereum = { version = "0.11.1", default-features = false, features = ["with-codec"] }
 ethereum-types = { version = "0.12", default-features = false }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 sp-runtime = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate" }

--- a/primitives/rpc/src/lib.rs
+++ b/primitives/rpc/src/lib.rs
@@ -77,6 +77,7 @@ sp_api::decl_runtime_apis! {
 			nonce: Option<U256>,
 			estimate: bool,
 		) -> Result<fp_evm::CallInfo, sp_runtime::DispatchError>;
+		#[changed_in(4)]
 		fn call(
 			from: H160,
 			to: H160,
@@ -87,6 +88,18 @@ sp_api::decl_runtime_apis! {
 			max_priority_fee_per_gas: Option<U256>,
 			nonce: Option<U256>,
 			estimate: bool,
+		) -> Result<fp_evm::CallInfo, sp_runtime::DispatchError>;
+		fn call(
+			from: H160,
+			to: H160,
+			data: Vec<u8>,
+			value: U256,
+			gas_limit: U256,
+			max_fee_per_gas: Option<U256>,
+			max_priority_fee_per_gas: Option<U256>,
+			nonce: Option<U256>,
+			estimate: bool,
+			access_list: Option<Vec<(H160, Vec<H256>)>>,
 		) -> Result<fp_evm::CallInfo, sp_runtime::DispatchError>;
 		/// Returns a frame_ethereum::create response.
 		#[changed_in(2)]
@@ -99,6 +112,7 @@ sp_api::decl_runtime_apis! {
 			nonce: Option<U256>,
 			estimate: bool,
 		) -> Result<fp_evm::CreateInfo, sp_runtime::DispatchError>;
+		#[changed_in(4)]
 		fn create(
 			from: H160,
 			data: Vec<u8>,
@@ -108,6 +122,17 @@ sp_api::decl_runtime_apis! {
 			max_priority_fee_per_gas: Option<U256>,
 			nonce: Option<U256>,
 			estimate: bool,
+		) -> Result<fp_evm::CreateInfo, sp_runtime::DispatchError>;
+		fn create(
+			from: H160,
+			data: Vec<u8>,
+			value: U256,
+			gas_limit: U256,
+			max_fee_per_gas: Option<U256>,
+			max_priority_fee_per_gas: Option<U256>,
+			nonce: Option<U256>,
+			estimate: bool,
+			access_list: Option<Vec<(H160, Vec<H256>)>>,
 		) -> Result<fp_evm::CreateInfo, sp_runtime::DispatchError>;
 		/// Return the current block. Legacy.
 		#[changed_in(2)]

--- a/primitives/rpc/src/lib.rs
+++ b/primitives/rpc/src/lib.rs
@@ -118,7 +118,7 @@ sp_api::decl_runtime_apis! {
 		#[changed_in(4)]
 		fn current_receipts() -> Option<Vec<ethereum::ReceiptV0>>;
 		/// Return the current receipt.
-		fn current_receipts() -> Option<Vec<ethereum::ReceiptV2>>;
+		fn current_receipts() -> Option<Vec<ethereum::ReceiptV3>>;
 		/// Return the current transaction status.
 		fn current_transaction_statuses() -> Option<Vec<TransactionStatus>>;
 		/// Return all the current data for a block in a single runtime call. Legacy.
@@ -137,7 +137,7 @@ sp_api::decl_runtime_apis! {
 		);
 		fn current_all() -> (
 			Option<ethereum::BlockV2>,
-			Option<Vec<ethereum::ReceiptV2>>,
+			Option<Vec<ethereum::ReceiptV3>>,
 			Option<Vec<TransactionStatus>>
 		);
 		/// Receives a `Vec<OpaqueExtrinsic>` and filters all the ethereum transactions. Legacy.

--- a/primitives/rpc/src/lib.rs
+++ b/primitives/rpc/src/lib.rs
@@ -51,7 +51,7 @@ impl Default for TransactionStatus {
 
 sp_api::decl_runtime_apis! {
 	/// API necessary for Ethereum-compatibility layer.
-	#[api_version(3)]
+	#[api_version(4)]
 	pub trait EthereumRuntimeRPCApi {
 		/// Returns runtime defined pallet_evm::ChainId.
 		fn chain_id() -> u64;
@@ -115,20 +115,29 @@ sp_api::decl_runtime_apis! {
 		/// Return the current block.
 		fn current_block() -> Option<ethereum::BlockV2>;
 		/// Return the current receipt.
-		fn current_receipts() -> Option<Vec<ethereum::Receipt>>;
+		#[changed_in(4)]
+		fn current_receipts() -> Option<Vec<ethereum::ReceiptV0>>;
+		/// Return the current receipt.
+		fn current_receipts() -> Option<Vec<ethereum::ReceiptV2>>;
 		/// Return the current transaction status.
 		fn current_transaction_statuses() -> Option<Vec<TransactionStatus>>;
 		/// Return all the current data for a block in a single runtime call. Legacy.
 		#[changed_in(2)]
 		fn current_all() -> (
 			Option<ethereum::BlockV0>,
-			Option<Vec<ethereum::Receipt>>,
+			Option<Vec<ethereum::ReceiptV0>>,
 			Option<Vec<TransactionStatus>>
 		);
 		/// Return all the current data for a block in a single runtime call.
+		#[changed_in(4)]
 		fn current_all() -> (
 			Option<ethereum::BlockV2>,
-			Option<Vec<ethereum::Receipt>>,
+			Option<Vec<ethereum::ReceiptV0>>,
+			Option<Vec<TransactionStatus>>
+		);
+		fn current_all() -> (
+			Option<ethereum::BlockV2>,
+			Option<Vec<ethereum::ReceiptV2>>,
 			Option<Vec<TransactionStatus>>
 		);
 		/// Receives a `Vec<OpaqueExtrinsic>` and filters all the ethereum transactions. Legacy.

--- a/primitives/self-contained/Cargo.toml
+++ b/primitives/self-contained/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/fp-ethereum"
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
-ethereum = { version = "0.10.0", default-features = false, features = ["with-codec"] }
+ethereum = { version = "0.11.0", default-features = false, features = ["with-codec"] }
 sp-core = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", default-features = false }
 sp-runtime = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", default-features = false }
 sp-io = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", default-features = false }

--- a/primitives/self-contained/Cargo.toml
+++ b/primitives/self-contained/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/fp-ethereum"
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
-ethereum = { version = "0.11.0", default-features = false, features = ["with-codec"] }
+ethereum = { version = "0.11.1", default-features = false, features = ["with-codec"] }
 sp-core = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", default-features = false }
 sp-runtime = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", default-features = false }
 sp-io = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", default-features = false }

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use fc_rpc::{
 	EthBlockDataCache, OverrideHandle, RuntimeApiStorageOverride, SchemaV1Override,
-	SchemaV2Override, StorageOverride,
+	SchemaV2Override, SchemaV3Override, StorageOverride,
 };
 use fc_rpc_core::types::{FeeHistoryCache, FilterPool};
 use frontier_template_runtime::{opaque::Block, AccountId, Balance, Hash, Index};
@@ -87,6 +87,11 @@ where
 	overrides_map.insert(
 		EthereumStorageSchema::V2,
 		Box::new(SchemaV2Override::new(client.clone()))
+			as Box<dyn StorageOverride<_> + Send + Sync>,
+	);
+	overrides_map.insert(
+		EthereumStorageSchema::V3,
+		Box::new(SchemaV3Override::new(client.clone()))
 			as Box<dyn StorageOverride<_> + Send + Sync>,
 	);
 

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -590,6 +590,7 @@ impl_runtime_apis! {
 			max_priority_fee_per_gas: Option<U256>,
 			nonce: Option<U256>,
 			estimate: bool,
+			access_list: Option<Vec<(H160, Vec<H256>)>>,
 		) -> Result<pallet_evm::CallInfo, sp_runtime::DispatchError> {
 			let config = if estimate {
 				let mut config = <Runtime as pallet_evm::Config>::config().clone();
@@ -608,7 +609,7 @@ impl_runtime_apis! {
 				max_fee_per_gas,
 				max_priority_fee_per_gas,
 				nonce,
-				Vec::new(),
+				access_list.unwrap_or_default(),
 				config.as_ref().unwrap_or(<Runtime as pallet_evm::Config>::config()),
 			).map_err(|err| err.into())
 		}
@@ -622,6 +623,7 @@ impl_runtime_apis! {
 			max_priority_fee_per_gas: Option<U256>,
 			nonce: Option<U256>,
 			estimate: bool,
+			access_list: Option<Vec<(H160, Vec<H256>)>>,
 		) -> Result<pallet_evm::CreateInfo, sp_runtime::DispatchError> {
 			let config = if estimate {
 				let mut config = <Runtime as pallet_evm::Config>::config().clone();
@@ -639,7 +641,7 @@ impl_runtime_apis! {
 				max_fee_per_gas,
 				max_priority_fee_per_gas,
 				nonce,
-				Vec::new(),
+				access_list.unwrap_or_default(),
 				config.as_ref().unwrap_or(<Runtime as pallet_evm::Config>::config()),
 			).map_err(|err| err.into())
 		}

--- a/ts-tests/tests/test-gas.ts
+++ b/ts-tests/tests/test-gas.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 
 import Test from "../build/contracts/Test.json"
-import { describeWithFrontier, createAndFinalizeBlock } from "./util";
+import { describeWithFrontier, createAndFinalizeBlock,customRequest } from "./util";
 import { AbiItem } from "web3-utils";
 
 describeWithFrontier("Frontier RPC (Gas)", (context) => {
@@ -56,6 +56,19 @@ describeWithFrontier("Frontier RPC (Gas)", (context) => {
 		});
 
 		expect(await contract.methods.multiply(3).estimateGas()).to.equal(21204);
+	});
+
+	it("eth_estimateGas should handle AccessList alias", async function () {
+		let result = (await customRequest(context.web3, "eth_estimateGas", [{
+			from: GENESIS_ACCOUNT,
+			data: Test.bytecode,
+			accessList: [{
+				address: "0x0000000000000000000000000000000000000000",
+				storageKeys: ["0x0000000000000000000000000000000000000000000000000000000000000000"]
+			}]
+		}])).result;
+		// 4300 == 1900 for one key and 2400 for one storage.
+		expect(result).to.equal(context.web3.utils.numberToHex(196657 + 4300));
 	});
 
 });


### PR DESCRIPTION
To properly calculate the block's `receipts_root`, receipts need to be rlp encoded using the `status` and the `cumulative_gas_used`. Additionally enveloped (2930 and 1559) transactions' receipts are encoded with the prepended type byte.

As shown [in geth](https://github.com/ethereum/go-ethereum/blob/e4f570fcc67aa2df489666cc08568c637024fd3c/core/types/receipt.go#L137-L151).