### PR TITLE
redirect estimation of batch precompile: force usage of batchAll

### DIFF
--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -13,6 +13,7 @@ ethereum-types = "0.13.1"
 evm = { git = "https://github.com/rust-blockchain/evm", branch = "master" }
 futures = { version = "0.3.1", features = ["compat"] }
 hex = "0.4"
+hex-literal = "0.3.4"
 jsonrpc-core = "18.0"
 jsonrpc-core-client = "18.0"
 jsonrpc-pubsub = "18.0"


### PR DESCRIPTION
For moonbeam, we need to redirect the estimation of calls to batch precompile to force the usage of BatchAll.

Otherwise, the estimation will not be correct because the binary search will optimize the case with the least amount of gas for which the transaction succeeds. And the problem is that with BatchSome* methods, the transaction succeeds even if some subcalls fail.

cc @nanocryk 