### PR TITLE
Fix `rpc-core` compile error

### DIFF
--- a/client/rpc-core/Cargo.toml
+++ b/client/rpc-core/Cargo.toml
@@ -12,7 +12,7 @@ jsonrpc-core-client = "18.0"
 jsonrpc-derive = "18.0"
 jsonrpc-pubsub = "18.0"
 rustc-hex = "2.1.0"
-ethereum = { version = "0.11.1", features = ["with-codec"] }
+ethereum = { version = "0.11.1", features = ["with-codec", "with-serde"] }
 sha3 = "0.8"
 ethereum-types = "0.12"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Compiling `rpc-core` alone will report compile errors, which should be caused by `resolver = "2"`