### PR TITLE
Allow larger gas limit in non-transactional execution

### DIFF
--- a/client/rpc/src/eth/execute.rs
+++ b/client/rpc/src/eth/execute.rs
@@ -102,27 +102,38 @@ where
 			} else {
 				return Err(internal_err("failed to retrieve Runtime Api version"));
 			};
+
+		let block = if api_version > 1 {
+			api.current_block(&id)
+				.map_err(|err| internal_err(format!("runtime error: {:?}", err)))?
+		} else {
+			#[allow(deprecated)]
+			let legacy_block = api
+				.current_block_before_version_2(&id)
+				.map_err(|err| internal_err(format!("runtime error: {:?}", err)))?;
+			legacy_block.map(|block| block.into())
+		};
+
+		let block_gas_limit = block
+			.ok_or_else(|| internal_err("block unavailable, cannot query gas limit"))?
+			.header
+			.gas_limit;
+		let max_gas_limit = block_gas_limit * self.execute_gas_limit_multiplier;
+
 		// use given gas limit or query current block's limit
 		let gas_limit = match gas {
-			Some(amount) => amount,
-			None => {
-				let block = if api_version > 1 {
-					api.current_block(&id)
-						.map_err(|err| internal_err(format!("runtime error: {:?}", err)))?
-				} else {
-					#[allow(deprecated)]
-					let legacy_block = api.current_block_before_version_2(&id)
-						.map_err(|err| internal_err(format!("runtime error: {:?}", err)))?;
-					legacy_block.map(|block| block.into())
-				};
-
-				if let Some(block) = block {
-					block.header.gas_limit
-				} else {
-					return Err(internal_err("block unavailable, cannot query gas limit"));
+			Some(amount) => {
+				if amount <= max_gas_limit {
+					return Err(internal_err(format!(
+						"provided gas limit is to high (can be up to {}x the block gas limit)",
+						self.execute_gas_limit_multiplier
+					)));
 				}
+				amount
 			}
+			None => max_gas_limit,
 		};
+
 		let data = data.map(|d| d.0).unwrap_or_default();
 		match to {
 			Some(to) => {
@@ -319,25 +330,32 @@ where
 			)
 		};
 
-		let get_current_block_gas_limit = || async {
+		let block_gas_limit = {
 			let substrate_hash = client.info().best_hash;
 			let id = BlockId::Hash(substrate_hash);
 			let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(&client, id);
 			let block = block_data_cache.current_block(schema, substrate_hash).await;
-			if let Some(block) = block {
-				Ok(block.header.gas_limit)
-			} else {
-				Err(internal_err("block unavailable, cannot query gas limit"))
-			}
+
+			block
+				.ok_or_else(|| internal_err("block unavailable, cannot query gas limit"))?
+				.header
+				.gas_limit
 		};
+
+		let max_gas_limit = block_gas_limit * self.execute_gas_limit_multiplier;
 
 		// Determine the highest possible gas limits
 		let mut highest = match request.gas {
-			Some(gas) => gas,
-			None => {
-				// query current block's gas limit
-				get_current_block_gas_limit().await?
+			Some(amount) => {
+				if amount <= max_gas_limit {
+					return Err(internal_err(format!(
+						"provided gas limit is to high (can be up to {}x the block gas limit)",
+						self.execute_gas_limit_multiplier
+					)));
+				}
+				amount
 			}
+			None => max_gas_limit,
 		};
 
 		let api = client.runtime_api();
@@ -582,7 +600,7 @@ where
 						used_gas: _,
 					} = executable(
 						request.clone(),
-						get_current_block_gas_limit().await?,
+						max_gas_limit,
 						api_version,
 						client.runtime_api(),
 						estimate_mode,

--- a/client/rpc/src/eth/execute.rs
+++ b/client/rpc/src/eth/execute.rs
@@ -125,7 +125,7 @@ where
 			Some(amount) => {
 				if amount > max_gas_limit {
 					return Err(internal_err(format!(
-						"provided gas limit is to high (can be up to {}x the block gas limit)",
+						"provided gas limit is too high (can be up to {}x the block gas limit)",
 						self.execute_gas_limit_multiplier
 					)));
 				}
@@ -349,7 +349,7 @@ where
 			Some(amount) => {
 				if amount > max_gas_limit {
 					return Err(internal_err(format!(
-						"provided gas limit is to high (can be up to {}x the block gas limit)",
+						"provided gas limit is too high (can be up to {}x the block gas limit)",
 						self.execute_gas_limit_multiplier
 					)));
 				}

--- a/client/rpc/src/eth/execute.rs
+++ b/client/rpc/src/eth/execute.rs
@@ -123,7 +123,7 @@ where
 		// use given gas limit or query current block's limit
 		let gas_limit = match gas {
 			Some(amount) => {
-				if amount <= max_gas_limit {
+				if amount > max_gas_limit {
 					return Err(internal_err(format!(
 						"provided gas limit is to high (can be up to {}x the block gas limit)",
 						self.execute_gas_limit_multiplier
@@ -347,7 +347,7 @@ where
 		// Determine the highest possible gas limits
 		let mut highest = match request.gas {
 			Some(amount) => {
-				if amount <= max_gas_limit {
+				if amount > max_gas_limit {
 					return Err(internal_err(format!(
 						"provided gas limit is to high (can be up to {}x the block gas limit)",
 						self.execute_gas_limit_multiplier

--- a/client/rpc/src/eth/mod.rs
+++ b/client/rpc/src/eth/mod.rs
@@ -70,6 +70,9 @@ pub struct Eth<B: BlockT, C, P, CT, BE, H: ExHashT, A: ChainApi> {
 	block_data_cache: Arc<EthBlockDataCacheTask<B>>,
 	fee_history_cache: FeeHistoryCache,
 	fee_history_cache_limit: FeeHistoryCacheLimit,
+	/// When using eth_call/eth_estimateGas, the maximum allowed gas limit will be
+	/// block.gas_limit * execute_gas_limit_multiplier
+	execute_gas_limit_multiplier: u64,
 	_marker: PhantomData<(B, BE)>,
 }
 
@@ -87,6 +90,7 @@ impl<B: BlockT, C, P, CT, BE, H: ExHashT, A: ChainApi> Eth<B, C, P, CT, BE, H, A
 		block_data_cache: Arc<EthBlockDataCacheTask<B>>,
 		fee_history_cache: FeeHistoryCache,
 		fee_history_cache_limit: FeeHistoryCacheLimit,
+		execute_gas_limit_multiplier: u64,
 	) -> Self {
 		Self {
 			client,
@@ -101,6 +105,7 @@ impl<B: BlockT, C, P, CT, BE, H: ExHashT, A: ChainApi> Eth<B, C, P, CT, BE, H, A
 			block_data_cache,
 			fee_history_cache,
 			fee_history_cache_limit,
+			execute_gas_limit_multiplier,
 			_marker: PhantomData,
 		}
 	}

--- a/primitives/evm/src/validation.rs
+++ b/primitives/evm/src/validation.rs
@@ -197,13 +197,15 @@ impl<'config, E: From<InvalidEvmTransactionError>> CheckEvmTransaction<'config, 
 					&self.transaction.access_list,
 				)
 			};
+
 			if gasometer.record_transaction(transaction_cost).is_err() {
 				return Err(InvalidEvmTransactionError::GasLimitTooLow.into());
 			}
-		}
-		// Transaction gas limit is within the upper bound block gas limit.
-		if self.transaction.gas_limit > self.config.block_gas_limit {
-			return Err(InvalidEvmTransactionError::GasLimitTooHigh.into());
+
+			// Transaction gas limit is within the upper bound block gas limit.
+			if self.transaction.gas_limit > self.config.block_gas_limit {
+				return Err(InvalidEvmTransactionError::GasLimitTooHigh.into());
+			}
 		}
 
 		Ok(self)

--- a/template/node/src/rpc.rs
+++ b/template/node/src/rpc.rs
@@ -169,6 +169,7 @@ where
 			block_data_cache.clone(),
 			fee_history_cache,
 			fee_history_cache_limit,
+			10,
 		)
 		.into_rpc(),
 	)?;

--- a/ts-tests/tests/test-execute.ts
+++ b/ts-tests/tests/test-execute.ts
@@ -4,43 +4,44 @@ import { BLOCK_GAS_LIMIT, GENESIS_ACCOUNT } from "./config";
 
 import { describeWithFrontier, customRequest } from "./util";
 
+import Test from "../build/contracts/Test.json";
+
 // EXTRINSIC_GAS_LIMIT = [BLOCK_GAS_LIMIT - BLOCK_GAS_LIMIT * (NORMAL_DISPATCH_RATIO - AVERAGE_ON_INITIALIZE_RATIO) - EXTRINSIC_BASE_Weight] / WEIGHT_PER_GAS = (1_000_000_000_000 * 2 * (0.75-0.1) - 125_000_000) / 20000
 const EXTRINSIC_GAS_LIMIT = 64995685;
+const TEST_CONTRACT_BYTECODE = Test.bytecode;
+const TEST_CONTRACT_DEPLOYED_BYTECODE = Test.deployedBytecode;
 
 describeWithFrontier("Frontier RPC (RPC execution)", (context) => {
 	step("should call with gas limit under block gas limit", async function () {
 		const result = await customRequest(context.web3, "eth_call", [
 			{
 				from: GENESIS_ACCOUNT,
-				to: GENESIS_ACCOUNT,
-				value: "0x00",
 				gas: `0x${BLOCK_GAS_LIMIT.toString(16)}`,
+				data: TEST_CONTRACT_BYTECODE,
 			},
 		]);
 
-		expect(result.result).to.be.equal("0x");
+		expect(result.result).to.be.equal(TEST_CONTRACT_DEPLOYED_BYTECODE);
 	});
 
 	step("should call with gas limit up to 10x block gas limit", async function () {
 		const result = await customRequest(context.web3, "eth_call", [
 			{
 				from: GENESIS_ACCOUNT,
-				to: GENESIS_ACCOUNT,
-				value: "0x00",
 				gas: `0x${(BLOCK_GAS_LIMIT * 10).toString(16)}`,
+				data: TEST_CONTRACT_BYTECODE,
 			},
 		]);
 
-		expect(result.result).to.be.equal("0x");
+		expect(result.result).to.be.equal(TEST_CONTRACT_DEPLOYED_BYTECODE);
 	});
 
 	step("shouldn't call with gas limit up higher than 10x block gas limit", async function () {
 		const result = await customRequest(context.web3, "eth_call", [
 			{
 				from: GENESIS_ACCOUNT,
-				to: GENESIS_ACCOUNT,
-				value: "0x00",
 				gas: `0x${(BLOCK_GAS_LIMIT * 10 + 1).toString(16)}`,
+				data: TEST_CONTRACT_BYTECODE,
 			},
 		]);
 
@@ -53,39 +54,36 @@ describeWithFrontier("Frontier RPC (RPC execution)", (context) => {
 		const result = await customRequest(context.web3, "eth_estimateGas", [
 			{
 				from: GENESIS_ACCOUNT,
-				to: GENESIS_ACCOUNT,
-				value: "0x00",
 				gas: `0x${BLOCK_GAS_LIMIT.toString(16)}`,
+				data: TEST_CONTRACT_BYTECODE,
 			},
 		]);
 
-		expect(result.result).to.be.equal("0x5208");
+		expect(result.result).to.be.equal("0x3043a");
 	});
 
 	step("should estimateGas with gas limit up to 10x block gas limit", async function () {
 		const result = await customRequest(context.web3, "eth_estimateGas", [
 			{
 				from: GENESIS_ACCOUNT,
-				to: GENESIS_ACCOUNT,
-				value: "0x00",
 				gas: `0x${(BLOCK_GAS_LIMIT * 10).toString(16)}`,
+				data: TEST_CONTRACT_BYTECODE,
 			},
 		]);
 
-		expect(result.result).to.be.equal("0x5208");
+		expect(result.result).to.be.equal("0x3043a");
 	});
 
 	step("shouldn't estimateGas with gas limit up higher than 10x block gas limit", async function () {
 		const result = await customRequest(context.web3, "eth_estimateGas", [
 			{
 				from: GENESIS_ACCOUNT,
-				to: GENESIS_ACCOUNT,
-				value: "0x00",
-				gas: `0x${(BLOCK_GAS_LIMIT * 10 + 1).toString(16)}`,
+				gas: `0x${(BLOCK_GAS_LIMIT * 20 + 1).toString(16)}`,
+				data: TEST_CONTRACT_BYTECODE,
 			},
 		]);
 
-		console.log(result);
+		expect(result.result).to.not.exist;
 		expect((result as any).error.message).to.be.equal(
 			"provided gas limit is too high (can be up to 10x the block gas limit)"
 		);

--- a/ts-tests/tests/test-execute.ts
+++ b/ts-tests/tests/test-execute.ts
@@ -1,0 +1,82 @@
+import { assert, expect } from "chai";
+import { step } from "mocha-steps";
+import { BLOCK_GAS_LIMIT, GENESIS_ACCOUNT } from "./config";
+
+import { describeWithFrontier, customRequest } from "./util";
+
+// EXTRINSIC_GAS_LIMIT = [BLOCK_GAS_LIMIT - BLOCK_GAS_LIMIT * (NORMAL_DISPATCH_RATIO - AVERAGE_ON_INITIALIZE_RATIO) - EXTRINSIC_BASE_Weight] / WEIGHT_PER_GAS = (1_000_000_000_000 * 2 * (0.75-0.1) - 125_000_000) / 20000
+const EXTRINSIC_GAS_LIMIT = 64995685;
+
+describeWithFrontier("Frontier RPC (RPC execution)", (context) => {
+	step("should call with gas limit under block gas limit", async function () {
+		const result = await customRequest(context.web3, "eth_call", [{
+			from: GENESIS_ACCOUNT,
+			to: GENESIS_ACCOUNT,
+			value: "0x00",
+			gas: `0x${BLOCK_GAS_LIMIT.toString(16)}`,
+		}]);
+
+		expect(result.result).to.be.equal("0x");
+	});
+
+	step("should call with gas limit up to 10x block gas limit", async function () {
+		const result = await customRequest(context.web3, "eth_call", [{
+			from: GENESIS_ACCOUNT,
+			to: GENESIS_ACCOUNT,
+			value: "0x00",
+			gas: `0x${(BLOCK_GAS_LIMIT * 10).toString(16)}`,
+		}]);
+
+		expect(result.result).to.be.equal("0x");
+	});
+
+	step("shouldn't call with gas limit up higher than 10x block gas limit", async function () {
+		const result = await customRequest(context.web3, "eth_call", [{
+			from: GENESIS_ACCOUNT,
+			to: GENESIS_ACCOUNT,
+			value: "0x00",
+			gas: `0x${(BLOCK_GAS_LIMIT * 10 + 1).toString(16)}`,
+		}]);
+
+		
+		expect((result as any).error.message).to.be.equal(
+			"provided gas limit is too high (can be up to 10x the block gas limit)"
+		);
+	});
+
+	step("should estimateGas with gas limit under block gas limit", async function () {
+		const result = await customRequest(context.web3, "eth_estimateGas", [{
+			from: GENESIS_ACCOUNT,
+			to: GENESIS_ACCOUNT,
+			value: "0x00",
+			gas: `0x${BLOCK_GAS_LIMIT.toString(16)}`,
+		}]);
+
+		expect(result.result).to.be.equal("0x5208");
+	});
+
+	step("should estimateGas with gas limit up to 10x block gas limit", async function () {
+		const result = await customRequest(context.web3, "eth_estimateGas", [{
+			from: GENESIS_ACCOUNT,
+			to: GENESIS_ACCOUNT,
+			value: "0x00",
+			gas: `0x${(BLOCK_GAS_LIMIT * 10).toString(16)}`,
+		}]);
+
+		expect(result.result).to.be.equal("0x5208");
+	});
+
+	step("shouldn't estimateGas with gas limit up higher than 10x block gas limit", async function () {
+		const result = await customRequest(context.web3, "eth_estimateGas", [{
+			from: GENESIS_ACCOUNT,
+			to: GENESIS_ACCOUNT,
+			value: "0x00",
+			gas: `0x${(BLOCK_GAS_LIMIT * 10 + 1).toString(16)}`,
+		}]);
+
+		console.log(result);
+		expect((result as any).error.message).to.be.equal(
+			"provided gas limit is too high (can be up to 10x the block gas limit)"
+		);
+	});
+});

--- a/ts-tests/tests/test-execute.ts
+++ b/ts-tests/tests/test-execute.ts
@@ -9,70 +9,81 @@ const EXTRINSIC_GAS_LIMIT = 64995685;
 
 describeWithFrontier("Frontier RPC (RPC execution)", (context) => {
 	step("should call with gas limit under block gas limit", async function () {
-		const result = await customRequest(context.web3, "eth_call", [{
-			from: GENESIS_ACCOUNT,
-			to: GENESIS_ACCOUNT,
-			value: "0x00",
-			gas: `0x${BLOCK_GAS_LIMIT.toString(16)}`,
-		}]);
+		const result = await customRequest(context.web3, "eth_call", [
+			{
+				from: GENESIS_ACCOUNT,
+				to: GENESIS_ACCOUNT,
+				value: "0x00",
+				gas: `0x${BLOCK_GAS_LIMIT.toString(16)}`,
+			},
+		]);
 
 		expect(result.result).to.be.equal("0x");
 	});
 
 	step("should call with gas limit up to 10x block gas limit", async function () {
-		const result = await customRequest(context.web3, "eth_call", [{
-			from: GENESIS_ACCOUNT,
-			to: GENESIS_ACCOUNT,
-			value: "0x00",
-			gas: `0x${(BLOCK_GAS_LIMIT * 10).toString(16)}`,
-		}]);
+		const result = await customRequest(context.web3, "eth_call", [
+			{
+				from: GENESIS_ACCOUNT,
+				to: GENESIS_ACCOUNT,
+				value: "0x00",
+				gas: `0x${(BLOCK_GAS_LIMIT * 10).toString(16)}`,
+			},
+		]);
 
 		expect(result.result).to.be.equal("0x");
 	});
 
 	step("shouldn't call with gas limit up higher than 10x block gas limit", async function () {
-		const result = await customRequest(context.web3, "eth_call", [{
-			from: GENESIS_ACCOUNT,
-			to: GENESIS_ACCOUNT,
-			value: "0x00",
-			gas: `0x${(BLOCK_GAS_LIMIT * 10 + 1).toString(16)}`,
-		}]);
+		const result = await customRequest(context.web3, "eth_call", [
+			{
+				from: GENESIS_ACCOUNT,
+				to: GENESIS_ACCOUNT,
+				value: "0x00",
+				gas: `0x${(BLOCK_GAS_LIMIT * 10 + 1).toString(16)}`,
+			},
+		]);
 
-		
 		expect((result as any).error.message).to.be.equal(
 			"provided gas limit is too high (can be up to 10x the block gas limit)"
 		);
 	});
 
 	step("should estimateGas with gas limit under block gas limit", async function () {
-		const result = await customRequest(context.web3, "eth_estimateGas", [{
-			from: GENESIS_ACCOUNT,
-			to: GENESIS_ACCOUNT,
-			value: "0x00",
-			gas: `0x${BLOCK_GAS_LIMIT.toString(16)}`,
-		}]);
+		const result = await customRequest(context.web3, "eth_estimateGas", [
+			{
+				from: GENESIS_ACCOUNT,
+				to: GENESIS_ACCOUNT,
+				value: "0x00",
+				gas: `0x${BLOCK_GAS_LIMIT.toString(16)}`,
+			},
+		]);
 
 		expect(result.result).to.be.equal("0x5208");
 	});
 
 	step("should estimateGas with gas limit up to 10x block gas limit", async function () {
-		const result = await customRequest(context.web3, "eth_estimateGas", [{
-			from: GENESIS_ACCOUNT,
-			to: GENESIS_ACCOUNT,
-			value: "0x00",
-			gas: `0x${(BLOCK_GAS_LIMIT * 10).toString(16)}`,
-		}]);
+		const result = await customRequest(context.web3, "eth_estimateGas", [
+			{
+				from: GENESIS_ACCOUNT,
+				to: GENESIS_ACCOUNT,
+				value: "0x00",
+				gas: `0x${(BLOCK_GAS_LIMIT * 10).toString(16)}`,
+			},
+		]);
 
 		expect(result.result).to.be.equal("0x5208");
 	});
 
 	step("shouldn't estimateGas with gas limit up higher than 10x block gas limit", async function () {
-		const result = await customRequest(context.web3, "eth_estimateGas", [{
-			from: GENESIS_ACCOUNT,
-			to: GENESIS_ACCOUNT,
-			value: "0x00",
-			gas: `0x${(BLOCK_GAS_LIMIT * 10 + 1).toString(16)}`,
-		}]);
+		const result = await customRequest(context.web3, "eth_estimateGas", [
+			{
+				from: GENESIS_ACCOUNT,
+				to: GENESIS_ACCOUNT,
+				value: "0x00",
+				gas: `0x${(BLOCK_GAS_LIMIT * 10 + 1).toString(16)}`,
+			},
+		]);
 
 		console.log(result);
 		expect((result as any).error.message).to.be.equal(

--- a/ts-tests/tests/test-gas.ts
+++ b/ts-tests/tests/test-gas.ts
@@ -44,7 +44,7 @@ describeWithFrontier("Frontier RPC (Gas)", (context) => {
 
 	it("eth_estimateGas for contract creation", async function () {
 		// The value returned as an estimation by the evm with estimate mode ON.
-		let oneOffEstimation = 196657;
+		let oneOffEstimation = 149143;
 		let binarySearchEstimation = binarySearch(oneOffEstimation);
 		// Sanity check expect a variance of 10%.
 		expect(estimationVariance(binarySearchEstimation, oneOffEstimation)).to.be.lessThan(1);
@@ -107,7 +107,7 @@ describeWithFrontier("Frontier RPC (Gas)", (context) => {
 	it("eth_estimateGas should handle AccessList alias", async function () {
 		// The value returned as an estimation by the evm with estimate mode ON.
 		// 4300 == 1900 for one key and 2400 for one storage.
-		let oneOffEstimation = 196657 + 4300;
+		let oneOffEstimation = 149143 + 4300;
 		let binarySearchEstimation = binarySearch(oneOffEstimation);
 		// Sanity check expect a variance of 10%.
 		expect(estimationVariance(binarySearchEstimation, oneOffEstimation)).to.be.lessThan(1);
@@ -134,12 +134,12 @@ describeWithFrontier("Frontier RPC (Gas)", (context) => {
 			data: Test.bytecode,
 			gasPrice: "0x0",
 		});
-		expect(result).to.equal(197690);
+		expect(result).to.equal(150926);
 		result = await context.web3.eth.estimateGas({
 			from: GENESIS_ACCOUNT,
 			data: Test.bytecode,
 		});
-		expect(result).to.equal(197690);
+		expect(result).to.equal(150926);
 	});
 
 	it("tx gas limit below EXTRINSIC_GAS_LIMIT", async function () {

--- a/ts-tests/tests/test-gas.ts
+++ b/ts-tests/tests/test-gas.ts
@@ -44,7 +44,7 @@ describeWithFrontier("Frontier RPC (Gas)", (context) => {
 
 	it("eth_estimateGas for contract creation", async function () {
 		// The value returned as an estimation by the evm with estimate mode ON.
-		let oneOffEstimation = 149143;
+		let oneOffEstimation = 196657;
 		let binarySearchEstimation = binarySearch(oneOffEstimation);
 		// Sanity check expect a variance of 10%.
 		expect(estimationVariance(binarySearchEstimation, oneOffEstimation)).to.be.lessThan(1);
@@ -107,7 +107,7 @@ describeWithFrontier("Frontier RPC (Gas)", (context) => {
 	it("eth_estimateGas should handle AccessList alias", async function () {
 		// The value returned as an estimation by the evm with estimate mode ON.
 		// 4300 == 1900 for one key and 2400 for one storage.
-		let oneOffEstimation = 149143 + 4300;
+		let oneOffEstimation = 196657 + 4300;
 		let binarySearchEstimation = binarySearch(oneOffEstimation);
 		// Sanity check expect a variance of 10%.
 		expect(estimationVariance(binarySearchEstimation, oneOffEstimation)).to.be.lessThan(1);
@@ -134,12 +134,12 @@ describeWithFrontier("Frontier RPC (Gas)", (context) => {
 			data: Test.bytecode,
 			gasPrice: "0x0",
 		});
-		expect(result).to.equal(150926);
+		expect(result).to.equal(197690);
 		result = await context.web3.eth.estimateGas({
 			from: GENESIS_ACCOUNT,
 			data: Test.bytecode,
 		});
-		expect(result).to.equal(150926);
+		expect(result).to.equal(197690);
 	});
 
 	it("tx gas limit below EXTRINSIC_GAS_LIMIT", async function () {


### PR DESCRIPTION
Infura allows to use eth_call/eth_estimateGas with up to 10x the block gas limit:
https://docs.infura.io/infura/networks/ethereum/json-rpc-methods/eth_call

To replicate this feature :
- Runtime gas limit check is made only if call is transactional.
- Client RPC have a configurable factor, and will ensure the requested gas limit is less than the block gas limit times the factor.