### PR TITLE
Fix panic in pending_runtime_api with Aura consensus env

### DIFF
--- a/client/rpc/src/eth/mod.rs
+++ b/client/rpc/src/eth/mod.rs
@@ -482,7 +482,7 @@ where
 		.collect::<Vec<<B as BlockT>::Extrinsic>>();
 	// Manually initialize the overlay.
 	let header = client.header(best).unwrap().unwrap();
-	let parent_hash = BlockId::Hash(header.parent_hash().clone());
+	let parent_hash = BlockId::Hash(header.parent_hash());
 	api.initialize_block(&parent_hash, &header)
 		.map_err(|e| internal_err(format!("Runtime api access error: {:?}", e)))?;
 	// Apply the ready queue to the best block's state.

--- a/client/rpc/src/eth/mod.rs
+++ b/client/rpc/src/eth/mod.rs
@@ -38,7 +38,7 @@ use sc_client_api::backend::{Backend, StateBackend, StorageProvider};
 use sc_network::{ExHashT, NetworkService};
 use sc_transaction_pool::{ChainApi, Pool};
 use sc_transaction_pool_api::{InPoolTransaction, TransactionPool};
-use sp_api::{Core, ProvideRuntimeApi};
+use sp_api::{Core, HeaderT, ProvideRuntimeApi};
 use sp_block_builder::BlockBuilder as BlockBuilderApi;
 use sp_blockchain::HeaderBackend;
 use sp_core::hashing::keccak_256;

--- a/client/rpc/src/eth/mod.rs
+++ b/client/rpc/src/eth/mod.rs
@@ -482,7 +482,7 @@ where
 		.collect::<Vec<<B as BlockT>::Extrinsic>>();
 	// Manually initialize the overlay.
 	let header = client.header(best).unwrap().unwrap();
-	let parent_hash = BlockId::Hash(header.parent_hash());
+	let parent_hash = BlockId::Hash(*header.parent_hash());
 	api.initialize_block(&parent_hash, &header)
 		.map_err(|e| internal_err(format!("Runtime api access error: {:?}", e)))?;
 	// Apply the ready queue to the best block's state.

--- a/client/rpc/src/eth/mod.rs
+++ b/client/rpc/src/eth/mod.rs
@@ -482,7 +482,8 @@ where
 		.collect::<Vec<<B as BlockT>::Extrinsic>>();
 	// Manually initialize the overlay.
 	let header = client.header(best).unwrap().unwrap();
-	api.initialize_block(&best, &header)
+	let parent_hash = BlockId::Hash(header.parent_hash().clone());
+	api.initialize_block(&parent_hash, &header)
 		.map_err(|e| internal_err(format!("Runtime api access error: {:?}", e)))?;
 	// Apply the ready queue to the best block's state.
 	for xt in xts {

--- a/ts-tests/tests/test-balance.ts
+++ b/ts-tests/tests/test-balance.ts
@@ -12,6 +12,7 @@ describeWithFrontier("Frontier RPC (Balance)", (context) => {
 	});
 
 	step("balance to be updated after transfer", async function () {
+		await createAndFinalizeBlock(context.web3);
 		this.timeout(15000);
 
 		const value = "0x200"; // 512, must be higher than ExistentialDeposit

--- a/ts-tests/tests/test-contract.ts
+++ b/ts-tests/tests/test-contract.ts
@@ -15,6 +15,7 @@ describeWithFrontier("Frontier RPC (Contract)", (context) => {
 	// to spin up a frontier node, it saves a lot of time.
 
 	it("contract creation should return transaction hash", async function () {
+		await createAndFinalizeBlock(context.web3);
 		this.timeout(15000);
 		const tx = await context.web3.eth.accounts.signTransaction(
 			{


### PR DESCRIPTION
1. The result of the pending query is not necessarily the final result (for example, inserting many transactions in the next second causes the previous transaction to expire, or the block may be rolled back) just to provide a reference value.
2. The current pending_runtime_api implementation will report the following panic for Aura consensus.
 - 1. steps to reproduce
```
cargo build --release
./target/release/frontier-template-node --tmp --dev --rpc-port 8546

curl -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "method": "eth_getBalance", "params": ["0x77777FeDdddFfC19Ff86DB637967013e6C6A116C","pending"],"id": 1}' http://127.0.0.1:8546

get error:
{"jsonrpc":"2.0","error":{"code":-32603,"message":"Runtime api access error: Application(Execution(RuntimePanicked(\"Slot must increase\")))"},"id":1}
```

 - 2. panic infos

The same slot is used twice  at https://github.com/paritytech/substrate/blob/master/frame/aura/src/lib.rs#L93
```
====================

Version: 0.0.0-45f13e0e-x86_64-linux-gnu

   0: sp_panic_handler::set::{{closure}}
   1: std::panicking::rust_panic_with_hook
             at /rustc/0727994435c75fdedd3e9d226cf434089b0ab585/library/std/src/panicking.rs:610:17
   2: std::panicking::begin_panic_handler::{{closure}}
             at /rustc/0727994435c75fdedd3e9d226cf434089b0ab585/library/std/src/panicking.rs:500:13
   3: std::sys_common::backtrace::__rust_end_short_backtrace
             at /rustc/0727994435c75fdedd3e9d226cf434089b0ab585/library/std/src/sys_common/backtrace.rs:139:18
   4: rust_begin_unwind
             at /rustc/0727994435c75fdedd3e9d226cf434089b0ab585/library/std/src/panicking.rs:498:5
   5: core::panicking::panic_fmt
             at /rustc/0727994435c75fdedd3e9d226cf434089b0ab585/library/core/src/panicking.rs:106:14
   6: <(TupleElement0,TupleElement1) as frame_support::traits::hooks::OnInitialize<BlockNumber>>::on_initialize
   7: <(TupleElement0,TupleElement1) as frame_support::traits::hooks::OnInitialize<BlockNumber>>::on_initialize
   8: <(TupleElement0,TupleElement1) as frame_support::traits::hooks::OnInitialize<BlockNumber>>::on_initialize
   9: <(TupleElement0,TupleElement1) as frame_support::traits::hooks::OnInitialize<BlockNumber>>::on_initialize
  10: frame_executive::Executive<System,Block,Context,UnsignedValidator,AllPalletsWithSystem,COnRuntimeUpgrade>::initialize_block
  11: std::panicking::try
  12: std::thread::local::LocalKey<T>::with
  13: sc_executor::native_executor::WasmExecutor<H>::with_instance::{{closure}}
  14: sc_executor::wasm_runtime::RuntimeCache::with_instance
  15: <sc_executor::native_executor::NativeElseWasmExecutor<D> as sp_core::traits::CodeExecutor>::call
  16: sp_state_machine::execution::StateMachine<B,H,Exec>::execute_aux
  17: sp_state_machine::execution::StateMachine<B,H,Exec>::execute_using_consensus_failure_handler
  18: <sc_service::client::call_executor::LocalCallExecutor<Block,B,E> as sc_client_api::call_executor::CallExecutor<Block>>::contextual_call
  19: <sc_service::client::client::Client<B,E,Block,RA> as sp_api::CallApiAt<Block>>::call_api_at
  20: sp_api::runtime_decl_for_Core::initialize_block_call_api_at
  21: <frontier_template_runtime::RuntimeApiImpl<__SR_API_BLOCK__,RuntimeApiImplCall> as sp_api::Core<__SR_API_BLOCK__>>::Core_initialize_block_runtime_api_impl
  22: sp_api::Core::initialize_block
  23: fc_rpc::eth::pending_runtime_api
  24: <fc_rpc::eth::EthApi<B,C,P,CT,BE,H,A,F> as fc_rpc_core::eth::rpc_impl_EthApi::gen_server::EthApi>::balance
  25: <jsonrpc_core::delegates::DelegateAsyncMethod<T,F> as jsonrpc_core::calls::RpcMethod<M>>::call
  26: <sc_rpc_server::middleware::RpcMiddleware as jsonrpc_core::middleware::Middleware<M>>::on_call
  27: <sc_rpc_server::middleware::RpcMiddleware as jsonrpc_core::middleware::Middleware<M>>::on_request
  28: jsonrpc_core::io::MetaIoHandler<T,S>::handle_request
  29: <jsonrpc_http_server::handler::RpcHandler<M,S> as core::future::future::Future>::poll
  30: <jsonrpc_http_server::handler::RpcHandler<M,S> as core::future::future::Future>::poll
  31: hyper::proto::h1::dispatch::Dispatcher<D,Bs,I,T>::poll_catch
  32: <hyper::server::conn::upgrades::UpgradeableConnection<I,S,E> as core::future::future::Future>::poll
  33: <hyper::server::conn::spawn_all::NewSvcTask<I,N,S,E,W> as core::future::future::Future>::poll
  34: tokio::runtime::task::core::CoreStage<T>::poll
  35: tokio::runtime::task::harness::Harness<T,S>::poll
  36: std::thread::local::LocalKey<T>::with
  37: tokio::runtime::thread_pool::worker::Context::run_task
  38: tokio::runtime::thread_pool::worker::Context::run
  39: tokio::macros::scoped_tls::ScopedKey<T>::set
  40: tokio::runtime::thread_pool::worker::run
  41: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
  42: tokio::runtime::task::harness::Harness<T,S>::poll
  43: tokio::runtime::blocking::pool::Inner::run
  44: std::sys_common::backtrace::__rust_begin_short_backtrace
  45: core::ops::function::FnOnce::call_once{{vtable.shim}}
  46: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/0727994435c75fdedd3e9d226cf434089b0ab585/library/alloc/src/boxed.rs:1691:9
      <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/0727994435c75fdedd3e9d226cf434089b0ab585/library/alloc/src/boxed.rs:1691:9
      std::sys::unix::thread::Thread::new::thread_start
             at /rustc/0727994435c75fdedd3e9d226cf434089b0ab585/library/std/src/sys/unix/thread.rs:106:17
  47: start_thread
             at /build/glibc-eX1tMB/glibc-2.31/nptl/pthread_create.c:477:8
  48: clone
             at /build/glibc-eX1tMB/glibc-2.31/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95


Thread 'tokio-runtime-worker' panicked at 'Slot must increase', /home/zjb/.cargo/git/checkouts/substrate-7e08433d4c370a21/fc3fd07/frame/aura/src/lib.rs:92

This is a bug. Please report it at:

	support.anonymous.an

```
3. choose `api.initialize_block(&parent_hash, &best_header)` instead of `api.initialize_block(&best_hash, &best_header)`
   It solves the panic of 2, reason refer to 1
