### PR TITLE
Update README.md

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -31,14 +31,14 @@ $ cargo build --release
 To execute the chain, run:
 
 ```
-$ ./target/debug/frontier-template-node --dev
+$ ./target/release/frontier-template-node --dev
 ```
 
 The node also supports to use manual seal (to produce block manually through RPC).  
 This is also used by the ts-tests:
 
 ```
-$ ./target/debug/frontier-template-node --dev --manual-seal
+$ ./target/release/frontier-template-node --dev --manual-seal
 ```
 
 ### Docker Based Development


### PR DESCRIPTION
Change to the README.md instruction to run the node with the "release" folder instead of the "debug" folder.