### PR TITLE
Refactor `Eth` type parameters into a config trait

### DIFF
--- a/client/rpc/src/eth/mining.rs
+++ b/client/rpc/src/eth/mining.rs
@@ -19,15 +19,11 @@
 use ethereum_types::{H256, H64, U256};
 use jsonrpsee::core::RpcResult as Result;
 
-use sc_network::ExHashT;
-use sc_transaction_pool::ChainApi;
-use sp_runtime::traits::Block as BlockT;
-
 use fc_rpc_core::types::*;
 
-use crate::eth::Eth;
+use crate::eth::{Eth, EthConfig};
 
-impl<B: BlockT, C, P, CT, BE, H: ExHashT, A: ChainApi> Eth<B, C, P, CT, BE, H, A> {
+impl<T: EthConfig> Eth<T> {
 	pub fn is_mining(&self) -> Result<bool> {
 		Ok(self.is_authority)
 	}

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -33,7 +33,7 @@ mod signer;
 mod web3;
 
 pub use self::{
-	eth::{Eth, EthBlockDataCacheTask, EthFilter, EthTask},
+	eth::{Eth, EthBlockDataCacheTask, EthConfig, EthFilter, EthTask},
 	eth_pubsub::{EthPubSub, EthereumSubIdProvider},
 	net::Net,
 	overrides::{


### PR DESCRIPTION
Similar to how Substrate pallets use a `Config` trait, I suggest doing the same for `Eth` which currently have 7 type parameters.

This will avoid adding new type parameters everywhere for new futures, such as:

- Having a clean and generic port of our gas estimation patch: https://github.com/PureStake/frontier/pull/70
- Resurecting this PR: https://github.com/paritytech/frontier/pull/510
- Any future feature that would require a new type parameter/associated type.