### PR TITLE
Remove redundant gas checks in precompiles

### DIFF
--- a/frame/evm/precompile/blake2/src/lib.rs
+++ b/frame/evm/precompile/blake2/src/lib.rs
@@ -54,7 +54,7 @@ impl Precompile for Blake2F {
 
 		let gas_cost: u64 = (rounds as u64) * Blake2F::GAS_COST_PER_ROUND;
 		handle.record_cost(gas_cost)?;
-		
+
 		let input = handle.input();
 
 		// we use from_le_bytes below to effectively swap byte order to LE if architecture is BE

--- a/frame/evm/precompile/blake2/src/lib.rs
+++ b/frame/evm/precompile/blake2/src/lib.rs
@@ -39,7 +39,6 @@ impl Precompile for Blake2F {
 		const BLAKE2_F_ARG_LEN: usize = 213;
 
 		let input = handle.input();
-		let target_gas = handle.gas_limit();
 
 		if input.len() != BLAKE2_F_ARG_LEN {
 			return Err(PrecompileFailure::Error {
@@ -54,15 +53,8 @@ impl Precompile for Blake2F {
 		let rounds: u32 = u32::from_be_bytes(rounds_buf);
 
 		let gas_cost: u64 = (rounds as u64) * Blake2F::GAS_COST_PER_ROUND;
-		if let Some(gas_left) = target_gas {
-			if gas_left < gas_cost {
-				return Err(PrecompileFailure::Error {
-					exit_status: ExitError::OutOfGas,
-				});
-			}
-		}
-
 		handle.record_cost(gas_cost)?;
+		
 		let input = handle.input();
 
 		// we use from_le_bytes below to effectively swap byte order to LE if architecture is BE

--- a/frame/evm/precompile/modexp/src/lib.rs
+++ b/frame/evm/precompile/modexp/src/lib.rs
@@ -161,8 +161,9 @@ impl Precompile for Modexp {
 		}
 
 		// Gas formula allows arbitrary large exp_len when base and modulus are empty, so we need to handle empty base first.
-		let (r, gas_cost) = if base_len == 0 && mod_len == 0 {
-			(BigUint::zero(), MIN_GAS_COST)
+		let r = if base_len == 0 && mod_len == 0 {
+			handle.record_cost(MIN_GAS_COST)?;
+			BigUint::zero()
 		} else {
 			// read the numbers themselves.
 			let base_start = 96; // previous 3 32-byte fields
@@ -174,25 +175,18 @@ impl Precompile for Modexp {
 			// do our gas accounting
 			let gas_cost =
 				calculate_gas_cost(base_len as u64, exp_len as u64, mod_len as u64, &exponent);
-			if let Some(gas_left) = target_gas {
-				if gas_left < gas_cost {
-					return Err(PrecompileFailure::Error {
-						exit_status: ExitError::OutOfGas,
-					});
-				}
-			};
+
+			handle.record_cost(gas_cost)?;
 
 			let mod_start = exp_start + exp_len;
 			let modulus = BigUint::from_bytes_be(&input[mod_start..mod_start + mod_len]);
 
 			if modulus.is_zero() || modulus.is_one() {
-				(BigUint::zero(), gas_cost)
+				BigUint::zero()
 			} else {
-				(base.modpow(&exponent, &modulus), gas_cost)
+				base.modpow(&exponent, &modulus)
 			}
 		};
-
-		handle.record_cost(gas_cost)?;
 
 		// write output to given memory, left padded and same length as the modulus.
 		let bytes = r.to_bytes_be();

--- a/frame/evm/precompile/modexp/src/lib.rs
+++ b/frame/evm/precompile/modexp/src/lib.rs
@@ -111,7 +111,6 @@ fn calculate_gas_cost(
 impl Precompile for Modexp {
 	fn execute(handle: &mut impl PrecompileHandle) -> PrecompileResult {
 		let input = handle.input();
-		let target_gas = handle.gas_limit();
 
 		if input.len() < 96 {
 			return Err(PrecompileFailure::Error {
@@ -177,6 +176,7 @@ impl Precompile for Modexp {
 				calculate_gas_cost(base_len as u64, exp_len as u64, mod_len as u64, &exponent);
 
 			handle.record_cost(gas_cost)?;
+			let input = handle.input();
 
 			let mod_start = exp_start + exp_len;
 			let modulus = BigUint::from_bytes_be(&input[mod_start..mod_start + mod_len]);


### PR DESCRIPTION
Now that we're recording gas using the `PrecompileHandle`, it can be done as soon as the cost is known. Since `record_cost` handles Out of Gas, it is no longer necessary to check it manually.