### PR TITLE
add a `from_account_id` api for `AddressMapping`

### DIFF
--- a/frame/ethereum/src/mock.rs
+++ b/frame/ethereum/src/mock.rs
@@ -26,7 +26,7 @@ use frame_support::{
 };
 use pallet_evm::{AddressMapping, EnsureAddressTruncated, FeeCalculator};
 use rlp::RlpStream;
-use sp_core::{hashing::keccak_256, H160, H256, U256, crypto::ByteArray};
+use sp_core::{crypto::ByteArray, hashing::keccak_256, H160, H256, U256};
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},

--- a/frame/ethereum/src/mock.rs
+++ b/frame/ethereum/src/mock.rs
@@ -26,7 +26,7 @@ use frame_support::{
 };
 use pallet_evm::{AddressMapping, EnsureAddressTruncated, FeeCalculator};
 use rlp::RlpStream;
-use sp_core::{hashing::keccak_256, H160, H256, U256};
+use sp_core::{hashing::keccak_256, H160, H256, U256, crypto::ByteArray};
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
@@ -149,6 +149,10 @@ impl AddressMapping<AccountId32> for HashedAddressMapping {
 		let mut data = [0u8; 32];
 		data[0..20].copy_from_slice(&address[..]);
 		AccountId32::from(Into::<[u8; 32]>::into(data))
+	}
+
+	fn from_account_id(account_id: AccountId32) -> H160 {
+		H160::from_slice(&account_id.as_slice()[0..20])
 	}
 }
 

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -568,6 +568,7 @@ where
 
 pub trait AddressMapping<A> {
 	fn into_account_id(address: H160) -> A;
+	fn from_account_id(account_id: A) -> H160;
 }
 
 /// Identity address mapping.
@@ -576,6 +577,10 @@ pub struct IdentityAddressMapping;
 impl AddressMapping<H160> for IdentityAddressMapping {
 	fn into_account_id(address: H160) -> H160 {
 		address
+	}
+
+	fn from_account_id(account_id: H160) -> H160 {
+		account_id
 	}
 }
 
@@ -590,6 +595,11 @@ impl<H: Hasher<Out = H256>> AddressMapping<AccountId32> for HashedAddressMapping
 		let hash = H::hash(&data);
 
 		AccountId32::from(Into::<[u8; 32]>::into(hash))
+	}
+
+	/// an hashed evm address can't be decoded as AccountId32
+	fn from_account_id(_account_id: AccountId32) -> H160 {
+		H160::zero()
 	}
 }
 

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -10,7 +10,7 @@
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 use codec::{Decode, Encode};
-use pallet_evm::{FeeCalculator, AddressMapping};
+use pallet_evm::{AddressMapping, FeeCalculator};
 use pallet_grandpa::{
 	fg_primitives, AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList,
 };
@@ -297,7 +297,9 @@ impl pallet_sudo::Config for Runtime {
 }
 
 pub struct FindAuthorTruncated<F, M>(PhantomData<(F, M)>);
-impl<F: FindAuthor<u32>, M: AddressMapping<AccountId>> FindAuthor<H160> for FindAuthorTruncated<F, M> {
+impl<F: FindAuthor<u32>, M: AddressMapping<AccountId>> FindAuthor<H160>
+	for FindAuthorTruncated<F, M>
+{
 	fn find_author<'a, I>(digests: I) -> Option<H160>
 	where
 		I: 'a + IntoIterator<Item = (ConsensusEngineId, &'a [u8])>,


### PR DESCRIPTION
To give the priority fee to the correct evm address, we need to convert an substrate address into evm address. Since we can customize `AddressMapping`, I think it's good to also define the reverse function of `into_account_id`.