### PR TITLE
Pre-validation fixes and dispatch error handling 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,6 +1748,7 @@ name = "fp-evm"
 version = "3.0.0-dev"
 dependencies = [
  "evm",
+ "frame-support",
  "parity-scale-codec",
  "serde",
  "sp-core",

--- a/frame/base-fee/src/lib.rs
+++ b/frame/base-fee/src/lib.rs
@@ -241,8 +241,8 @@ pub mod pallet {
 }
 
 impl<T: Config> fp_evm::FeeCalculator for Pallet<T> {
-	fn min_gas_price() -> U256 {
-		<BaseFeePerGas<T>>::get()
+	fn min_gas_price() -> (U256, Weight) {
+		(<BaseFeePerGas<T>>::get(), T::DbWeight::get().reads(1))
 	}
 }
 

--- a/frame/dynamic-fee/src/lib.rs
+++ b/frame/dynamic-fee/src/lib.rs
@@ -21,7 +21,7 @@
 #[cfg(test)]
 mod tests;
 
-use frame_support::inherent::IsFatalError;
+use frame_support::{inherent::IsFatalError, traits::Get, weights::Weight};
 use sp_core::U256;
 use sp_inherents::{InherentData, InherentIdentifier};
 use sp_std::cmp::{max, min};
@@ -136,7 +136,7 @@ pub mod pallet {
 }
 
 impl<T: Config> fp_evm::FeeCalculator for Pallet<T> {
-	fn min_gas_price() -> U256 {
-		MinGasPrice::<T>::get()
+	fn min_gas_price() -> (U256, Weight) {
+		(MinGasPrice::<T>::get(), T::DbWeight::get().reads(1))
 	}
 }

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -540,6 +540,12 @@ impl<T: Config> Pallet<T> {
 			(None, Some(max_fee_per_gas), None) => max_fee_per_gas,
 			// EIP-1559 transaction with tip.
 			(None, Some(max_fee_per_gas), Some(max_priority_fee_per_gas)) => {
+				if max_priority_fee_per_gas > max_fee_per_gas {
+					return Err(InvalidTransaction::Custom(
+						TransactionValidationError::MaxFeePerGasTooLow as u8,
+					)
+					.into());
+				}
 				priority = max_fee_per_gas
 					.saturating_sub(base_fee)
 					.min(max_priority_fee_per_gas)

--- a/frame/ethereum/src/mock.rs
+++ b/frame/ethereum/src/mock.rs
@@ -21,6 +21,7 @@ use ethereum::{TransactionAction, TransactionSignature};
 use frame_support::{
 	parameter_types,
 	traits::{ConstU32, FindAuthor},
+	weights::Weight,
 	ConsensusEngineId, PalletId,
 };
 use pallet_evm::{AddressMapping, EnsureAddressTruncated, FeeCalculator};
@@ -120,8 +121,8 @@ impl pallet_timestamp::Config for Test {
 
 pub struct FixedGasPrice;
 impl FeeCalculator for FixedGasPrice {
-	fn min_gas_price() -> U256 {
-		1.into()
+	fn min_gas_price() -> (U256, Weight) {
+		(1.into(), 0u64)
 	}
 }
 

--- a/frame/ethereum/src/tests/eip1559.rs
+++ b/frame/ethereum/src/tests/eip1559.rs
@@ -43,7 +43,7 @@ fn transaction_should_increment_nonce() {
 	ext.execute_with(|| {
 		let t = eip1559_erc20_creation_transaction(alice);
 		assert_ok!(Ethereum::execute(alice.address, &t, None,));
-		assert_eq!(EVM::account_basic(&alice.address).nonce, U256::from(1));
+		assert_eq!(EVM::account_basic(&alice.address).0.nonce, U256::from(1));
 	});
 }
 

--- a/frame/ethereum/src/tests/eip2930.rs
+++ b/frame/ethereum/src/tests/eip2930.rs
@@ -42,7 +42,7 @@ fn transaction_should_increment_nonce() {
 	ext.execute_with(|| {
 		let t = eip2930_erc20_creation_transaction(alice);
 		assert_ok!(Ethereum::execute(alice.address, &t, None,));
-		assert_eq!(EVM::account_basic(&alice.address).nonce, U256::from(1));
+		assert_eq!(EVM::account_basic(&alice.address).0.nonce, U256::from(1));
 	});
 }
 

--- a/frame/ethereum/src/tests/legacy.rs
+++ b/frame/ethereum/src/tests/legacy.rs
@@ -42,7 +42,7 @@ fn transaction_should_increment_nonce() {
 	ext.execute_with(|| {
 		let t = legacy_erc20_creation_transaction(alice);
 		assert_ok!(Ethereum::execute(alice.address, &t, None,));
-		assert_eq!(EVM::account_basic(&alice.address).nonce, U256::from(1));
+		assert_eq!(EVM::account_basic(&alice.address).0.nonce, U256::from(1));
 	});
 }
 

--- a/frame/evm/src/mock.rs
+++ b/frame/evm/src/mock.rs
@@ -20,6 +20,7 @@
 use frame_support::{
 	parameter_types,
 	traits::{ConstU32, FindAuthor},
+	weights::Weight,
 	ConsensusEngineId,
 };
 use sp_core::{H160, H256, U256};
@@ -104,11 +105,11 @@ impl pallet_timestamp::Config for Test {
 	type WeightInfo = ();
 }
 
-/// Fixed gas price of `0`.
 pub struct FixedGasPrice;
 impl FeeCalculator for FixedGasPrice {
-	fn min_gas_price() -> U256 {
-		1_000_000_000u128.into()
+	fn min_gas_price() -> (U256, Weight) {
+		// Return some meaningful gas price and weight
+		(1_000_000_000u128.into(), 7u64)
 	}
 }
 

--- a/frame/evm/src/runner/mod.rs
+++ b/frame/evm/src/runner/mod.rs
@@ -22,6 +22,12 @@ use fp_evm::{CallInfo, CreateInfo};
 use sp_core::{H160, H256, U256};
 use sp_std::vec::Vec;
 
+#[derive(Debug)]
+pub struct RunnerError<E: Into<sp_runtime::DispatchError>> {
+	pub error: E,
+	pub weight: frame_support::weights::Weight,
+}
+
 pub trait Runner<T: Config> {
 	type Error: Into<sp_runtime::DispatchError>;
 
@@ -37,7 +43,7 @@ pub trait Runner<T: Config> {
 		access_list: Vec<(H160, Vec<H256>)>,
 		is_transactional: bool,
 		config: &evm::Config,
-	) -> Result<CallInfo, Self::Error>;
+	) -> Result<CallInfo, RunnerError<Self::Error>>;
 
 	fn create(
 		source: H160,
@@ -50,7 +56,7 @@ pub trait Runner<T: Config> {
 		access_list: Vec<(H160, Vec<H256>)>,
 		is_transactional: bool,
 		config: &evm::Config,
-	) -> Result<CreateInfo, Self::Error>;
+	) -> Result<CreateInfo, RunnerError<Self::Error>>;
 
 	fn create2(
 		source: H160,
@@ -64,5 +70,5 @@ pub trait Runner<T: Config> {
 		access_list: Vec<(H160, Vec<H256>)>,
 		is_transactional: bool,
 		config: &evm::Config,
-	) -> Result<CreateInfo, Self::Error>;
+	) -> Result<CreateInfo, RunnerError<Self::Error>>;
 }

--- a/frame/evm/src/tests.rs
+++ b/frame/evm/src/tests.rs
@@ -213,7 +213,7 @@ fn reducible_balance() {
 		let existential = ExistentialDeposit::get();
 
 		// Genesis Balance.
-		let genesis_balance = EVM::account_basic(&evm_addr).balance;
+		let genesis_balance = EVM::account_basic(&evm_addr).0.balance;
 
 		// Lock identifier.
 		let lock_id: LockIdentifier = *b"te/stlok";
@@ -221,7 +221,7 @@ fn reducible_balance() {
 		let to_lock = 1000;
 		Balances::set_lock(lock_id, &account_id, to_lock, WithdrawReasons::RESERVE);
 		// Reducible is, as currently configured in `account_basic`, (balance - lock - existential).
-		let reducible_balance = EVM::account_basic(&evm_addr).balance;
+		let reducible_balance = EVM::account_basic(&evm_addr).0.balance;
 		assert_eq!(reducible_balance, (genesis_balance - to_lock - existential));
 	});
 }
@@ -230,7 +230,7 @@ fn reducible_balance() {
 fn author_should_get_tip() {
 	new_test_ext().execute_with(|| {
 		let author = EVM::find_author();
-		let before_tip = EVM::account_basic(&author).balance;
+		let before_tip = EVM::account_basic(&author).0.balance;
 		let result = EVM::call(
 			Origin::root(),
 			H160::default(),
@@ -244,7 +244,7 @@ fn author_should_get_tip() {
 			Vec::new(),
 		);
 		result.expect("EVM can be called");
-		let after_tip = EVM::account_basic(&author).balance;
+		let after_tip = EVM::account_basic(&author).0.balance;
 		assert_eq!(after_tip, (before_tip + 21000));
 	});
 }
@@ -253,7 +253,7 @@ fn author_should_get_tip() {
 fn author_same_balance_without_tip() {
 	new_test_ext().execute_with(|| {
 		let author = EVM::find_author();
-		let before_tip = EVM::account_basic(&author).balance;
+		let before_tip = EVM::account_basic(&author).0.balance;
 		let _ = EVM::call(
 			Origin::root(),
 			H160::default(),
@@ -266,7 +266,7 @@ fn author_same_balance_without_tip() {
 			None,
 			Vec::new(),
 		);
-		let after_tip = EVM::account_basic(&author).balance;
+		let after_tip = EVM::account_basic(&author).0.balance;
 		assert_eq!(after_tip, before_tip);
 	});
 }
@@ -274,7 +274,7 @@ fn author_same_balance_without_tip() {
 #[test]
 fn refunds_should_work() {
 	new_test_ext().execute_with(|| {
-		let before_call = EVM::account_basic(&H160::default()).balance;
+		let before_call = EVM::account_basic(&H160::default()).0.balance;
 		// Gas price is not part of the actual fee calculations anymore, only the base fee.
 		//
 		// Because we first deduct max_fee_per_gas * gas_limit (2_000_000_000 * 1000000) we need
@@ -291,9 +291,9 @@ fn refunds_should_work() {
 			None,
 			Vec::new(),
 		);
-		let total_cost =
-			(U256::from(21_000) * <Test as Config>::FeeCalculator::min_gas_price()) + U256::from(1);
-		let after_call = EVM::account_basic(&H160::default()).balance;
+		let (base_fee, _) = <Test as Config>::FeeCalculator::min_gas_price();
+		let total_cost = (U256::from(21_000) * base_fee) + U256::from(1);
+		let after_call = EVM::account_basic(&H160::default()).0.balance;
 		assert_eq!(after_call, before_call - total_cost);
 	});
 }
@@ -302,8 +302,8 @@ fn refunds_should_work() {
 fn refunds_and_priority_should_work() {
 	new_test_ext().execute_with(|| {
 		let author = EVM::find_author();
-		let before_tip = EVM::account_basic(&author).balance;
-		let before_call = EVM::account_basic(&H160::default()).balance;
+		let before_tip = EVM::account_basic(&author).0.balance;
+		let before_call = EVM::account_basic(&H160::default()).0.balance;
 		// We deliberately set a base fee + max tip > max fee.
 		// The effective priority tip will be 1GWEI instead 1.5GWEI:
 		// 		(max_fee_per_gas - base_fee).min(max_priority_fee)
@@ -323,14 +323,14 @@ fn refunds_and_priority_should_work() {
 			None,
 			Vec::new(),
 		);
-		let base_fee = <Test as Config>::FeeCalculator::min_gas_price();
+		let (base_fee, _) = <Test as Config>::FeeCalculator::min_gas_price();
 		let actual_tip = (max_fee_per_gas - base_fee).min(tip) * used_gas;
 		let total_cost = (used_gas * base_fee) + U256::from(actual_tip) + U256::from(1);
-		let after_call = EVM::account_basic(&H160::default()).balance;
+		let after_call = EVM::account_basic(&H160::default()).0.balance;
 		// The tip is deducted but never refunded to the caller.
 		assert_eq!(after_call, before_call - total_cost);
 
-		let after_tip = EVM::account_basic(&author).balance;
+		let after_tip = EVM::account_basic(&author).0.balance;
 		assert_eq!(after_tip, (before_tip + actual_tip.low_u128()));
 	});
 }
@@ -353,6 +353,8 @@ fn call_should_fail_with_priority_greater_than_max_fee() {
 			Vec::new(),
 		);
 		assert!(result.is_err());
+		// Some used weight is returned as part of the error.
+		assert_eq!(result.unwrap_err().post_info.actual_weight, Some(7));
 	});
 }
 
@@ -413,7 +415,7 @@ fn runner_non_transactional_calls_with_non_balance_accounts_is_ok_without_gas_pr
 		let non_balance_account =
 			H160::from_str("7700000000000000000000000000000000000001").unwrap();
 		assert_eq!(
-			EVM::account_basic(&non_balance_account).balance,
+			EVM::account_basic(&non_balance_account).0.balance,
 			U256::zero()
 		);
 		let _ = <Test as Config>::Runner::call(
@@ -431,7 +433,7 @@ fn runner_non_transactional_calls_with_non_balance_accounts_is_ok_without_gas_pr
 		)
 		.expect("Non transactional call succeeds");
 		assert_eq!(
-			EVM::account_basic(&non_balance_account).balance,
+			EVM::account_basic(&non_balance_account).0.balance,
 			U256::zero()
 		);
 	});
@@ -446,7 +448,7 @@ fn runner_non_transactional_calls_with_non_balance_accounts_is_err_with_gas_pric
 		let non_balance_account =
 			H160::from_str("7700000000000000000000000000000000000001").unwrap();
 		assert_eq!(
-			EVM::account_basic(&non_balance_account).balance,
+			EVM::account_basic(&non_balance_account).0.balance,
 			U256::zero()
 		);
 		let res = <Test as Config>::Runner::call(

--- a/primitives/evm/Cargo.toml
+++ b/primitives/evm/Cargo.toml
@@ -19,6 +19,7 @@ serde = { version = "1.0.101", features = ["derive"], optional = true }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
 sp-core = { version = "6.0.0", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-std = { version = "4.0.0", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+frame-support = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 
 [features]
 default = ["std"]
@@ -30,4 +31,5 @@ std = [
 	"codec/std",
 	"sp-core/std",
 	"sp-std/std",
+	"frame-support/std",
 ]

--- a/primitives/evm/src/lib.rs
+++ b/primitives/evm/src/lib.rs
@@ -21,6 +21,7 @@ mod precompile;
 
 use codec::{Decode, Encode};
 pub use evm::ExitReason;
+use frame_support::weights::Weight;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 use sp_core::{H160, U256};
@@ -79,11 +80,11 @@ pub struct GenesisAccount {
 /// Trait that outputs the current transaction gas price.
 pub trait FeeCalculator {
 	/// Return the minimal required gas price.
-	fn min_gas_price() -> U256;
+	fn min_gas_price() -> (U256, Weight);
 }
 
 impl FeeCalculator for () {
-	fn min_gas_price() -> U256 {
-		U256::zero()
+	fn min_gas_price() -> (U256, Weight) {
+		(U256::zero(), 0u64)
 	}
 }

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -589,11 +589,13 @@ impl_runtime_apis! {
 		}
 
 		fn account_basic(address: H160) -> EVMAccount {
-			EVM::account_basic(&address)
+			let (account, _) = EVM::account_basic(&address);
+			account
 		}
 
 		fn gas_price() -> U256 {
-			<Runtime as pallet_evm::Config>::FeeCalculator::min_gas_price()
+			let (gas_price, _) = <Runtime as pallet_evm::Config>::FeeCalculator::min_gas_price();
+			gas_price
 		}
 
 		fn account_code_at(address: H160) -> Vec<u8> {
@@ -643,7 +645,7 @@ impl_runtime_apis! {
 				access_list.unwrap_or_default(),
 				is_transactional,
 				config.as_ref().unwrap_or(<Runtime as pallet_evm::Config>::config()),
-			).map_err(|err| err.into())
+			).map_err(|err| err.error.into())
 		}
 
 		fn create(
@@ -677,7 +679,7 @@ impl_runtime_apis! {
 				access_list.unwrap_or_default(),
 				is_transactional,
 				config.as_ref().unwrap_or(<Runtime as pallet_evm::Config>::config()),
-			).map_err(|err| err.into())
+			).map_err(|err| err.error.into())
 		}
 
 		fn current_transaction_statuses() -> Option<Vec<TransactionStatus>> {


### PR DESCRIPTION
Currently in `pallet-ethereum`, we call the `execute` function assuming a fully validated transaction and calling `expect` over the runner's `Result`.

This PR:

- Adds missing `max_fee_per_gas >= max_priority_fee_per_gas` validation condition. Without this, transactions sent through RPC are submitted to the pool and later fail on `apply` (because this check is performed in the runner), causing the **panic** on `pallet-ethereum` `execute` call.
- Handles the eventual error in `pallet-ethereum` instead of panicking. Again, as we expect the transaction to be fully validated, this should never happen. But because `pallet-evm` and `pallet-ethereum` are two different paths that ultimately interface with the evm, redundant validation on both sides is necessary, and if they are not totally aligned will lead to issues like the one we are fixing in this PR.
- Used `Weight` is accounted and charged as part of a extrinsic that fails pre-evm execution. As a result, **failed** calls to `pallet-ethereum` and `pallet-evm` dispatchables will pay fees for the db reads.