### PR TITLE
`eth_call` return code instead address

### DIFF
--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -1352,7 +1352,11 @@ where
 					.map_err(|err| internal_err(format!("execution fatal: {:?}", err)))?;
 
 					error_on_execution_failure(&info.exit_reason, &[])?;
-					Ok(Bytes(info.value[..].to_vec()))
+
+					let code = api
+						.account_code_at(&id, info.value)
+						.map_err(|err| internal_err(format!("runtime error: {:?}", err)))?;
+					Ok(Bytes(code))
 				} else if api_version >= 2 && api_version < 4 {
 					// Post-london
 					#[allow(deprecated)]
@@ -1371,7 +1375,11 @@ where
 					.map_err(|err| internal_err(format!("execution fatal: {:?}", err)))?;
 
 					error_on_execution_failure(&info.exit_reason, &[])?;
-					Ok(Bytes(info.value[..].to_vec()))
+
+					let code = api
+						.account_code_at(&id, info.value)
+						.map_err(|err| internal_err(format!("runtime error: {:?}", err)))?;
+					Ok(Bytes(code))
 				} else if api_version == 4 {
 					// Post-london + access list support
 					let access_list = access_list.unwrap_or_default();
@@ -1397,7 +1405,11 @@ where
 						.map_err(|err| internal_err(format!("execution fatal: {:?}", err)))?;
 
 					error_on_execution_failure(&info.exit_reason, &[])?;
-					Ok(Bytes(info.value[..].to_vec()))
+
+					let code = api
+						.account_code_at(&id, info.value)
+						.map_err(|err| internal_err(format!("runtime error: {:?}", err)))?;
+					Ok(Bytes(code))
 				} else {
 					return Err(internal_err(format!(
 						"failed to retrieve Runtime Api version"

--- a/ts-tests/tests/test-contract.ts
+++ b/ts-tests/tests/test-contract.ts
@@ -54,4 +54,10 @@ describeWithFrontier("Frontier RPC (Contract)", (context) => {
 			TEST_CONTRACT_DEPLOYED_BYTECODE,
 		});
 	});
+
+	it("eth_call contract create should return code", async function () {
+		expect(await context.web3.eth.call({
+			data: TEST_CONTRACT_BYTECODE
+		})).to.be.eq(TEST_CONTRACT_DEPLOYED_BYTECODE);
+	});
 });


### PR DESCRIPTION
To match ethereum mainnet and other evm compatible chains behaviout as reported [here](https://github.com/PureStake/moonbeam/issues/1301).