### PR TITLE
pallet-ethereum: kill `Pending` storage when finalizing block

### DIFF
--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -204,10 +204,10 @@ pub mod pallet {
 					UniqueSaturatedInto::<u32>::unique_saturated_into(to_remove),
 				));
 			}
+			Pending::<T>::kill();
 		}
 
 		fn on_initialize(_: T::BlockNumber) -> Weight {
-			Pending::<T>::kill();
 			let mut weight = T::SystemWeightInfo::kill_storage(1);
 
 			// If the digest contain an existing ethereum block(encoded as PreLog), If contains,


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

The current implementation will store the `Pending` on-chain, but I don't think it's necessary