### PR TITLE
Eth blocks cache: replace blocks limit by a byte size limit & add prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1582,6 +1582,7 @@ dependencies = [
  "log",
  "lru 0.6.6",
  "parity-scale-codec",
+ "prometheus",
  "rand 0.8.4",
  "rlp",
  "sc-client-api",
@@ -1597,6 +1598,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-storage",
+ "substrate-prometheus-endpoint 0.10.0-dev (git+https://github.com/purestake/substrate?branch=master)",
  "tokio",
 ]
 
@@ -5559,7 +5561,7 @@ dependencies = [
  "sp-core",
  "sp-inherents",
  "sp-runtime",
- "substrate-prometheus-endpoint",
+ "substrate-prometheus-endpoint 0.10.0-dev (git+https://github.com/paritytech/substrate?branch=master)",
 ]
 
 [[package]]
@@ -5669,7 +5671,7 @@ dependencies = [
  "sp-state-machine",
  "sp-storage",
  "sp-trie",
- "substrate-prometheus-endpoint",
+ "substrate-prometheus-endpoint 0.10.0-dev (git+https://github.com/paritytech/substrate?branch=master)",
 ]
 
 [[package]]
@@ -5717,7 +5719,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-state-machine",
- "substrate-prometheus-endpoint",
+ "substrate-prometheus-endpoint 0.10.0-dev (git+https://github.com/paritytech/substrate?branch=master)",
  "thiserror",
 ]
 
@@ -5746,7 +5748,7 @@ dependencies = [
  "sp-inherents",
  "sp-keystore",
  "sp-runtime",
- "substrate-prometheus-endpoint",
+ "substrate-prometheus-endpoint 0.10.0-dev (git+https://github.com/paritytech/substrate?branch=master)",
  "thiserror",
 ]
 
@@ -5789,7 +5791,7 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "sp-version",
- "substrate-prometheus-endpoint",
+ "substrate-prometheus-endpoint 0.10.0-dev (git+https://github.com/paritytech/substrate?branch=master)",
  "thiserror",
 ]
 
@@ -5838,7 +5840,7 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "sp-timestamp",
- "substrate-prometheus-endpoint",
+ "substrate-prometheus-endpoint 0.10.0-dev (git+https://github.com/paritytech/substrate?branch=master)",
  "thiserror",
 ]
 
@@ -5980,7 +5982,7 @@ dependencies = [
  "sp-finality-grandpa",
  "sp-keystore",
  "sp-runtime",
- "substrate-prometheus-endpoint",
+ "substrate-prometheus-endpoint 0.10.0-dev (git+https://github.com/paritytech/substrate?branch=master)",
  "thiserror",
 ]
 
@@ -6059,7 +6061,7 @@ dependencies = [
  "sp-core",
  "sp-finality-grandpa",
  "sp-runtime",
- "substrate-prometheus-endpoint",
+ "substrate-prometheus-endpoint 0.10.0-dev (git+https://github.com/paritytech/substrate?branch=master)",
  "thiserror",
  "unsigned-varint 0.6.0",
  "void",
@@ -6078,7 +6080,7 @@ dependencies = [
  "lru 0.7.2",
  "sc-network",
  "sp-runtime",
- "substrate-prometheus-endpoint",
+ "substrate-prometheus-endpoint 0.10.0-dev (git+https://github.com/paritytech/substrate?branch=master)",
  "tracing",
 ]
 
@@ -6129,7 +6131,7 @@ version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=master#4bc2af13cd81007a2a340d0333062179420d5daf"
 dependencies = [
  "log",
- "substrate-prometheus-endpoint",
+ "substrate-prometheus-endpoint 0.10.0-dev (git+https://github.com/paritytech/substrate?branch=master)",
 ]
 
 [[package]]
@@ -6201,7 +6203,7 @@ dependencies = [
  "jsonrpc-ws-server",
  "log",
  "serde_json",
- "substrate-prometheus-endpoint",
+ "substrate-prometheus-endpoint 0.10.0-dev (git+https://github.com/paritytech/substrate?branch=master)",
  "tokio",
 ]
 
@@ -6261,7 +6263,7 @@ dependencies = [
  "sp-transaction-storage-proof",
  "sp-trie",
  "sp-version",
- "substrate-prometheus-endpoint",
+ "substrate-prometheus-endpoint 0.10.0-dev (git+https://github.com/paritytech/substrate?branch=master)",
  "tempfile",
  "thiserror",
  "tokio",
@@ -6366,7 +6368,7 @@ dependencies = [
  "sp-runtime",
  "sp-tracing",
  "sp-transaction-pool",
- "substrate-prometheus-endpoint",
+ "substrate-prometheus-endpoint 0.10.0-dev (git+https://github.com/paritytech/substrate?branch=master)",
  "thiserror",
 ]
 
@@ -7595,6 +7597,20 @@ dependencies = [
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=master#4bc2af13cd81007a2a340d0333062179420d5daf"
+dependencies = [
+ "async-std",
+ "futures-util",
+ "hyper",
+ "log",
+ "prometheus",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "substrate-prometheus-endpoint"
+version = "0.10.0-dev"
+source = "git+https://github.com/purestake/substrate?branch=master#70925041649ace60f7f8996f3928617bab0bb7d5"
 dependencies = [
  "async-std",
  "futures-util",

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -18,12 +18,14 @@ lru = "0.6.6"
 jsonrpc-core = "18.0"
 jsonrpc-core-client = "18.0"
 jsonrpc-pubsub = "18.0"
+prometheus = { version = "0.13.0", default-features = false }
 rand = "0.8"
 rlp = "0.5"
 tokio = { version = "1.14", features = [ "sync" ] }
 
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 sp-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", branch = "master" }
+prometheus-endpoint = { package = "substrate-prometheus-endpoint",  git = "https://github.com/purestake/substrate", branch = "master" }
 sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-block-builder = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-core = { version = "5.0.0", git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/client/rpc/src/cache.rs
+++ b/client/rpc/src/cache.rs
@@ -1,0 +1,156 @@
+// Copyright 2017-2020 Parity Technologies (UK) Ltd.
+// This file is part of Frontier.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+use codec::Encode;
+use lru::LruCache;
+
+pub struct LRUCacheByteLimited<K, V> {
+	cache: LruCache<K, V>,
+	max_size: u64,
+	metrics: Option<LRUCacheByteLimitedMetrics>,
+	size: u64,
+}
+
+impl<K: Eq + core::hash::Hash, V: Encode> LRUCacheByteLimited<K, V> {
+	pub fn new(
+		cache_name: &'static str,
+		max_size: u64,
+		prometheus_registry: Option<prometheus_endpoint::Registry>,
+	) -> Self {
+		let metrics = match prometheus_registry {
+			Some(registry) => match LRUCacheByteLimitedMetrics::register(cache_name, &registry) {
+				Ok(metrics) => Some(metrics),
+				Err(e) => {
+					log::error!(target: "eth-cache", "Failed to register metrics: {:?}", e);
+					None
+				}
+			},
+			None => None,
+		};
+
+		Self {
+			cache: LruCache::unbounded(),
+			max_size,
+			metrics,
+			size: 0,
+		}
+	}
+	pub fn get(&mut self, k: &K) -> Option<&V> {
+		if let Some(ref v) = self.cache.get(k) {
+			// Update metrics
+			if let Some(ref metrics) = self.metrics {
+				metrics.hits.inc();
+			}
+			Some(v)
+		} else {
+			// Update metrics
+			if let Some(ref metrics) = self.metrics {
+				metrics.miss.inc();
+			}
+			None
+		}
+	}
+	pub fn put(&mut self, k: K, v: V) {
+		// Handle size limit
+		self.size += v.encoded_size() as u64;
+		if self.size > self.max_size {
+			let keys_to_remove = self
+				.cache
+				.iter()
+				.rev()
+				.take_while(|(_k, v)| {
+					if self.size > self.max_size {
+						let v_size = v.encoded_size() as u64;
+						self.size -= v_size;
+						true
+					} else {
+						false
+					}
+				})
+				.map(|(k, _v)| k)
+				.collect::<Vec<_>>();
+			for key in keys_to_remove {
+				self.cache.pop(key);
+			}
+		}
+		// Add entry in cache
+		self.cache.put(k, v);
+		// Update metrics
+		if let Some(ref metrics) = self.metrics {
+			metrics
+				.size
+				.set(self.size.try_into().unwrap_or(std::u64::MAX));
+		}
+	}
+}
+
+struct LRUCacheByteLimitedMetrics {
+	hits: prometheus::IntCounter,
+	miss: prometheus::IntCounter,
+	size: prometheus_endpoint::Gauge<prometheus_endpoint::U64>,
+}
+
+impl LRUCacheByteLimitedMetrics {
+	pub(crate) fn register(
+		cache_name: &'static str,
+		registry: &prometheus_endpoint::Registry,
+	) -> std::result::Result<Self, prometheus_endpoint::PrometheusError> {
+		Ok(Self {
+			hits: prometheus_endpoint::register(
+				prometheus::IntCounter::new(
+					format!("frontier_eth_{}_hits", cache_name),
+					format!("Hits of eth {} cache.", cache_name),
+				)?,
+				registry,
+			)?,
+			miss: prometheus_endpoint::register(
+				prometheus::IntCounter::new(
+					format!("frontier_eth_{}_miss", cache_name),
+					format!("Misses of eth {} cache.", cache_name),
+				)?,
+				registry,
+			)?,
+			size: prometheus_endpoint::register(
+				prometheus_endpoint::Gauge::new(
+					format!("frontier_eth_{}_size", cache_name),
+					format!("Size of eth {} data cache.", cache_name),
+				)?,
+				registry,
+			)?,
+		})
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_size_limit() {
+		let mut cache = LRUCacheByteLimited::new("name", 10, None);
+		cache.put(0, "abcd");
+		assert!(cache.get(&0).is_some());
+		cache.put(1, "efghij");
+		assert!(cache.get(&1).is_some());
+		cache.put(2, "k");
+		assert!(cache.get(&2).is_some());
+		// Entry (0,  "abcd") should be deleted
+		assert!(cache.get(&0).is_none());
+		// Size should be 7 now, so we should be able to add a value of size 3
+		cache.put(3, "lmn");
+		assert!(cache.get(&3).is_some());
+	}
+}

--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -23,12 +23,12 @@ use std::{
 	time,
 };
 
+use crate::cache::LRUCacheByteLimited;
 use ethereum::{BlockV2 as EthereumBlock, TransactionV2 as EthereumTransaction};
 use ethereum_types::{H160, H256, H512, H64, U256, U64};
 use evm::{ExitError, ExitReason};
 use futures::{future::TryFutureExt, StreamExt};
 use jsonrpc_core::{futures::future, BoxFuture, Result};
-use lru::LruCache;
 use tokio::sync::{mpsc, oneshot};
 
 use codec::{Decode, Encode};
@@ -66,6 +66,8 @@ use crate::{
 	public_key, EthSigner, StorageOverride,
 };
 
+type WaitList<Hash, T> = HashMap<Hash, Vec<oneshot::Sender<Option<T>>>>;
+
 pub struct EthApi<B: BlockT, C, P, CT, BE, H: ExHashT, A: ChainApi> {
 	pool: Arc<P>,
 	graph: Arc<Pool<A>>,
@@ -77,7 +79,7 @@ pub struct EthApi<B: BlockT, C, P, CT, BE, H: ExHashT, A: ChainApi> {
 	overrides: Arc<OverrideHandle<B>>,
 	backend: Arc<fc_db::Backend<B>>,
 	max_past_logs: u32,
-	block_data_cache: Arc<EthBlockDataCache<B>>,
+	block_data_cache: Arc<EthBlockDataCacheTask<B>>,
 	fee_history_limit: u64,
 	fee_history_cache: FeeHistoryCache,
 	_marker: PhantomData<(B, BE)>,
@@ -95,7 +97,7 @@ impl<B: BlockT, C, P, CT, BE, H: ExHashT, A: ChainApi> EthApi<B, C, P, CT, BE, H
 		backend: Arc<fc_db::Backend<B>>,
 		is_authority: bool,
 		max_past_logs: u32,
-		block_data_cache: Arc<EthBlockDataCache<B>>,
+		block_data_cache: Arc<EthBlockDataCacheTask<B>>,
 		fee_history_limit: u64,
 		fee_history_cache: FeeHistoryCache,
 	) -> Self {
@@ -311,7 +313,7 @@ where
 async fn filter_range_logs<B: BlockT, C, BE>(
 	client: &C,
 	backend: &fc_db::Backend<B>,
-	block_data_cache: &EthBlockDataCache<B>,
+	block_data_cache: &EthBlockDataCacheTask<B>,
 	ret: &mut Vec<Log>,
 	max_past_logs: u32,
 	filter: &Filter,
@@ -2464,7 +2466,7 @@ pub struct EthFilterApi<B: BlockT, C, BE> {
 	filter_pool: FilterPool,
 	max_stored_filters: usize,
 	max_past_logs: u32,
-	block_data_cache: Arc<EthBlockDataCache<B>>,
+	block_data_cache: Arc<EthBlockDataCacheTask<B>>,
 	_marker: PhantomData<BE>,
 }
 
@@ -2475,7 +2477,7 @@ impl<B: BlockT, C, BE> EthFilterApi<B, C, BE> {
 		filter_pool: FilterPool,
 		max_stored_filters: usize,
 		max_past_logs: u32,
-		block_data_cache: Arc<EthBlockDataCache<B>>,
+		block_data_cache: Arc<EthBlockDataCacheTask<B>>,
 	) -> Self {
 		Self {
 			client,
@@ -3137,24 +3139,31 @@ enum EthBlockDataCacheMessage<B: BlockT> {
 /// These are large and take a lot of time to fetch from the database.
 /// Storing them in an LRU cache will allow to reduce database accesses
 /// when many subsequent requests are related to the same blocks.
-pub struct EthBlockDataCache<B: BlockT>(mpsc::Sender<EthBlockDataCacheMessage<B>>);
+pub struct EthBlockDataCacheTask<B: BlockT>(mpsc::Sender<EthBlockDataCacheMessage<B>>);
 
-impl<B: BlockT> EthBlockDataCache<B> {
+impl<B: BlockT> EthBlockDataCacheTask<B> {
 	pub fn new(
 		spawn_handle: SpawnTaskHandle,
 		overrides: Arc<OverrideHandle<B>>,
-		blocks_cache_size: usize,
-		statuses_cache_size: usize,
+		blocks_cache_max_size: u64,
+		statuses_cache_max_size: u64,
+		prometheus_registry: Option<prometheus_endpoint::Registry>,
 	) -> Self {
 		let (task_tx, mut task_rx) = mpsc::channel(100);
 		let outer_task_tx = task_tx.clone();
 		let outer_spawn_handle = spawn_handle.clone();
 
-		outer_spawn_handle.spawn("EthBlockDataCache", None, async move {
-			let mut blocks_cache = LruCache::<B::Hash, EthereumBlock>::new(blocks_cache_size);
-			let mut statuses_cache =
-				LruCache::<B::Hash, Vec<TransactionStatus>>::new(statuses_cache_size);
-
+		outer_spawn_handle.spawn("EthBlockDataCacheTask", None, async move {
+			let mut blocks_cache = LRUCacheByteLimited::<B::Hash, EthereumBlock>::new(
+				"blocks_cache",
+				blocks_cache_max_size,
+				prometheus_registry.clone(),
+			);
+			let mut statuses_cache = LRUCacheByteLimited::<B::Hash, Vec<TransactionStatus>>::new(
+				"statuses_cache",
+				statuses_cache_max_size,
+				prometheus_registry,
+			);
 			let mut awaiting_blocks =
 				HashMap::<B::Hash, Vec<oneshot::Sender<Option<EthereumBlock>>>>::new();
 			let mut awaiting_statuses =
@@ -3239,8 +3248,8 @@ impl<B: BlockT> EthBlockDataCache<B> {
 
 	fn request_current<T, F>(
 		spawn_handle: &SpawnTaskHandle,
-		cache: &mut LruCache<B::Hash, T>,
-		wait_list: &mut HashMap<B::Hash, Vec<oneshot::Sender<Option<T>>>>,
+		cache: &mut LRUCacheByteLimited<B::Hash, T>,
+		wait_list: &mut WaitList<B::Hash, T>,
 		overrides: Arc<OverrideHandle<B>>,
 		block_hash: B::Hash,
 		schema: EthereumStorageSchema,
@@ -3248,9 +3257,10 @@ impl<B: BlockT> EthBlockDataCache<B> {
 		task_tx: mpsc::Sender<EthBlockDataCacheMessage<B>>,
 		handler_call: F,
 	) where
-		T: Clone,
-		F: FnOnce(&Box<dyn StorageOverride<B> + Send + Sync>) -> EthBlockDataCacheMessage<B>,
-		F: Send + 'static,
+		T: Clone + Encode,
+		F: 'static
+			+ Send
+			+ FnOnce(&Box<dyn StorageOverride<B> + Send + Sync>) -> EthBlockDataCacheMessage<B>,
 	{
 		// Data is cached, we respond immediately.
 		if let Some(data) = cache.get(&block_hash).cloned() {
@@ -3270,7 +3280,7 @@ impl<B: BlockT> EthBlockDataCache<B> {
 		// the data.
 		wait_list.insert(block_hash.clone(), vec![response_tx]);
 
-		spawn_handle.spawn("EthBlockDataCache Worker", None, async move {
+		spawn_handle.spawn("EthBlockDataCacheTask Worker", None, async move {
 			let handler = overrides
 				.schemas
 				.get(&schema)

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -16,6 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+mod cache;
 mod eth;
 mod eth_pubsub;
 mod net;
@@ -23,7 +24,7 @@ mod overrides;
 mod web3;
 
 pub use self::{
-	eth::{EthApi, EthBlockDataCache, EthFilterApi, EthTask},
+	eth::{EthApi, EthBlockDataCacheTask, EthFilterApi, EthTask},
 	eth_pubsub::{EthPubSubApi, HexEncodedIdProvider},
 	net::NetApi,
 	overrides::{
@@ -32,8 +33,8 @@ pub use self::{
 	},
 	web3::Web3Api,
 };
-
 pub use ethereum::TransactionV2 as EthereumTransaction;
+
 use ethereum_types::{H160, H256};
 use evm::{ExitError, ExitReason};
 pub use fc_rpc_core::{

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -3,7 +3,7 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use fc_rpc::{
-	EthBlockDataCache, OverrideHandle, RuntimeApiStorageOverride, SchemaV1Override,
+	EthBlockDataCacheTask, OverrideHandle, RuntimeApiStorageOverride, SchemaV1Override,
 	SchemaV2Override, SchemaV3Override, StorageOverride,
 };
 use fc_rpc_core::types::{FeeHistoryCache, FilterPool};
@@ -57,7 +57,7 @@ pub struct FullDeps<C, P, A: ChainApi> {
 	/// Ethereum data access overrides.
 	pub overrides: Arc<OverrideHandle<Block>>,
 	/// Cache for Ethereum block data.
-	pub block_data_cache: Arc<EthBlockDataCache<Block>>,
+	pub block_data_cache: Arc<EthBlockDataCacheTask<Block>>,
 }
 
 pub fn overrides_handle<C, BE>(client: Arc<C>) -> Arc<OverrideHandle<Block>>

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -395,11 +395,12 @@ pub fn new_full(mut config: Configuration, cli: &Cli) -> Result<TaskManager, Ser
 	let overrides = crate::rpc::overrides_handle(client.clone());
 	let fee_history_limit = cli.run.fee_history_limit;
 
-	let block_data_cache = Arc::new(fc_rpc::EthBlockDataCache::new(
+	let block_data_cache = Arc::new(fc_rpc::EthBlockDataCacheTask::new(
 		task_manager.spawn_handle(),
 		overrides.clone(),
 		50,
 		50,
+		prometheus_registry.clone(),
 	));
 
 	let rpc_extensions_builder = {


### PR DESCRIPTION
The cache size was adjustable per block just because it was the easiest to implement, but this causes serious problems for node maintainers. Some have problems with nodes crashing out of memory, because the size of a block is variable and difficult to predict.
This RP allows to fix the cache size in number of bytes, and also adds prometheus metrics to know how much memory space the cache actually takes and how much it is used (hits/miss ratio).