### PR TITLE
`type` field for rpc `Receipt` response payload

### DIFF
--- a/client/rpc-core/src/types/receipt.rs
+++ b/client/rpc-core/src/types/receipt.rs
@@ -56,4 +56,7 @@ pub struct Receipt {
 	pub status_code: Option<U64>,
 	/// Effective gas price. Pre-eip1559 this is just the gasprice. Post-eip1559 this is base fee + priority fee.
 	pub effective_gas_price: U256,
+	/// EIP-2718 type
+	#[serde(rename = "type")]
+	pub transaction_type: U256,
 }

--- a/client/rpc/src/eth/transaction.rs
+++ b/client/rpc/src/eth/transaction.rs
@@ -324,7 +324,7 @@ where
 				{
 					// Pre-london frontier update stored receipts require cumulative gas calculation.
 					match receipt {
-						ethereum::ReceiptV3::Legacy(d) => {
+						ethereum::ReceiptV3::Legacy(ref d) => {
 							let index = core::cmp::min(receipts.len(), index + 1);
 							let cumulative_gas: u32 = receipts[..index]
 								.iter()
@@ -337,7 +337,7 @@ where
 								})
 								.sum::<Result<u32>>()?;
 							(
-								d.logs,
+								d.logs.clone(),
 								d.logs_bloom,
 								d.status_code,
 								U256::from(cumulative_gas),
@@ -353,9 +353,9 @@ where
 					}
 				} else {
 					match receipt {
-						ethereum::ReceiptV3::Legacy(d)
-						| ethereum::ReceiptV3::EIP2930(d)
-						| ethereum::ReceiptV3::EIP1559(d) => {
+						ethereum::ReceiptV3::Legacy(ref d)
+						| ethereum::ReceiptV3::EIP2930(ref d)
+						| ethereum::ReceiptV3::EIP1559(ref d) => {
 							let cumulative_gas = d.used_gas;
 							let gas_used = if index > 0 {
 								let previous_receipt = receipts[index - 1].clone();
@@ -369,7 +369,7 @@ where
 								cumulative_gas
 							};
 							(
-								d.logs,
+								d.logs.clone(),
 								d.logs_bloom,
 								d.status_code,
 								cumulative_gas,
@@ -442,6 +442,11 @@ where
 					logs_bloom,
 					state_root: None,
 					effective_gas_price,
+					transaction_type: match receipt {
+						ethereum::ReceiptV3::Legacy(_) => U256::from(0),
+						ethereum::ReceiptV3::EIP2930(_) => U256::from(1),
+						ethereum::ReceiptV3::EIP1559(_) => U256::from(2),
+					},
 				}));
 			}
 			_ => Ok(None),

--- a/ts-tests/tests/test-revert-receipt.ts
+++ b/ts-tests/tests/test-revert-receipt.ts
@@ -43,6 +43,7 @@ describeWithFrontier("Frontier RPC (Constructor Revert)", (context) => {
 			transactionHash: txHash,
 			transactionIndex: 0,
 			status: true,
+			type: "0x0",
 		});
 	});
 


### PR DESCRIPTION
@sorpaas this is a complementary change to what we talked about receipt root calculation. This is part of the expected response payload (https://github.com/ethereum/go-ethereum/blob/master/core/types/receipt.go#L54), and is used by dapps to perform the offchain receipt proof verification.