### PR TITLE
Allow transfer from a substrate address to a evm address

### DIFF
--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -175,6 +175,25 @@ pub mod pallet {
 			Ok(())
 		}
 
+		#[pallet::weight(0)]
+		pub fn transfer(
+			origin: OriginFor<T>,
+			address: H160,
+			value: BalanceOf<T>,
+		) -> DispatchResult {
+			let sender = ensure_signed(origin)?;
+			let destination = T::AddressMapping::into_account_id(address);
+
+			T::Currency::transfer(
+				&sender,
+				&destination,
+				value,
+				ExistenceRequirement::AllowDeath,
+			)?;
+
+			Ok(())
+		}
+
 		/// Issue an EVM call operation. This is similar to a message call transaction in Ethereum.
 		#[pallet::weight(T::GasWeightMapping::gas_to_weight(*gas_limit))]
 		pub fn call(


### PR DESCRIPTION
Currently there 2 ways to deploy a contract to the chain.

1. Through the polkadotjs app, click developer -> rpc, call `evm.create`.
2. Using tools like remix or truffle to deploy through the http rpc.

Both of them requires that the source evm address(H160) has enough balance to pay the gas, but currently the only way to specify balance of an evm address is through genesis config, which is not convinent.

This pr added a `transfer` api, so anyone with a evm private key and some tokens can create contract on chain.

How to test:

1. Build the template node. `cargo build -p frontier-template-node`
2. Run it. `./target/debug/frontier-template-node --dev`
3. Generate evm keypair using metamask.
4. Transfer some token from alice to the H160 address.
5. Deploy contract using truffle.

![image](https://user-images.githubusercontent.com/4054836/184324268-eb53c148-dab5-4972-8228-21191c825f71.png)
