### PR TITLE
EIP-2718 rpc `type` field support

### DIFF
--- a/client/rpc-core/src/types/call_request.rs
+++ b/client/rpc-core/src/types/call_request.rs
@@ -46,4 +46,7 @@ pub struct CallRequest {
 	pub nonce: Option<U256>,
 	/// AccessList
 	pub access_list: Option<Vec<AccessListItem>>,
+	/// EIP-2718 type
+	#[serde(rename = "type")]
+	pub transaction_type: Option<U256>,
 }

--- a/client/rpc-core/src/types/transaction.rs
+++ b/client/rpc-core/src/types/transaction.rs
@@ -73,6 +73,9 @@ pub struct Transaction {
 	/// Pre-pay to warm storage access.
 	#[cfg_attr(feature = "std", serde(skip_serializing_if = "Option::is_none"))]
 	pub access_list: Option<Vec<AccessListItem>>,
+	/// EIP-2718 type
+	#[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+	pub transaction_type: Option<U256>,
 }
 
 impl From<TransactionV2> for Transaction {
@@ -104,6 +107,7 @@ impl From<TransactionV2> for Transaction {
 				r: U256::from(t.signature.r().as_bytes()),
 				s: U256::from(t.signature.s().as_bytes()),
 				access_list: None,
+				transaction_type: Some(U256::from(0)),
 			},
 			TransactionV2::EIP2930(t) => Transaction {
 				hash,
@@ -128,6 +132,7 @@ impl From<TransactionV2> for Transaction {
 				r: U256::from(t.r.as_bytes()),
 				s: U256::from(t.s.as_bytes()),
 				access_list: Some(t.access_list),
+				transaction_type: Some(U256::from(1)),
 			},
 			TransactionV2::EIP1559(t) => Transaction {
 				hash,
@@ -152,6 +157,7 @@ impl From<TransactionV2> for Transaction {
 				r: U256::from(t.r.as_bytes()),
 				s: U256::from(t.s.as_bytes()),
 				access_list: Some(t.access_list),
+				transaction_type: Some(U256::from(2)),
 			},
 		}
 	}

--- a/client/rpc-core/src/types/transaction_request.rs
+++ b/client/rpc-core/src/types/transaction_request.rs
@@ -60,6 +60,9 @@ pub struct TransactionRequest {
 	/// Pre-pay to warm storage access.
 	#[serde(default)]
 	pub access_list: Option<Vec<AccessListItem>>,
+	/// EIP-2718 type
+	#[serde(rename = "type")]
+	pub transaction_type: Option<U256>,
 }
 
 impl Into<Option<TransactionMessage>> for TransactionRequest {

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -223,9 +223,10 @@ fn transaction_build(
 	} else if !is_eip1559 {
 		// This is a pre-eip1559 support transaction a.k.a. txns on frontier before we introduced EIP1559 support in
 		// pallet-ethereum schema V2.
-		// They do not include `maxFeePerGas` or `maxPriorityFeePerGas` fields.
+		// They do not include `maxFeePerGas`, `maxPriorityFeePerGas` or `type` fields.
 		transaction.max_fee_per_gas = None;
 		transaction.max_priority_fee_per_gas = None;
+		transaction.transaction_type = None;
 	}
 
 	let pubkey = match public_key(&ethereum_transaction) {
@@ -1092,6 +1093,7 @@ where
 			data,
 			nonce,
 			access_list,
+			..
 		} = request;
 
 		let (gas_price, max_fee_per_gas, max_priority_fee_per_gas) = {

--- a/ts-tests/tests/test-transaction-version.ts
+++ b/ts-tests/tests/test-transaction-version.ts
@@ -22,7 +22,7 @@ describeWithFrontier("Frontier RPC (Transaction Version)", (context) => {
 	}
 	
 	step("should handle EIP-2930 transaction type 1", async function () {
-		const tx_hash = (await sendTransaction(context, {
+		let tx = {
 			from: GENESIS_ACCOUNT,
 			data: TEST_CONTRACT_BYTECODE,
 			value: "0x00",
@@ -31,8 +31,9 @@ describeWithFrontier("Frontier RPC (Transaction Version)", (context) => {
 			accessList: [],
 			nonce: 0,
 			gasLimit: "0x100000",
-			chainId: 42
-		})).hash;
+			chainId: 42,
+		};
+		const tx_hash = (await sendTransaction(context, tx)).hash;
 		await createAndFinalizeBlock(context.web3);
 		const latest = await context.web3.eth.getBlock("latest");
 		expect(latest.transactions.length).to.be.eq(1);
@@ -43,17 +44,19 @@ describeWithFrontier("Frontier RPC (Transaction Version)", (context) => {
 	});
 	
 	step("should handle EIP-1559 transaction type 2", async function () {
-		const tx_hash = (await sendTransaction(context, {
+		let tx = {
 			from: GENESIS_ACCOUNT,
 			data: TEST_CONTRACT_BYTECODE,
 			value: "0x00",
 			maxFeePerGas: "0x3B9ACA00",
 			maxPriorityFeePerGas: "0x01",
+			type: 2,
 			accessList: [],
 			nonce: 1,
 			gasLimit: "0x100000",
-			chainId: 42
-		})).hash;
+			chainId: 42,
+		};
+		const tx_hash = (await sendTransaction(context, tx)).hash;
 		await createAndFinalizeBlock(context.web3);
 		const latest = await context.web3.eth.getBlock("latest");
 		expect(latest.transactions.length).to.be.eq(1);


### PR DESCRIPTION
Add support for optional `type` in transaction request. See [geth](https://github.com/ethereum/go-ethereum/blob/c503f98f6d5e80e079c1d8a3601d188af2a899da/core/types/transaction_marshalling.go#L30) and this [wishlist](https://gist.github.com/ryanschneider/723d8e2bce0829de9d6beb43639b6d3e).