### PR TITLE
Add `IsActive` associated type to `pallet-base-fee`

### DIFF
--- a/frame/base-fee/src/lib.rs
+++ b/frame/base-fee/src/lib.rs
@@ -302,7 +302,7 @@ mod tests {
 	}
 
 	frame_support::parameter_types! {
-		pub const Threshold: (u8, u8) = (0, 100);
+		pub IsActive: bool = true;
 	}
 
 	pub struct BaseFeeThreshold;
@@ -321,6 +321,7 @@ mod tests {
 	impl Config for Test {
 		type Event = Event;
 		type Threshold = BaseFeeThreshold;
+		type IsActive = IsActive;
 	}
 
 	frame_support::construct_runtime!(

--- a/frame/base-fee/src/lib.rs
+++ b/frame/base-fee/src/lib.rs
@@ -36,6 +36,7 @@ pub mod pallet {
 		type Event: From<Event> + IsType<<Self as frame_system::Config>::Event>;
 		/// Lower and upper bounds for increasing / decreasing `BaseFeePerGas`.
 		type Threshold: BaseFeeThreshold;
+		type IsActive: Get<bool>;
 	}
 
 	#[pallet::pallet]
@@ -93,13 +94,13 @@ pub mod pallet {
 	pub type BaseFeePerGas<T> = StorageValue<_, U256, ValueQuery, DefaultBaseFeePerGas>;
 
 	#[pallet::type_value]
-	pub fn DefaultIsActive() -> bool {
-		true
+	pub fn DefaultIsActive<T: Config>() -> bool {
+		T::IsActive::get()
 	}
 
 	#[pallet::storage]
 	#[pallet::getter(fn is_active)]
-	pub type IsActive<T> = StorageValue<_, bool, ValueQuery, DefaultIsActive>;
+	pub type IsActive<T> = StorageValue<_, bool, ValueQuery, DefaultIsActive<T>>;
 
 	#[pallet::type_value]
 	pub fn DefaultElasticity() -> Permill {
@@ -196,6 +197,11 @@ pub mod pallet {
 					});
 				}
 			}
+		}
+
+		fn on_runtime_upgrade() -> Weight {
+			<IsActive<T>>::put(T::IsActive::get());
+			T::DbWeight::get().write
 		}
 	}
 

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -332,6 +332,10 @@ impl pallet_dynamic_fee::Config for Runtime {
 	type MinGasPriceBoundDivisor = BoundDivision;
 }
 
+frame_support::parameter_types! {
+	pub IsActive: bool = true;
+}
+
 pub struct BaseFeeThreshold;
 impl pallet_base_fee::BaseFeeThreshold for BaseFeeThreshold {
 	fn lower() -> Permill {
@@ -348,6 +352,7 @@ impl pallet_base_fee::BaseFeeThreshold for BaseFeeThreshold {
 impl pallet_base_fee::Config for Runtime {
 	type Event = Event;
 	type Threshold = BaseFeeThreshold;
+	type IsActive = IsActive;
 }
 
 impl pallet_randomness_collective_flip::Config for Runtime {}


### PR DESCRIPTION
Introduces a new associated type to `pallet-base-fee` for allowing to configure the default `IsActive` storage item. Also used `on_runtime_upgrade`.