### PR TITLE
Replace `seal_fields` with `nonce`

### DIFF
--- a/client/rpc-core/src/types/block.rs
+++ b/client/rpc-core/src/types/block.rs
@@ -19,7 +19,7 @@
 use std::{collections::BTreeMap, ops::Deref};
 
 use crate::types::{Bytes, Transaction};
-use ethereum_types::{Bloom as H2048, H160, H256, U256};
+use ethereum_types::{Bloom as H2048, H160, H256, H64, U256};
 use serde::{ser::Error, Serialize, Serializer};
 
 /// Block Transactions
@@ -98,8 +98,8 @@ pub struct Header {
 	pub timestamp: U256,
 	/// Difficulty
 	pub difficulty: U256,
-	/// Seal fields
-	pub seal_fields: Vec<Bytes>,
+	/// Nonce
+	pub nonce: Option<H64>,
 	/// Size in bytes
 	pub size: Option<U256>,
 }

--- a/client/rpc/src/eth/mod.rs
+++ b/client/rpc/src/eth/mod.rs
@@ -337,10 +337,7 @@ fn rich_block_build(
 				logs_bloom: block.header.logs_bloom,
 				timestamp: U256::from(block.header.timestamp / 1000),
 				difficulty: block.header.difficulty,
-				seal_fields: vec![
-					Bytes(block.header.mix_hash.as_bytes().to_vec()),
-					Bytes(block.header.nonce.as_bytes().to_vec()),
-				],
+				nonce: Some(block.header.nonce),
 				size: Some(U256::from(rlp::encode(&block.header).len() as u32)),
 			},
 			total_difficulty: U256::zero(),

--- a/client/rpc/src/eth_pubsub.rs
+++ b/client/rpc/src/eth_pubsub.rs
@@ -120,10 +120,7 @@ impl SubscriptionResult {
 				logs_bloom: block.header.logs_bloom,
 				timestamp: U256::from(block.header.timestamp),
 				difficulty: block.header.difficulty,
-				seal_fields: vec![
-					Bytes(block.header.mix_hash.as_bytes().to_vec()),
-					Bytes(block.header.nonce.as_bytes().to_vec()),
-				],
+				nonce: Some(block.header.nonce),
 				size: Some(U256::from(rlp::encode(&block.header).len() as u32)),
 			},
 			extra_info: BTreeMap::new(),

--- a/ts-tests/tests/test-block.ts
+++ b/ts-tests/tests/test-block.ts
@@ -33,10 +33,7 @@ describeWithFrontier("Frontier RPC (Block)", (context) => {
 			totalDifficulty: "0",
 		});
 
-		expect((block as any).sealFields).to.eql([
-			"0x0000000000000000000000000000000000000000000000000000000000000000",
-			"0x0000000000000000",
-		]);
+		expect(block.nonce).to.eql("0x0000000000000000");
 		expect(block.hash).to.be.a("string").lengthOf(66);
 		expect(block.parentHash).to.be.a("string").lengthOf(66);
 		expect(block.timestamp).to.be.a("number");
@@ -88,10 +85,7 @@ describeWithFrontier("Frontier RPC (Block)", (context) => {
 			totalDifficulty: "0",
 		});
 
-		expect((block as any).sealFields).to.eql([
-			"0x0000000000000000000000000000000000000000000000000000000000000000",
-			"0x0000000000000000",
-		]);
+		expect(block.nonce).to.eql("0x0000000000000000");
 		expect(block.hash).to.be.a("string").lengthOf(66);
 		expect(block.parentHash).to.be.a("string").lengthOf(66);
 		expect(block.timestamp).to.be.a("number");
@@ -125,10 +119,7 @@ describeWithFrontier("Frontier RPC (Block)", (context) => {
 
 		expect(block.transactions).to.be.a("array").empty;
 		expect(block.uncles).to.be.a("array").empty;
-		expect((block as any).sealFields).to.eql([
-			"0x0000000000000000000000000000000000000000000000000000000000000000",
-			"0x0000000000000000",
-		]);
+		expect(block.nonce).to.eql("0x0000000000000000");
 		expect(block.hash).to.be.a("string").lengthOf(66);
 		expect(block.parentHash).to.be.a("string").lengthOf(66);
 		expect(block.timestamp).to.be.a("number");

--- a/ts-tests/tests/test-subscription.ts
+++ b/ts-tests/tests/test-subscription.ts
@@ -80,10 +80,7 @@ describeWithFrontier("Frontier RPC (Subscription)", (context) => {
 			sha3Uncles: '0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347',
 			transactionsRoot: '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421'
 		});
-		expect((data as any).sealFields).to.eql([
-			"0x0000000000000000000000000000000000000000000000000000000000000000",
-			"0x0000000000000000",
-		]);
+		expect(data.nonce).to.eql("0x0000000000000000");
 
 		done()
 	}).timeout(40000);


### PR DESCRIPTION
Replace parity/open-ethereum's `seal_fields` field by the more adopted `nonce`, which is compatible with libraries (web3js, ethers), thus less prone to break existing Dapps.

We are zero defaulting `mix_hash` and `nonce` anyway.