### PR TITLE
Add executed data to `Executed` event

### DIFF
--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -278,8 +278,8 @@ pub mod pallet {
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event {
-		/// An ethereum transaction was successfully executed. [from, to/contract_address, transaction_hash, exit_reason]
-		Executed(H160, H160, H256, ExitReason),
+		/// An ethereum transaction was successfully executed. [from, executed_data, transaction_hash, exit_reason]
+		Executed(H160, Vec<u8>, H256, ExitReason),
 	}
 
 	#[pallet::error]
@@ -510,7 +510,7 @@ impl<T: Config> Pallet<T> {
 		let transaction_hash = transaction.hash();
 		let transaction_index = pending.len() as u32;
 
-		let (reason, status, used_gas, dest) = match info {
+		let (reason, status, used_gas, data) = match info {
 			CallOrCreateInfo::Call(info) => (
 				info.exit_reason,
 				TransactionStatus {
@@ -527,7 +527,7 @@ impl<T: Config> Pallet<T> {
 					},
 				},
 				info.used_gas,
-				to,
+				info.value,
 			),
 			CallOrCreateInfo::Create(info) => (
 				info.exit_reason,
@@ -545,7 +545,7 @@ impl<T: Config> Pallet<T> {
 					},
 				},
 				info.used_gas,
-				Some(info.value),
+				info.value.as_bytes().to_vec(),
 			),
 		};
 
@@ -589,12 +589,7 @@ impl<T: Config> Pallet<T> {
 
 		Pending::<T>::append((transaction, status, receipt));
 
-		Self::deposit_event(Event::Executed(
-			source,
-			dest.unwrap_or_default(),
-			transaction_hash,
-			reason,
-		));
+		Self::deposit_event(Event::Executed(source, data, transaction_hash, reason));
 
 		Ok(PostDispatchInfo {
 			actual_weight: Some(T::GasWeightMapping::gas_to_weight(


### PR DESCRIPTION
The application side wants to see more detailed revert info when tx fails like the following :

1. https://moonbase.subscan.io/extrinsic/2394019-336?event=2394019-2115
2. https://pangolin.subscan.io/extrinsic/3026367-1?event=3026367-4

![image](https://user-images.githubusercontent.com/11801722/176679427-7b412e5d-69a3-45b4-8eb4-4f9dba8bcfc4.png)
![image](https://user-images.githubusercontent.com/11801722/176679464-e8a1acc5-e530-4762-a96d-257838b18015.png)

Given the executed data out, then they can decode it to display.
