### PR TITLE
Implement missed From<UncheckedExtrinsic> for OpaqueExtrinsic

### DIFF
--- a/primitives/self-contained/src/unchecked_extrinsic.rs
+++ b/primitives/self-contained/src/unchecked_extrinsic.rs
@@ -175,9 +175,6 @@ where
 	Extra: SignedExtension,
 {
 	fn from(extrinsic: UncheckedExtrinsic<Address, Call, Signature, Extra>) -> Self {
-		Self::from_bytes(extrinsic.encode().as_slice()).expect(
-			"both OpaqueExtrinsic and UncheckedExtrinsic have encoding that is compatible with \
-				raw Vec<u8> encoding; qed",
-		)
+		extrinsic.0.into()
 	}
 }

--- a/primitives/self-contained/src/unchecked_extrinsic.rs
+++ b/primitives/self-contained/src/unchecked_extrinsic.rs
@@ -11,7 +11,7 @@ use sp_runtime::{
 		SignedExtension,
 	},
 	transaction_validity::{InvalidTransaction, TransactionValidityError},
-	RuntimeDebug,
+	OpaqueExtrinsic, RuntimeDebug,
 };
 
 /// A extrinsic right from the external world. This is unchecked and so
@@ -163,5 +163,21 @@ impl<'a, Address: Decode, Signature: Decode, Call: Decode, Extra: SignedExtensio
 	{
 		<sp_runtime::generic::UncheckedExtrinsic<Address, Call, Signature, Extra>>::deserialize(de)
 			.map(Self)
+	}
+}
+
+impl<Address, Call, Signature, Extra> From<UncheckedExtrinsic<Address, Call, Signature, Extra>>
+	for OpaqueExtrinsic
+where
+	Address: Encode,
+	Signature: Encode,
+	Call: Encode,
+	Extra: SignedExtension,
+{
+	fn from(extrinsic: UncheckedExtrinsic<Address, Call, Signature, Extra>) -> Self {
+		Self::from_bytes(extrinsic.encode().as_slice()).expect(
+			"both OpaqueExtrinsic and UncheckedExtrinsic have encoding that is compatible with \
+				raw Vec<u8> encoding; qed",
+		)
 	}
 }


### PR DESCRIPTION
For some reason `From<UncheckedExtrinsic>` wasn't implemented for `sp_runtime::OpaqueExtrinsic`. But it should be to avoid incorrect usage of `fp_self_contained::UncheckedExtrinsic` in runtime of substrate-based nodes.