### PR TITLE
Fresh runtime api instance per call estimation

### DIFF
--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -1701,7 +1701,13 @@ where
 				data,
 				exit_reason,
 				used_gas,
-			} = executable(request.clone(), highest, api_version, client.runtime_api(), estimate_mode)?;
+			} = executable(
+				request.clone(),
+				highest,
+				api_version,
+				client.runtime_api(),
+				estimate_mode,
+			)?;
 			match exit_reason {
 				ExitReason::Succeed(_) => (),
 				ExitReason::Error(ExitError::OutOfGas) => {
@@ -1768,7 +1774,13 @@ where
 						data,
 						exit_reason,
 						used_gas: _,
-					} = executable(request.clone(), mid, api_version, client.runtime_api(), estimate_mode)?;
+					} = executable(
+						request.clone(),
+						mid,
+						api_version,
+						client.runtime_api(),
+						estimate_mode,
+					)?;
 					match exit_reason {
 						ExitReason::Succeed(_) => {
 							highest = mid;

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -1523,11 +1523,10 @@ where
 			// of time, the RPC response time would degrade a lot, as the VersionedRuntime needs to be compiled.
 			//
 			// To solve that, and if we introduce historical gas estimation, we'd need to increase that default.
-			let executable = move |request,
-			                       gas_limit,
-			                       api_version,
-			                       api: sp_api::ApiRef<'_, C::Api>|
-			      -> Result<ExecutableResult> {
+			#[rustfmt::skip]
+			let executable = move |
+				request, gas_limit, api_version, api: sp_api::ApiRef<'_, C::Api>
+			| -> Result<ExecutableResult> {
 				let CallRequest {
 					from,
 					to,


### PR DESCRIPTION
A new `ApiRef` instance needs to be used per execution to avoid the overlayed state to affect the estimation result of subsequent calls.

Note that this would have a performance penalty if we introduce gas estimation for past blocks - and thus, past runtime versions - in the future. Substrate has a `runtime_cache_size` (introduced in https://github.com/paritytech/substrate/pull/10177) which defaults to 2 slots LRU-style, meaning if users were to access multiple runtime versions (more than 2) in a short period of time, the RPC response time would degrade a lot, as the `VersionedRuntime` needs to be compiled to occupy a slot. 

To solve that, and if we introduce historical gas estimation, we'd need to increase value.