### PR TITLE
Move `EthereumStorageSchema` to primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,6 @@ dependencies = [
  "fp-storage",
  "kvdb",
  "kvdb-rocksdb",
- "pallet-ethereum",
  "parity-scale-codec",
  "parking_lot 0.11.1",
  "sp-core",
@@ -1774,6 +1773,9 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
+dependencies = [
+ "parity-scale-codec",
+]
 
 [[package]]
 name = "frame-benchmarking"
@@ -1963,6 +1965,7 @@ dependencies = [
  "fc-rpc-core",
  "fp-consensus",
  "fp-rpc",
+ "fp-storage",
  "frame-benchmarking",
  "frame-benchmarking-cli",
  "frontier-template-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1583,8 +1583,6 @@ dependencies = [
  "libsecp256k1 0.3.5",
  "log",
  "lru",
- "pallet-ethereum",
- "pallet-evm",
  "parity-scale-codec",
  "parking_lot 0.11.1",
  "rand 0.7.3",

--- a/client/db/Cargo.toml
+++ b/client/db/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/paritytech/frontier/"
 sp-core = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }
 sp-database = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }
 sp-runtime = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }
-pallet-ethereum = { version = "4.0.0-dev", path = "../../frame/ethereum" }
 fp-storage = { version = "2.0.0-dev", path = "../../primitives/storage"}
 kvdb = "0.10.0"
 kvdb-rocksdb = "0.14.0"

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -21,8 +21,7 @@ mod utils;
 pub use sp_database::Database;
 
 use codec::{Decode, Encode};
-use fp_storage::PALLET_ETHEREUM_SCHEMA_CACHE;
-use pallet_ethereum::EthereumStorageSchema;
+use fp_storage::{EthereumStorageSchema, PALLET_ETHEREUM_SCHEMA_CACHE};
 use parking_lot::Mutex;
 use sp_core::H256;
 use sp_runtime::traits::Block as BlockT;

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -33,9 +33,7 @@ sc-service = { version = "0.10.0-dev", git = "https://github.com/paritytech/subs
 sc-client-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }
 sc-rpc = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate" }
 sc-network = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate" }
-pallet-evm = { version = "6.0.0-dev", path = "../../frame/evm" }
 fp-evm = { version = "3.0.0-dev", path = "../../primitives/evm" }
-pallet-ethereum = { version = "4.0.0-dev", path = "../../frame/ethereum" }
 ethereum = { version = "0.11.1", features = ["with-codec"] }
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 rlp = "0.5"

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -62,7 +62,7 @@ use tokio::sync::{mpsc, oneshot};
 use crate::overrides::OverrideHandle;
 use codec::{self, Decode, Encode};
 pub use fc_rpc_core::{EthApiServer, EthFilterApiServer, NetApiServer, Web3ApiServer};
-use pallet_ethereum::EthereumStorageSchema;
+use fp_storage::EthereumStorageSchema;
 
 pub struct EthApi<B: BlockT, C, P, CT, BE, H: ExHashT, A: ChainApi> {
 	pool: Arc<P>,

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -32,10 +32,9 @@ pub use overrides::{
 };
 
 use ethereum_types::{H160, H256};
-use evm::ExitError;
+use evm::{ExitError, ExitReason};
 pub use fc_rpc_core::types::TransactionMessage;
 use jsonrpc_core::{Error, ErrorCode, Value};
-use pallet_evm::ExitReason;
 use rustc_hex::ToHex;
 use sha3::{Digest, Keccak256};
 

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -55,7 +55,7 @@ pub mod frontier_backend_client {
 	use jsonrpc_core::Result as RpcResult;
 
 	use ethereum_types::H256;
-	use pallet_ethereum::EthereumStorageSchema;
+	use fp_storage::EthereumStorageSchema;
 
 	pub fn native_block_id<B: BlockT, C>(
 		client: &C,

--- a/client/rpc/src/overrides/mod.rs
+++ b/client/rpc/src/overrides/mod.rs
@@ -18,6 +18,7 @@ use std::collections::BTreeMap;
 use ethereum::BlockV2 as EthereumBlock;
 use ethereum_types::{H160, H256, U256};
 use fp_rpc::{EthereumRuntimeRPCApi, TransactionStatus};
+use fp_storage::EthereumStorageSchema;
 use sp_api::{ApiExt, BlockId, ProvideRuntimeApi};
 use sp_io::hashing::{blake2_128, twox_128};
 use sp_runtime::{traits::Block as BlockT, Permill};
@@ -28,7 +29,6 @@ mod schema_v2_override;
 mod schema_v3_override;
 
 pub use fc_rpc_core::{EthApiServer, NetApiServer};
-use pallet_ethereum::EthereumStorageSchema;
 pub use schema_v1_override::SchemaV1Override;
 pub use schema_v2_override::SchemaV2Override;
 pub use schema_v3_override::SchemaV3Override;

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -28,7 +28,7 @@ use ethereum_types::{Bloom, BloomInput, H160, H256, H64, U256};
 use evm::ExitReason;
 use fp_consensus::{PostLog, PreLog, FRONTIER_ENGINE_ID};
 use fp_evm::CallOrCreateInfo;
-use fp_storage::PALLET_ETHEREUM_SCHEMA;
+use fp_storage::{EthereumStorageSchema, PALLET_ETHEREUM_SCHEMA};
 use frame_support::{
 	dispatch::DispatchResultWithPostInfo,
 	traits::{EnsureOrigin, Get},
@@ -857,21 +857,6 @@ impl<T: Config> Pallet<T> {
 pub enum ReturnValue {
 	Bytes(Vec<u8>),
 	Hash(H160),
-}
-
-/// The schema version for Pallet Ethereum's storage
-#[derive(Clone, Copy, Debug, Encode, Decode, PartialEq, Eq, PartialOrd, Ord)]
-pub enum EthereumStorageSchema {
-	Undefined,
-	V1,
-	V2,
-	V3,
-}
-
-impl Default for EthereumStorageSchema {
-	fn default() -> Self {
-		Self::Undefined
-	}
 }
 
 pub struct IntermediateStateRoot;

--- a/primitives/storage/Cargo.toml
+++ b/primitives/storage/Cargo.toml
@@ -6,6 +6,11 @@ edition = "2018"
 description = "Storage primitives for Ethereum RPC (web3) compatibility layer for Substrate."
 license = "Apache-2.0"
 
+[dependencies]
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
+
 [features]
 default = ["std"]
-std = []
+std = [
+	"codec/std"
+]

--- a/primitives/storage/src/lib.rs
+++ b/primitives/storage/src/lib.rs
@@ -17,7 +17,24 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use codec::{Decode, Encode};
+
 /// Current version of pallet Ethereum's storage schema is stored under this key.
 pub const PALLET_ETHEREUM_SCHEMA: &'static [u8] = b":ethereum_schema";
 /// Cached version of pallet Ethereum's storage schema is stored under this key in the AuxStore.
 pub const PALLET_ETHEREUM_SCHEMA_CACHE: &'static [u8] = b":ethereum_schema_cache";
+
+/// The schema version for Pallet Ethereum's storage
+#[derive(Clone, Copy, Debug, Encode, Decode, PartialEq, Eq, PartialOrd, Ord)]
+pub enum EthereumStorageSchema {
+	Undefined,
+	V1,
+	V2,
+	V3,
+}
+
+impl Default for EthereumStorageSchema {
+	fn default() -> Self {
+		Self::Undefined
+	}
+}

--- a/template/node/Cargo.toml
+++ b/template/node/Cargo.toml
@@ -58,6 +58,7 @@ frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate" }
 
 fc-consensus = { path = "../../client/consensus" }
 fp-consensus = { path = "../../primitives/consensus" }
+fp-storage = { path = "../../primitives/storage" }
 frontier-template-runtime = { path = "../runtime", default-features = false, features = ["std"] }
 fc-rpc = { path = "../../client/rpc" }
 fp-rpc = { path = "../../primitives/rpc" }

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -7,9 +7,9 @@ use fc_rpc::{
 	SchemaV2Override, SchemaV3Override, StorageOverride,
 };
 use fc_rpc_core::types::{FeeHistoryCache, FilterPool};
+use fp_storage::EthereumStorageSchema;
 use frontier_template_runtime::{opaque::Block, AccountId, Balance, Hash, Index};
 use jsonrpc_pubsub::manager::SubscriptionManager;
-use pallet_ethereum::EthereumStorageSchema;
 use sc_client_api::{
 	backend::{AuxStore, Backend, StateBackend, StorageProvider},
 	client::BlockchainEvents,


### PR DESCRIPTION
By moving `EthereumStorageSchema` from the pallet-ethereum to primitives, decouple the pallets from the client db/rpc module.

Oher custom ethereum-pallet can reuse the client part code after this.
