### PR TITLE
pallet-base-fee: use runtime config `IsActive` as genesis config

### DIFF
--- a/frame/base-fee/src/lib.rs
+++ b/frame/base-fee/src/lib.rs
@@ -78,7 +78,7 @@ pub mod pallet {
 		fn default() -> Self {
 			Self {
 				base_fee_per_gas: T::DefaultBaseFeePerGas::get(),
-				is_active: true,
+				is_active: T::IsActive::get(),
 				elasticity: Permill::from_parts(125_000),
 				_marker: PhantomData,
 			}


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

It's confusing that default value of `IsActive` in the `pallet_base_fee::GenesisConfig` is true, although I configure `pallet_base_fee::Config` with `type IsActive = ConstBool<false>;`.