### PR TITLE
Do not enter `evm` estimate mode when binary search flag is enabled

### DIFF
--- a/client/rpc/src/eth/execute.rs
+++ b/client/rpc/src/eth/execute.rs
@@ -561,6 +561,9 @@ where
 
 			// Verify that the transaction succeed with highest capacity
 			let cap = highest;
+			#[cfg(feature = "rpc_binary_search_estimate")]
+			let estimate_mode = false;
+			#[cfg(not(feature = "rpc_binary_search_estimate"))]
 			let estimate_mode = true;
 			let ExecutableResult {
 				data,

--- a/client/rpc/src/eth/execute.rs
+++ b/client/rpc/src/eth/execute.rs
@@ -561,10 +561,7 @@ where
 
 			// Verify that the transaction succeed with highest capacity
 			let cap = highest;
-			#[cfg(feature = "rpc_binary_search_estimate")]
-			let estimate_mode = false;
-			#[cfg(not(feature = "rpc_binary_search_estimate"))]
-			let estimate_mode = true;
+			let estimate_mode = !cfg!(feature = "rpc_binary_search_estimate");
 			let ExecutableResult {
 				data,
 				exit_reason,


### PR DESCRIPTION
When `rpc_binary_search_estimate` is available we don't care about estimate mode. Just use regular, non-transactional evm calls, including the first call.