### PR TITLE
Only trace block with digest

### DIFF
--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -228,6 +228,24 @@ impl<Block: BlockT> MappingDb<Block> {
 		}
 	}
 
+	pub fn write_none(&self, block_hash: Block::Hash) -> Result<(), String> {
+		let _lock = self.write_lock.lock();
+
+		let mut transaction = sp_database::Transaction::new();
+
+		transaction.set(
+			crate::columns::SYNCED_MAPPING,
+			&block_hash.encode(),
+			&true.encode(),
+		);
+
+		self.db
+			.commit(transaction)
+			.map_err(|e| format!("{:?}", e))?;
+
+		Ok(())
+	}
+
 	pub fn write_hashes(&self, commitment: MappingCommitment<Block>) -> Result<(), String> {
 		let _lock = self.write_lock.lock();
 

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -228,24 +228,6 @@ impl<Block: BlockT> MappingDb<Block> {
 		}
 	}
 
-	pub fn write_none(&self, block_hash: Block::Hash) -> Result<(), String> {
-		let _lock = self.write_lock.lock();
-
-		let mut transaction = sp_database::Transaction::new();
-
-		transaction.set(
-			crate::columns::SYNCED_MAPPING,
-			&block_hash.encode(),
-			&true.encode(),
-		);
-
-		self.db
-			.commit(transaction)
-			.map_err(|e| format!("{:?}", e))?;
-
-		Ok(())
-	}
-
 	pub fn write_hashes(&self, commitment: MappingCommitment<Block>) -> Result<(), String> {
 		let _lock = self.write_lock.lock();
 

--- a/client/mapping-sync/src/lib.rs
+++ b/client/mapping-sync/src/lib.rs
@@ -147,7 +147,7 @@ where
 
 		frontier_backend
 			.meta()
-			.write_current_syncing_tips(current_syncing_tips.clone())?;
+			.write_current_syncing_tips(current_syncing_tips)?;
 		Ok(true)
 	} else {
 		let mut have_next = true;
@@ -169,7 +169,7 @@ where
 
 		frontier_backend
 			.meta()
-			.write_current_syncing_tips(current_syncing_tips.clone())?;
+			.write_current_syncing_tips(current_syncing_tips)?;
 		Ok(have_next)
 	}
 }
@@ -190,8 +190,14 @@ where
 	let mut synced_any = false;
 
 	for _ in 0..limit {
-		synced_any =
-			synced_any || sync_one_block(client, substrate_backend, frontier_backend, sync_from, strategy)?;
+		synced_any = synced_any
+			|| sync_one_block(
+				client,
+				substrate_backend,
+				frontier_backend,
+				sync_from,
+				strategy,
+			)?;
 	}
 
 	Ok(synced_any)

--- a/client/mapping-sync/src/lib.rs
+++ b/client/mapping-sync/src/lib.rs
@@ -201,7 +201,7 @@ where
 	}
 
 	match substrate_backend.header(BlockId::Hash(checking_tip)) {
-		Ok(Some(checking_header)) if checking_header.number() > &sync_from => {
+		Ok(Some(checking_header)) if checking_header.number() >= &sync_from => {
 			Ok(Some(checking_header))
 		}
 		Ok(Some(_)) => Ok(None),

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -460,6 +460,7 @@ pub fn new_full(mut config: Configuration, cli: &Cli) -> Result<TaskManager, Ser
 			client.clone(),
 			backend.clone(),
 			frontier_backend.clone(),
+			3,
 			SyncStrategy::Normal,
 		)
 		.for_each(|()| futures::future::ready(())),

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -461,6 +461,7 @@ pub fn new_full(mut config: Configuration, cli: &Cli) -> Result<TaskManager, Ser
 			backend.clone(),
 			frontier_backend.clone(),
 			3,
+			0,
 			SyncStrategy::Normal,
 		)
 		.for_each(|()| futures::future::ready(())),


### PR DESCRIPTION
For chains that want to install frontier pallets mid-flight, the mapping-sync-worker helps extract the block and transaction information from the header digest and writes it to rocksDB for all history blocks. When the original chain is high enough(1M above), the problem arises. During this time, the node can easily become stuck due to intensive calculations.

I do some changes in the `sync_blocks` strategy and only track and sync these blocks with frontier digest. Another change is making the `retry_limit` configured. I shorten the default retry times from 8 to 3. Everything works fine in my tests. 