### PR TITLE
Dispatch precompile: decode call with depth limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4501,7 +4501,17 @@ version = "2.0.0-dev"
 dependencies = [
  "fp-evm",
  "frame-support",
+ "frame-system",
+ "pallet-balances",
  "pallet-evm",
+ "pallet-timestamp",
+ "pallet-utility",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -4684,6 +4694,21 @@ dependencies = [
  "parity-scale-codec",
  "sp-api",
  "sp-runtime",
+]
+
+[[package]]
+name = "pallet-utility"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=master#fe5bf49290d166b9552f65e751d46ec592173ebd"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]

--- a/frame/evm/precompile/dispatch/Cargo.toml
+++ b/frame/evm/precompile/dispatch/Cargo.toml
@@ -25,8 +25,8 @@ sp-runtime = { version = "6.0.0", git = "https://github.com/paritytech/substrate
 sp-std = { version = "4.0.0", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 
 frame-system = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-timestamp = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 pallet-balances = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+pallet-timestamp = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 pallet-utility = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 
 [features]

--- a/frame/evm/precompile/dispatch/Cargo.toml
+++ b/frame/evm/precompile/dispatch/Cargo.toml
@@ -15,6 +15,20 @@ frame-support = { version = "4.0.0-dev", git = "https://github.com/paritytech/su
 fp-evm = { version = "3.0.0-dev", path = "../../../../primitives/evm", default-features = false }
 pallet-evm = { version = "6.0.0-dev", path = "../..", default-features = false }
 
+[dev-dependencies]
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
+
+sp-core = { version = "6.0.0", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-io = { version = "6.0.0", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-runtime = { version = "6.0.0", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-std = { version = "4.0.0", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+
+frame-system = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+pallet-timestamp = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+pallet-balances = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+pallet-utility = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+
 [features]
 default = ["std"]
 std = [

--- a/frame/evm/precompile/dispatch/src/lib.rs
+++ b/frame/evm/precompile/dispatch/src/lib.rs
@@ -25,30 +25,38 @@ use fp_evm::{
 	PrecompileResult,
 };
 use frame_support::{
-	codec::Decode,
+	codec::{Decode, DecodeLimit as _},
 	dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo},
+	traits::{ConstU32, Get},
 	weights::{DispatchClass, Pays},
 };
 use pallet_evm::{AddressMapping, GasWeightMapping};
 
-pub struct Dispatch<T> {
-	_marker: PhantomData<T>,
+// `DecodeLimit` specifies the max depth a call can use when decoding, as unbounded depth
+// can be used to overflow the stack.
+// Default value is 8, which is the same as in XCM call decoding.
+pub struct Dispatch<T, DecodeLimit = ConstU32<8>> {
+	_marker: PhantomData<(T, DecodeLimit)>,
 }
 
-impl<T> Precompile for Dispatch<T>
+impl<T, DecodeLimit> Precompile for Dispatch<T, DecodeLimit>
 where
 	T: pallet_evm::Config,
 	T::Call: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo + Decode,
 	<T::Call as Dispatchable>::Origin: From<Option<T::AccountId>>,
+	DecodeLimit: Get<u32>,
 {
 	fn execute(handle: &mut impl PrecompileHandle) -> PrecompileResult {
 		let input = handle.input();
 		let target_gas = handle.gas_limit();
 		let context = handle.context();
 
-		let call = T::Call::decode(&mut &*input).map_err(|_| PrecompileFailure::Error {
-			exit_status: ExitError::Other("decode failed".into()),
-		})?;
+		let call =
+			T::Call::decode_with_depth_limit(DecodeLimit::get(), &mut &*input).map_err(|_| {
+				PrecompileFailure::Error {
+					exit_status: ExitError::Other("decode failed".into()),
+				}
+			})?;
 		let info = call.get_dispatch_info();
 
 		let valid_call = info.pays_fee == Pays::Yes && info.class == DispatchClass::Normal;

--- a/frame/evm/precompile/dispatch/src/lib.rs
+++ b/frame/evm/precompile/dispatch/src/lib.rs
@@ -19,6 +19,12 @@
 
 extern crate alloc;
 
+#[cfg(test)]
+mod mock;
+
+#[cfg(test)]
+mod tests;
+
 use core::marker::PhantomData;
 use fp_evm::{
 	ExitError, ExitSucceed, Precompile, PrecompileFailure, PrecompileHandle, PrecompileOutput,

--- a/frame/evm/precompile/dispatch/src/mock.rs
+++ b/frame/evm/precompile/dispatch/src/mock.rs
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of Frontier.
+//
+// Copyright (c) 2020-2022 Parity Technologies (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Test mock for unit tests and benchmarking
+
+use frame_support::{
+	parameter_types,
+	traits::{ConstU32, FindAuthor},
+	weights::Weight,
+	ConsensusEngineId,
+};
+use sp_core::{H160, H256, U256};
+use sp_runtime::{
+	generic,
+	traits::{BlakeTwo256, IdentityLookup},
+};
+use sp_std::{boxed::Box, prelude::*, str::FromStr};
+
+use fp_evm::{ExitError, ExitReason, Transfer};
+use pallet_evm::{
+	Context, EnsureAddressNever, EnsureAddressRoot, FeeCalculator, IdentityAddressMapping,
+	PrecompileHandle,
+};
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
+
+frame_support::construct_runtime! {
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+		Timestamp: pallet_timestamp::{Pallet, Call, Storage},
+		EVM: pallet_evm::{Pallet, Call, Storage, Config, Event<T>},
+		Utility: pallet_utility::{Pallet, Call, Event},
+	}
+}
+
+parameter_types! {
+	pub const BlockHashCount: u64 = 250;
+	pub BlockWeights: frame_system::limits::BlockWeights =
+		frame_system::limits::BlockWeights::simple_max(1024);
+}
+impl frame_system::Config for Test {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type Origin = Origin;
+	type Index = u64;
+	type BlockNumber = u64;
+	type Hash = H256;
+	type Call = Call;
+	type Hashing = BlakeTwo256;
+	type AccountId = H160;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = generic::Header<u64, BlakeTwo256>;
+	type Event = Event;
+	type BlockHashCount = BlockHashCount;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = pallet_balances::AccountData<u64>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = ();
+	type MaxConsumers = ConstU32<16>;
+}
+
+impl pallet_utility::Config for Test {
+	type Event = Event;
+	type Call = Call;
+	type PalletsOrigin = OriginCaller;
+	type WeightInfo = pallet_utility::weights::SubstrateWeight<Test>;
+}
+
+parameter_types! {
+	pub const ExistentialDeposit: u64 = 0;
+}
+impl pallet_balances::Config for Test {
+	type MaxLocks = ();
+	type Balance = u64;
+	type DustRemoval = ();
+	type Event = Event;
+	type ExistentialDeposit = ExistentialDeposit;
+	type AccountStore = System;
+	type WeightInfo = ();
+	type MaxReserves = ();
+	type ReserveIdentifier = ();
+}
+
+parameter_types! {
+	pub const MinimumPeriod: u64 = 1000;
+}
+impl pallet_timestamp::Config for Test {
+	type Moment = u64;
+	type OnTimestampSet = ();
+	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
+}
+
+pub struct FixedGasPrice;
+impl FeeCalculator for FixedGasPrice {
+	fn min_gas_price() -> (U256, Weight) {
+		// Return some meaningful gas price and weight
+		(1_000_000_000u128.into(), 7u64)
+	}
+}
+
+pub struct FindAuthorTruncated;
+impl FindAuthor<H160> for FindAuthorTruncated {
+	fn find_author<'a, I>(_digests: I) -> Option<H160>
+	where
+		I: 'a + IntoIterator<Item = (ConsensusEngineId, &'a [u8])>,
+	{
+		Some(H160::from_str("1234500000000000000000000000000000000000").unwrap())
+	}
+}
+parameter_types! {
+	pub BlockGasLimit: U256 = U256::max_value();
+}
+impl pallet_evm::Config for Test {
+	type FeeCalculator = FixedGasPrice;
+	type GasWeightMapping = ();
+
+	type CallOrigin = EnsureAddressRoot<Self::AccountId>;
+	type WithdrawOrigin = EnsureAddressNever<Self::AccountId>;
+
+	type AddressMapping = IdentityAddressMapping;
+	type Currency = Balances;
+	type Runner = pallet_evm::runner::stack::Runner<Self>;
+
+	type Event = Event;
+	type PrecompilesType = ();
+	type PrecompilesValue = ();
+	type ChainId = ();
+	type BlockGasLimit = BlockGasLimit;
+	type OnChargeTransaction = ();
+	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
+	type FindAuthor = FindAuthorTruncated;
+}
+
+pub(crate) struct MockHandle {
+	pub input: Vec<u8>,
+	pub context: Context,
+}
+
+impl PrecompileHandle for MockHandle {
+	/// Perform subcall in provided context.
+	/// Precompile specifies in which context the subcall is executed.
+	fn call(
+		&mut self,
+		_: H160,
+		_: Option<Transfer>,
+		_: Vec<u8>,
+		_: Option<u64>,
+		_: bool,
+		_: &Context,
+	) -> (ExitReason, Vec<u8>) {
+		unimplemented!()
+	}
+
+	fn record_cost(&mut self, _: u64) -> Result<(), ExitError> {
+		Ok(())
+	}
+
+	fn remaining_gas(&self) -> u64 {
+		unimplemented!()
+	}
+
+	fn log(&mut self, _: H160, _: Vec<H256>, _: Vec<u8>) -> Result<(), ExitError> {
+		unimplemented!()
+	}
+
+	/// Retreive the code address (what is the address of the precompile being called).
+	fn code_address(&self) -> H160 {
+		unimplemented!()
+	}
+
+	/// Retreive the input data the precompile is called with.
+	fn input(&self) -> &[u8] {
+		&self.input
+	}
+
+	/// Retreive the context in which the precompile is executed.
+	fn context(&self) -> &Context {
+		&self.context
+	}
+
+	/// Is the precompile call is done statically.
+	fn is_static(&self) -> bool {
+		unimplemented!()
+	}
+
+	/// Retreive the gas limit of this call.
+	fn gas_limit(&self) -> Option<u64> {
+		None
+	}
+}

--- a/frame/evm/precompile/dispatch/src/tests.rs
+++ b/frame/evm/precompile/dispatch/src/tests.rs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of Frontier.
+//
+// Copyright (c) 2020-2022 Parity Technologies (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(test)]
+
+use super::*;
+use crate::mock::*;
+
+use codec::Encode;
+use fp_evm::{Context, GenesisAccount};
+use frame_support::{assert_ok, traits::GenesisBuild};
+use sp_core::{H160, U256};
+use std::{collections::BTreeMap, str::FromStr};
+
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	let mut t = frame_system::GenesisConfig::default()
+		.build_storage::<Test>()
+		.unwrap();
+
+	let mut accounts = BTreeMap::new();
+	accounts.insert(
+		H160::from_str("1000000000000000000000000000000000000001").unwrap(),
+		GenesisAccount {
+			nonce: U256::from(1),
+			balance: U256::from(1000000),
+			storage: Default::default(),
+			code: vec![
+				0x00, // STOP
+			],
+		},
+	);
+	accounts.insert(
+		H160::from_str("1000000000000000000000000000000000000002").unwrap(),
+		GenesisAccount {
+			nonce: U256::from(1),
+			balance: U256::from(1000000),
+			storage: Default::default(),
+			code: vec![
+				0xff, // INVALID
+			],
+		},
+	);
+	accounts.insert(
+		H160::default(), // root
+		GenesisAccount {
+			nonce: U256::from(1),
+			balance: U256::max_value(),
+			storage: Default::default(),
+			code: vec![],
+		},
+	);
+
+	pallet_balances::GenesisConfig::<Test> {
+		// Create the block author account with some balance.
+		balances: vec![(
+			H160::from_str("0x1234500000000000000000000000000000000000").unwrap(),
+			12345,
+		)],
+	}
+	.assimilate_storage(&mut t)
+	.expect("Pallet balances storage can be assimilated");
+	GenesisBuild::<Test>::assimilate_storage(&pallet_evm::GenesisConfig { accounts }, &mut t)
+		.unwrap();
+	t.into()
+}
+
+#[test]
+fn decode_limit_too_high() {
+	new_test_ext().execute_with(|| {
+		let mut nested_call = Call::System(frame_system::Call::remark { remark: Vec::new() });
+
+		// More than 8 depth
+		for _ in 0..9 {
+			nested_call = Call::Utility(pallet_utility::Call::as_derivative {
+				index: 0,
+				call: Box::new(nested_call),
+			});
+		}
+
+		let mut handle = MockHandle {
+			input: nested_call.encode(),
+			context: Context {
+				address: H160::default(),
+				caller: H160::default(),
+				apparent_value: U256::default(),
+			},
+		};
+
+		assert_eq!(
+			Dispatch::<Test>::execute(&mut handle),
+			Err(PrecompileFailure::Error {
+				exit_status: ExitError::Other("decode failed".into())
+			})
+		);
+	});
+}
+
+#[test]
+fn decode_limit_ok() {
+	new_test_ext().execute_with(|| {
+		let mut nested_call = Call::System(frame_system::Call::remark { remark: Vec::new() });
+
+		for _ in 0..8 {
+			nested_call = Call::Utility(pallet_utility::Call::as_derivative {
+				index: 0,
+				call: Box::new(nested_call),
+			});
+		}
+
+		let mut handle = MockHandle {
+			input: nested_call.encode(),
+			context: Context {
+				address: H160::default(),
+				caller: H160::default(),
+				apparent_value: U256::default(),
+			},
+		};
+
+		assert_ok!(Dispatch::<Test>::execute(&mut handle));
+	});
+}


### PR DESCRIPTION
Add a type parameter to configure a depth limit when decoding the call data.
Otherwise it is possible to craft a arbitrarily deep nested call that can overflow the stack.