### PR TITLE
Validate balance against effective gas price

### DIFF
--- a/primitives/evm/src/validation.rs
+++ b/primitives/evm/src/validation.rs
@@ -103,10 +103,10 @@ impl<'config, E: From<InvalidEvmTransactionError>> CheckEvmTransaction<'config, 
 
 	pub fn with_base_fee(&self) -> Result<&Self, E> {
 		// Get fee data from either a legacy or typed transaction input.
-		let max_fee_per_gas = self.max_fee_per_gas()?;
-		if self.config.is_transactional || max_fee_per_gas > U256::zero() {
+		let (gas_price, _) = self.transaction_fee_input()?;
+		if self.config.is_transactional || gas_price > U256::zero() {
 			// Transaction max fee is at least the current base fee.
-			if max_fee_per_gas < self.config.base_fee {
+			if gas_price < self.config.base_fee {
 				return Err(InvalidEvmTransactionError::GasPriceTooLow.into());
 			}
 		}
@@ -115,12 +115,27 @@ impl<'config, E: From<InvalidEvmTransactionError>> CheckEvmTransaction<'config, 
 
 	pub fn with_balance_for(&self, who: &Account) -> Result<&Self, E> {
 		// Get fee data from either a legacy or typed transaction input.
-		let max_fee_per_gas = self.max_fee_per_gas()?;
+		let (gas_price, effective_gas_price) = self.transaction_fee_input()?;
 
 		// Account has enough funds to pay for the transaction.
 		// Check is skipped on non-transactional calls that don't provide
 		// a gas price input.
-		let fee = max_fee_per_gas.saturating_mul(self.transaction.gas_limit);
+		let fee = if let Some(effective_gas_price) = effective_gas_price {
+			// Fee for EIP-1559 transaction with tip is calculated using
+			// the effective gas price.
+			effective_gas_price.saturating_mul(self.transaction.gas_limit)
+		} else {
+			let base = if self.transaction.max_fee_per_gas.is_some() {
+				// Fee for EIP-1559 transaction without tip is calculated using
+				// the base fee.
+				self.config.base_fee
+			} else {
+				// Fee for Legacy or EIP-2930 transaction is calculated using
+				// the provided `gas_price`.
+				gas_price
+			};
+			base.saturating_mul(self.transaction.gas_limit)
+		};
 		if self.config.is_transactional || fee > U256::zero() {
 			let total_payment = self.transaction.value.saturating_add(fee);
 			if who.balance < total_payment {
@@ -130,29 +145,35 @@ impl<'config, E: From<InvalidEvmTransactionError>> CheckEvmTransaction<'config, 
 		Ok(self)
 	}
 
-	fn max_fee_per_gas(&self) -> Result<U256, E> {
+	fn transaction_fee_input(&self) -> Result<(U256, Option<U256>), E> {
 		match (
 			self.transaction.gas_price,
 			self.transaction.max_fee_per_gas,
 			self.transaction.max_priority_fee_per_gas,
 		) {
 			// Legacy or EIP-2930 transaction.
-			(Some(gas_price), None, None) => Ok(gas_price),
+			(Some(gas_price), None, None) => Ok((gas_price, None)),
 			// EIP-1559 transaction without tip.
-			(None, Some(max_fee_per_gas), None) => Ok(max_fee_per_gas),
+			(None, Some(max_fee_per_gas), None) => Ok((max_fee_per_gas, None)),
 			// EIP-1559 tip.
 			(None, Some(max_fee_per_gas), Some(max_priority_fee_per_gas)) => {
 				if max_priority_fee_per_gas > max_fee_per_gas {
 					return Err(InvalidEvmTransactionError::PriorityFeeTooHigh.into());
 				}
-				Ok(max_fee_per_gas)
+				let effective_gas_price = self
+					.config
+					.base_fee
+					.checked_add(max_priority_fee_per_gas)
+					.unwrap_or_else(U256::max_value)
+					.min(max_fee_per_gas);
+				Ok((max_fee_per_gas, Some(effective_gas_price)))
 			}
 			_ => {
 				if self.config.is_transactional {
 					Err(InvalidEvmTransactionError::InvalidPaymentInput.into())
 				} else {
 					// Allow non-set fee input for non-transactional calls.
-					Ok(U256::zero())
+					Ok((U256::zero(), None))
 				}
 			}
 		}
@@ -352,6 +373,15 @@ mod tests {
 		let mut input = TestCase::default();
 		input.max_priority_fee_per_gas = Some(U256::from(1_100_000_000));
 		input.is_transactional = is_transactional;
+		test_env(input)
+	}
+
+	fn transaction_max_fee_high<'config>(tip: bool) -> CheckEvmTransaction<'config, TestError> {
+		let mut input = TestCase::default();
+		input.max_fee_per_gas = Some(U256::from(5_000_000_000u128));
+		if !tip {
+			input.max_priority_fee_per_gas = None;
+		}
 		test_env(input)
 	}
 
@@ -582,6 +612,32 @@ mod tests {
 			nonce: U256::zero(),
 		};
 		let test = transaction_none_fee(false);
+		let res = test.with_balance_for(&who);
+		assert!(res.is_ok());
+	}
+
+	#[test]
+	// Account balance is matched against the base fee without tip.
+	fn validate_balance_using_base_fee() {
+		let who = Account {
+			balance: U256::from(21_000_000_000_001u128),
+			nonce: U256::zero(),
+		};
+		let with_tip = false;
+		let test = transaction_max_fee_high(with_tip);
+		let res = test.with_balance_for(&who);
+		assert!(res.is_ok());
+	}
+
+	#[test]
+	// Account balance is matched against the effective gas price with tip.
+	fn validate_balance_using_effective_gas_price() {
+		let who = Account {
+			balance: U256::from(42_000_000_000_001u128),
+			nonce: U256::zero(),
+		};
+		let with_tip = true;
+		let test = transaction_max_fee_high(with_tip);
 		let res = test.with_balance_for(&who);
 		assert!(res.is_ok());
 	}


### PR DESCRIPTION
Fixes a minor discrepancy with EIP-1559 specification on how account balance must be validated against transaction input. 

Currently we validate a transaction using the provided `max_fee_per_gas`, which in some cases is requiring the sender to have more free balance than the strictly necessary to submit or apply it. This PR proposes changing that to validate a transaction using:

- The `effective_gas_price`* in case of eip-1559 transactions.
- The provided `gas_price` for legacy and eip2930 transactions.

*`effective_gas_price = MIN( (base_fee + max_priority_fee_per_gas), max_fee_per_gas )`

Additionally I added some more test coverage for legacy input.