### PR TITLE
`fp-ethereum` refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1836,6 +1836,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "fp-ethereum"
+version = "1.0.0-dev"
+dependencies = [
+ "ethereum",
+ "ethereum-types",
+ "fp-evm",
+ "frame-support",
+ "parity-scale-codec",
+ "sp-core",
+ "sp-std",
+]
+
+[[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
 dependencies = [
@@ -4410,6 +4423,7 @@ dependencies = [
  "ethereum-types",
  "evm",
  "fp-consensus",
+ "fp-ethereum",
  "fp-evm",
  "fp-rpc",
  "fp-self-contained",

--- a/frame/ethereum/Cargo.toml
+++ b/frame/ethereum/Cargo.toml
@@ -32,6 +32,7 @@ pallet-timestamp = { version = "4.0.0-dev", git = "https://github.com/paritytech
 
 # Frontier
 fp-consensus = { version = "2.0.0-dev", path = "../../primitives/consensus", default-features = false }
+fp-ethereum = { version = "1.0.0-dev", path = "../../primitives/ethereum", default-features = false }
 fp-evm = { version = "3.0.0-dev", path = "../../primitives/evm", default-features = false }
 fp-rpc = { version = "3.0.0-dev", path = "../../primitives/rpc", default-features = false }
 fp-self-contained = { version = "1.0.0-dev", path = "../../primitives/self-contained", default-features = false }
@@ -68,6 +69,7 @@ std = [
 	"pallet-timestamp/std",
 	# Frontier
 	"fp-consensus/std",
+	"fp-ethereum/std",
 	"fp-evm/std",
 	"fp-rpc/std",
 	"fp-self-contained/std",

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -32,9 +32,9 @@ mod tests;
 use ethereum_types::{Bloom, BloomInput, H160, H256, H64, U256};
 use evm::ExitReason;
 use fp_consensus::{PostLog, PreLog, FRONTIER_ENGINE_ID};
+use fp_ethereum::{TransactionData, ValidatedTransaction as ValidatedTransactionT};
 use fp_evm::{
-	CallOrCreateInfo, CheckEvmTransaction, CheckEvmTransactionConfig, CheckEvmTransactionInput,
-	InvalidEvmTransactionError,
+	CallOrCreateInfo, CheckEvmTransaction, CheckEvmTransactionConfig, InvalidEvmTransactionError,
 };
 use fp_storage::{EthereumStorageSchema, PALLET_ETHEREUM_SCHEMA};
 #[cfg(feature = "try-runtime")]
@@ -76,41 +76,6 @@ where
 	match o.into() {
 		Ok(RawOrigin::EthereumTransaction(n)) => Ok(n),
 		_ => Err("bad origin: expected to be an Ethereum transaction"),
-	}
-}
-
-#[derive(Clone, Debug, Encode, Decode, PartialEq, Eq)]
-struct TransactionData {
-	action: TransactionAction,
-	input: Vec<u8>,
-	nonce: U256,
-	gas_limit: U256,
-	gas_price: Option<U256>,
-	max_fee_per_gas: Option<U256>,
-	max_priority_fee_per_gas: Option<U256>,
-	value: U256,
-	chain_id: Option<u64>,
-	access_list: Vec<(H160, Vec<H256>)>,
-}
-
-impl From<TransactionData> for CheckEvmTransactionInput {
-	fn from(t: TransactionData) -> Self {
-		CheckEvmTransactionInput {
-			to: if let TransactionAction::Call(to) = t.action {
-				Some(to)
-			} else {
-				None
-			},
-			chain_id: t.chain_id,
-			input: t.input,
-			nonce: t.nonce,
-			gas_limit: t.gas_limit,
-			gas_price: t.gas_price,
-			max_fee_per_gas: t.max_fee_per_gas,
-			max_priority_fee_per_gas: t.max_priority_fee_per_gas,
-			value: t.value,
-			access_list: t.access_list,
-		}
 	}
 }
 
@@ -285,9 +250,10 @@ pub mod pallet {
 		OriginFor<T>: Into<Result<RawOrigin, OriginFor<T>>>,
 	{
 		/// Transact an Ethereum transaction.
-		#[pallet::weight(<T as pallet_evm::Config>::GasWeightMapping::gas_to_weight(
-			Pallet::<T>::transaction_data(transaction).gas_limit.unique_saturated_into()
-		))]
+		#[pallet::weight(<T as pallet_evm::Config>::GasWeightMapping::gas_to_weight({
+			let transaction_data: TransactionData = transaction.into();
+			transaction_data.gas_limit.unique_saturated_into()
+		}))]
 		pub fn transact(
 			origin: OriginFor<T>,
 			transaction: Transaction,
@@ -356,55 +322,6 @@ pub mod pallet {
 }
 
 impl<T: Config> Pallet<T> {
-	fn transaction_data(transaction: &Transaction) -> TransactionData {
-		match transaction {
-			Transaction::Legacy(t) => TransactionData {
-				action: t.action,
-				input: t.input.clone(),
-				nonce: t.nonce,
-				gas_limit: t.gas_limit,
-				gas_price: Some(t.gas_price),
-				max_fee_per_gas: None,
-				max_priority_fee_per_gas: None,
-				value: t.value,
-				chain_id: t.signature.chain_id(),
-				access_list: Vec::new(),
-			},
-			Transaction::EIP2930(t) => TransactionData {
-				action: t.action,
-				input: t.input.clone(),
-				nonce: t.nonce,
-				gas_limit: t.gas_limit,
-				gas_price: Some(t.gas_price),
-				max_fee_per_gas: None,
-				max_priority_fee_per_gas: None,
-				value: t.value,
-				chain_id: Some(t.chain_id),
-				access_list: t
-					.access_list
-					.iter()
-					.map(|d| (d.address, d.storage_keys.clone()))
-					.collect(),
-			},
-			Transaction::EIP1559(t) => TransactionData {
-				action: t.action,
-				input: t.input.clone(),
-				nonce: t.nonce,
-				gas_limit: t.gas_limit,
-				gas_price: None,
-				max_fee_per_gas: Some(t.max_fee_per_gas),
-				max_priority_fee_per_gas: Some(t.max_priority_fee_per_gas),
-				value: t.value,
-				chain_id: Some(t.chain_id),
-				access_list: t
-					.access_list
-					.iter()
-					.map(|d| (d.address, d.storage_keys.clone()))
-					.collect(),
-			},
-		}
-	}
-
 	fn recover_signer(transaction: &Transaction) -> Option<H160> {
 		let mut sig = [0u8; 65];
 		let mut msg = [0u8; 32];
@@ -512,7 +429,7 @@ impl<T: Config> Pallet<T> {
 		origin: H160,
 		transaction: &Transaction,
 	) -> TransactionValidity {
-		let transaction_data = Pallet::<T>::transaction_data(transaction);
+		let transaction_data: TransactionData = transaction.into();
 		let transaction_nonce = transaction_data.nonce;
 
 		let (base_fee, _) = T::FeeCalculator::min_gas_price();
@@ -836,7 +753,7 @@ impl<T: Config> Pallet<T> {
 		origin: H160,
 		transaction: &Transaction,
 	) -> Result<(), TransactionValidityError> {
-		let transaction_data = Pallet::<T>::transaction_data(transaction);
+		let transaction_data: TransactionData = transaction.into();
 
 		let (base_fee, _) = T::FeeCalculator::min_gas_price();
 		let (who, _) = pallet_evm::Pallet::<T>::account_basic(&origin);
@@ -921,6 +838,13 @@ impl<T: Config> Pallet<T> {
 		assert_eq!(block_v2.header.parent_hash, v0_parent_hash);
 		assert_eq!(block_v2.transactions.len() as u64, v0_transaction_len);
 		Ok(())
+	}
+}
+
+pub struct ValidatedTransaction<T>(PhantomData<T>);
+impl<T: Config> ValidatedTransactionT for ValidatedTransaction<T> {
+	fn apply(source: H160, transaction: Transaction) -> DispatchResultWithPostInfo {
+		Pallet::<T>::apply_validated_transaction(source, transaction)
 	}
 }
 

--- a/primitives/ethereum/Cargo.toml
+++ b/primitives/ethereum/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "fp-ethereum"
+version = "1.0.0-dev"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2021"
+license = "Apache-2.0"
+description = "Primitive Ethereum types."
+repository = "https://github.com/paritytech/frontier/"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+ethereum = { version = "0.12.0", default-features = false, features = ["with-codec"] }
+ethereum-types = { version = "0.13.1", default-features = false }
+fp-evm = { version = "3.0.0-dev", path = "../evm", default-features = false }
+
+# Parity
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
+
+# Substrate
+sp-core = { version = "6.0.0", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-std = { version = "4.0.0", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+# Substrate FRAME
+frame-support = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+	"ethereum/std",
+	"ethereum-types/std",
+	# Parity
+	"codec/std",
+	# Substrate
+	"sp-core/std",
+	"sp-std/std",
+	# Substrate FRAME
+	"frame-support/std",
+]

--- a/primitives/ethereum/src/lib.rs
+++ b/primitives/ethereum/src/lib.rs
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of Frontier.
+//
+// Copyright (c) 2020-2022 Parity Technologies (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use codec::{Decode, Encode};
+pub use ethereum::{
+	AccessListItem, BlockV2 as Block, LegacyTransactionMessage, Log, ReceiptV3 as Receipt,
+	TransactionAction, TransactionV2 as Transaction,
+};
+use ethereum_types::{H160, H256, U256};
+use fp_evm::CheckEvmTransactionInput;
+use sp_std::vec::Vec;
+
+pub trait ValidatedTransaction {
+	fn apply(
+		source: H160,
+		transaction: Transaction,
+	) -> frame_support::dispatch::DispatchResultWithPostInfo;
+}
+
+#[derive(Clone, Debug, Encode, Decode, PartialEq, Eq)]
+pub struct TransactionData {
+	pub action: TransactionAction,
+	pub input: Vec<u8>,
+	pub nonce: U256,
+	pub gas_limit: U256,
+	pub gas_price: Option<U256>,
+	pub max_fee_per_gas: Option<U256>,
+	pub max_priority_fee_per_gas: Option<U256>,
+	pub value: U256,
+	pub chain_id: Option<u64>,
+	pub access_list: Vec<(H160, Vec<H256>)>,
+}
+
+impl From<TransactionData> for CheckEvmTransactionInput {
+	fn from(t: TransactionData) -> Self {
+		CheckEvmTransactionInput {
+			to: if let TransactionAction::Call(to) = t.action {
+				Some(to)
+			} else {
+				None
+			},
+			chain_id: t.chain_id,
+			input: t.input,
+			nonce: t.nonce,
+			gas_limit: t.gas_limit,
+			gas_price: t.gas_price,
+			max_fee_per_gas: t.max_fee_per_gas,
+			max_priority_fee_per_gas: t.max_priority_fee_per_gas,
+			value: t.value,
+			access_list: t.access_list,
+		}
+	}
+}
+
+impl From<&Transaction> for TransactionData {
+	fn from(t: &Transaction) -> Self {
+		match t {
+			Transaction::Legacy(t) => TransactionData {
+				action: t.action,
+				input: t.input.clone(),
+				nonce: t.nonce,
+				gas_limit: t.gas_limit,
+				gas_price: Some(t.gas_price),
+				max_fee_per_gas: None,
+				max_priority_fee_per_gas: None,
+				value: t.value,
+				chain_id: t.signature.chain_id(),
+				access_list: Vec::new(),
+			},
+			Transaction::EIP2930(t) => TransactionData {
+				action: t.action,
+				input: t.input.clone(),
+				nonce: t.nonce,
+				gas_limit: t.gas_limit,
+				gas_price: Some(t.gas_price),
+				max_fee_per_gas: None,
+				max_priority_fee_per_gas: None,
+				value: t.value,
+				chain_id: Some(t.chain_id),
+				access_list: t
+					.access_list
+					.iter()
+					.map(|d| (d.address, d.storage_keys.clone()))
+					.collect(),
+			},
+			Transaction::EIP1559(t) => TransactionData {
+				action: t.action,
+				input: t.input.clone(),
+				nonce: t.nonce,
+				gas_limit: t.gas_limit,
+				gas_price: None,
+				max_fee_per_gas: Some(t.max_fee_per_gas),
+				max_priority_fee_per_gas: Some(t.max_priority_fee_per_gas),
+				value: t.value,
+				chain_id: Some(t.chain_id),
+				access_list: t
+					.access_list
+					.iter()
+					.map(|d| (d.address, d.storage_keys.clone()))
+					.collect(),
+			},
+		}
+	}
+}


### PR DESCRIPTION
- Move `TransactionData` and it's impls to a new `fp-ethereum` so it can be used by external code.
- Implements the new `ValidatedTransaction` trait in `pallet-ethereum` to interface with `apply_validated_transaction`.