### PR TITLE
add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "03:00"
+      timezone: Europe/Berlin
+  - package-ecosystem: npm
+    directory: "/docs"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This PR adds `dependabot` to repository. To automate dependency updates and security vulnerabilities fixes.  
Related issue https://github.com/paritytech/ci_cd/issues/114