### PR TITLE
Fix bug parent hash on `BlockV2` upgrade

### DIFF
--- a/frame/ethereum/Cargo.toml
+++ b/frame/ethereum/Cargo.toml
@@ -65,3 +65,4 @@ std = [
 	"fp-self-contained/std",
 	"scale-info/std",
 ]
+try-runtime = [ "frame-support/try-runtime" ]

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -430,7 +430,11 @@ impl<T: Config> Pallet<T> {
 		let receipts_root =
 			ethereum::util::ordered_trie_root(receipts.iter().map(|r| rlp::encode(r)));
 		let partial_header = ethereum::PartialHeader {
-			parent_hash: Self::current_block_hash().unwrap_or_default(),
+			parent_hash: if block_number > U256::zero() {
+				BlockHash::<T>::get(block_number - 1)
+			} else {
+				H256::default()
+			},
 			beneficiary: pallet_evm::Pallet::<T>::find_author(),
 			state_root: T::StateRoot::get(),
 			receipts_root,

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -29,9 +29,11 @@ use evm::ExitReason;
 use fp_consensus::{PostLog, PreLog, FRONTIER_ENGINE_ID};
 use fp_evm::CallOrCreateInfo;
 use fp_storage::{EthereumStorageSchema, PALLET_ETHEREUM_SCHEMA};
+#[cfg(feature = "try-runtime")]
+use frame_support::traits::OnRuntimeUpgradeHelpersExt;
 use frame_support::{
 	dispatch::DispatchResultWithPostInfo,
-	traits::{EnsureOrigin, Get},
+	traits::{EnsureOrigin, Get, PalletInfoAccess},
 	weights::{Pays, PostDispatchInfo, Weight},
 };
 use frame_system::{pallet_prelude::OriginFor, WeightInfo};
@@ -854,6 +856,69 @@ impl<T: Config> Pallet<T> {
 		} else {
 			Ok(())
 		}
+	}
+
+	pub fn migrate_block_v0_to_v2() -> Weight {
+		let db_weights = T::DbWeight::get();
+		let mut weight: Weight = db_weights.read;
+		let item = b"CurrentBlock";
+		let block_v0 = frame_support::storage::migration::get_storage_value::<ethereum::BlockV0>(
+			Self::name().as_bytes(),
+			item,
+			&[],
+		);
+		if let Some(block_v0) = block_v0 {
+			weight = weight.saturating_add(db_weights.write);
+			let block_v2: ethereum::BlockV2 = block_v0.into();
+			frame_support::storage::migration::put_storage_value::<ethereum::BlockV2>(
+				Self::name().as_bytes(),
+				item,
+				&[],
+				block_v2,
+			);
+		}
+		weight
+	}
+
+	#[cfg(feature = "try-runtime")]
+	pub fn pre_migrate_block_v2() -> Result<(), &'static str> {
+		let item = b"CurrentBlock";
+		let block_v0 = frame_support::storage::migration::get_storage_value::<ethereum::BlockV0>(
+			Self::name().as_bytes(),
+			item,
+			&[],
+		);
+		if let Some(block_v0) = block_v0 {
+			Self::set_temp_storage(block_v0.header.number, "number");
+			Self::set_temp_storage(block_v0.header.parent_hash, "parent_hash");
+			Self::set_temp_storage(block_v0.transactions.len() as u64, "transaction_len");
+		}
+		Ok(())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	pub fn post_migrate_block_v2() -> Result<(), &'static str> {
+		let v0_number =
+			Self::get_temp_storage("number").expect("We stored a number; it should be there; qed");
+		let v0_parent_hash = Self::get_temp_storage("parent_hash")
+			.expect("We stored a parent hash; it should be there; qed");
+		let v0_transaction_len: u64 = Self::get_temp_storage("transaction_len")
+			.expect("We stored a transaction count; it should be there; qed");
+
+		let item = b"CurrentBlock";
+		let block_v2 = frame_support::storage::migration::get_storage_value::<ethereum::BlockV2>(
+			Self::name().as_bytes(),
+			item,
+			&[],
+		);
+
+		assert!(block_v2.is_some());
+
+		let block_v2 = block_v2.unwrap();
+		assert_eq!(block_v2.header.number, v0_number);
+		assert_eq!(block_v2.header.parent_hash, v0_parent_hash);
+		assert_eq!(block_v2.transactions.len() as u64, v0_transaction_len);
+		Ok(())
 	}
 }
 


### PR DESCRIPTION
This bug can be reproduced after storage upgrade from `BlockV0` to `BlockV2`, and only if the preceding block contained transactions. In that case the `current_block_hash` function will try to decode `BlockV2`, failing to do so because the block contains `TransactionV0`s and returning `None`, defaulting to `H256::default()`, rendering the parent hash useless and of course messing the block hashing of the subsequent blocks.

This PR proposes just use the already existing `BlockHash` storage and query it using the previous block number.

This is a pretty nasty bug and should merged in asap @sorpaas . Also, do you have any suggestion on how to test this type of situation in frontier?