### PR TITLE
Fix benchmarking build + add to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,8 @@ jobs:
         override: true
     - name: Run tests
       run: cargo test --locked --verbose --all
+    - name: Ensure benchmarking compiles
+      run: cargo check --release --features=runtime-benchmarks
 
   integration:
     name: 'Run integration tests'

--- a/frame/evm/src/benchmarking.rs
+++ b/frame/evm/src/benchmarking.rs
@@ -76,6 +76,7 @@ benchmarks! {
 		let value = U256::default();
 		let gas_limit_create: u64 = 1_250_000 * 1_000_000_000;
 		let is_transactional = true;
+		let validate = true;
 		let create_runner_results = T::Runner::create(
 			caller,
 			contract_bytecode,
@@ -86,6 +87,7 @@ benchmarks! {
 			Some(nonce_as_u256),
 			Vec::new(),
 			is_transactional,
+			validate,
 			T::config(),
 		);
 		assert_eq!(create_runner_results.is_ok(), true, "create() failed");
@@ -108,6 +110,7 @@ benchmarks! {
 		let nonce_as_u256: U256 = nonce.into();
 
 		let is_transactional = true;
+		let validate = true;
 		let call_runner_results = T::Runner::call(
 			caller,
 			contract_address,
@@ -119,6 +122,7 @@ benchmarks! {
 			Some(nonce_as_u256),
 			Vec::new(),
 			is_transactional,
+			validate,
 			T::config(),
 		);
 		assert_eq!(call_runner_results.is_ok(), true, "call() failed");


### PR DESCRIPTION
Recent additions broke the benchmarking build. Fix that + add the `cargo check --release --features=runtime-benchmarks` to the `build` CI job.