### PR TITLE
Fix `used_gas` bug

### DIFF
--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -668,7 +668,7 @@ impl<T: Config> Pallet<T> {
 				}),
 				Transaction::EIP1559(_) => Receipt::EIP1559(ethereum::EIP2930ReceiptData {
 					status_code,
-					used_gas: cumulative_gas_used.saturating_add(used_gas),
+					used_gas: cumulative_gas_used,
 					logs_bloom,
 					logs,
 				}),


### PR DESCRIPTION
This was left in https://github.com/paritytech/frontier/pull/541 and was uncovered by tests in Moonbeam. I will try to find some time to port our TS test setup to Frontier, where we run all tests for every supported ethereum transaction type.