### PR TITLE
fix(frame): CheckWeight controls should be applied on pre_dispatch

### DIFF
--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -160,8 +160,14 @@ where
 	pub fn pre_dispatch_self_contained(
 		&self,
 		origin: &H160,
+		dispatch_info: &DispatchInfoOf<T::Call>,
+		len: usize,
 	) -> Option<Result<(), TransactionValidityError>> {
 		if let Call::transact { transaction } = self {
+			if let Err(e) = CheckWeight::<T>::do_pre_dispatch(dispatch_info, len) {
+				return Some(Err(e));
+			}
+
 			Some(Pallet::<T>::validate_transaction_in_block(
 				*origin,
 				transaction,

--- a/frame/ethereum/src/mock.rs
+++ b/frame/ethereum/src/mock.rs
@@ -207,9 +207,11 @@ impl fp_self_contained::SelfContainedCall for Call {
 	fn pre_dispatch_self_contained(
 		&self,
 		info: &Self::SignedInfo,
+		dispatch_info: &DispatchInfoOf<Call>,
+		len: usize,
 	) -> Option<Result<(), TransactionValidityError>> {
 		match self {
-			Call::Ethereum(call) => call.pre_dispatch_self_contained(info),
+			Call::Ethereum(call) => call.pre_dispatch_self_contained(info, dispatch_info, len),
 			_ => None,
 		}
 	}

--- a/primitives/self-contained/src/checked_extrinsic.rs
+++ b/primitives/self-contained/src/checked_extrinsic.rs
@@ -140,7 +140,7 @@ where
 			CheckedSignature::SelfContained(signed_info) => {
 				// If pre-dispatch fail, the block must be considered invalid
 				self.function
-					.pre_dispatch_self_contained(&signed_info)
+					.pre_dispatch_self_contained(&signed_info, info, len)
 					.ok_or(TransactionValidityError::Invalid(
 						InvalidTransaction::BadProof,
 					))??;

--- a/primitives/self-contained/src/lib.rs
+++ b/primitives/self-contained/src/lib.rs
@@ -62,7 +62,12 @@ pub trait SelfContainedCall: Dispatchable {
 	fn pre_dispatch_self_contained(
 		&self,
 		info: &Self::SignedInfo,
-	) -> Option<Result<(), TransactionValidityError>>;
+		dispatch_info: &DispatchInfoOf<Self>,
+		len: usize,
+	) -> Option<Result<(), TransactionValidityError>> {
+		self.validate_self_contained(info, dispatch_info, len)
+			.map(|res| res.map(|_| ()))
+	}
 	/// Apply a self-contained function. Returns `None` if the
 	/// function is not a self-contained.
 	fn apply_self_contained(

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -502,9 +502,11 @@ impl fp_self_contained::SelfContainedCall for Call {
 	fn pre_dispatch_self_contained(
 		&self,
 		info: &Self::SignedInfo,
+		dispatch_info: &DispatchInfoOf<Call>,
+		len: usize,
 	) -> Option<Result<(), TransactionValidityError>> {
 		match self {
-			Call::Ethereum(call) => call.pre_dispatch_self_contained(info),
+			Call::Ethereum(call) => call.pre_dispatch_self_contained(info, dispatch_info, len),
 			_ => None,
 		}
 	}


### PR DESCRIPTION
We realized at moonbeam that the dispatch class limits did not apply to ethereum transactions.

As a result, ethereum transactions can fill the entire 'n block by weight, without respecting the `NORMAL_DISPATCH_RATIO`.

This bug is due to the fact that the application of limits by dispatch class is done only in `CheckWeight::pre_dispatch`, and the actual frontier code does not use CheckWeight in `pre_dispatch_self_contained`.

This PR fix that.