### PR TITLE
Verify the gas limit is within the system configured limits

### DIFF
--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -357,6 +357,9 @@ pub mod pallet {
 		GasPriceTooLow,
 		/// Nonce is invalid
 		InvalidNonce,
+		/// Gas limit above the system configured limits.
+		/// See https://crates.parity.io/frame_system/limits/struct.WeightsPerClass.html
+		GasLimitTooHigh,
 	}
 
 	#[pallet::genesis_config]


### PR DESCRIPTION
In the `pallet-evm` runner, if a [max_extrinsic](https://crates.parity.io/frame_system/limits/struct.WeightsPerClass.html#structfield.max_extrinsic) has been set for the runtime `BlockWeights`, we need to make sure the requested gas limit does not go above the configured value.