### PR TITLE
Fix post dispatch weight

### DIFF
--- a/frame/ethereum/src/tests/eip1559.rs
+++ b/frame/ethereum/src/tests/eip1559.rs
@@ -407,3 +407,47 @@ fn call_should_handle_errors() {
 		Ethereum::execute(alice.address, &t3, None).ok().unwrap();
 	});
 }
+
+#[test]
+fn transaction_with_extra_gas_should_adjust_weight() {
+	let (pairs, mut ext) = new_test_ext(1);
+	let alice = &pairs[0];
+	let base_extrinsic_weight = frame_system::limits::BlockWeights::with_sensible_defaults(
+		2000000000000,
+		sp_runtime::Perbill::from_percent(75),
+	)
+	.per_class
+	.get(frame_support::weights::DispatchClass::Normal)
+	.base_extrinsic;
+
+	ext.execute_with(|| {
+		let mut transaction = eip1559_erc20_creation_unsigned_transaction();
+		transaction.gas_limit = 9_000_000.into();
+		let signed = transaction.sign(&alice.private_key, None);
+		let call = crate::Call::<Test>::transact {
+			transaction: signed,
+		};
+		let source = call.check_self_contained().unwrap().unwrap();
+		let extrinsic = CheckedExtrinsic::<_, _, frame_system::CheckWeight<Test>, _> {
+			signed: fp_self_contained::CheckedSignature::SelfContained(source),
+			function: Call::Ethereum(call),
+		};
+		let dispatch_info = extrinsic.get_dispatch_info();
+		let post_dispatch_weight = extrinsic
+			.apply::<Test>(&dispatch_info, 0)
+			.unwrap()
+			.unwrap()
+			.actual_weight
+			.unwrap();
+
+		let expected_weight = base_extrinsic_weight.saturating_add(post_dispatch_weight);
+		let actual_weight = *frame_system::Pallet::<Test>::block_weight()
+			.get(frame_support::weights::DispatchClass::Normal);
+		assert_eq!(
+			expected_weight,
+			actual_weight,
+			"the block weight was unexpected, excess '{}'",
+			actual_weight as i128 - expected_weight as i128
+		);
+	});
+}

--- a/frame/ethereum/src/tests/eip1559.rs
+++ b/frame/ethereum/src/tests/eip1559.rs
@@ -409,7 +409,7 @@ fn call_should_handle_errors() {
 }
 
 #[test]
-fn transaction_with_extra_gas_should_adjust_weight() {
+fn self_contained_transaction_with_extra_gas_should_adjust_weight_with_post_dispatch() {
 	let (pairs, mut ext) = new_test_ext(1);
 	let alice = &pairs[0];
 	let base_extrinsic_weight = frame_system::limits::BlockWeights::with_sensible_defaults(

--- a/frame/ethereum/src/tests/eip2930.rs
+++ b/frame/ethereum/src/tests/eip2930.rs
@@ -330,3 +330,47 @@ fn call_should_handle_errors() {
 		Ethereum::execute(alice.address, &t3, None).ok().unwrap();
 	});
 }
+
+#[test]
+fn transaction_with_extra_gas_should_adjust_weight() {
+	let (pairs, mut ext) = new_test_ext(1);
+	let alice = &pairs[0];
+	let base_extrinsic_weight = frame_system::limits::BlockWeights::with_sensible_defaults(
+		2000000000000,
+		sp_runtime::Perbill::from_percent(75),
+	)
+	.per_class
+	.get(frame_support::weights::DispatchClass::Normal)
+	.base_extrinsic;
+
+	ext.execute_with(|| {
+		let mut transaction = eip2930_erc20_creation_unsigned_transaction();
+		transaction.gas_limit = 9_000_000.into();
+		let signed = transaction.sign(&alice.private_key, None);
+		let call = crate::Call::<Test>::transact {
+			transaction: signed,
+		};
+		let source = call.check_self_contained().unwrap().unwrap();
+		let extrinsic = CheckedExtrinsic::<_, _, frame_system::CheckWeight<Test>, _> {
+			signed: fp_self_contained::CheckedSignature::SelfContained(source),
+			function: Call::Ethereum(call),
+		};
+		let dispatch_info = extrinsic.get_dispatch_info();
+		let post_dispatch_weight = extrinsic
+			.apply::<Test>(&dispatch_info, 0)
+			.unwrap()
+			.unwrap()
+			.actual_weight
+			.unwrap();
+
+		let expected_weight = base_extrinsic_weight.saturating_add(post_dispatch_weight);
+		let actual_weight = *frame_system::Pallet::<Test>::block_weight()
+			.get(frame_support::weights::DispatchClass::Normal);
+		assert_eq!(
+			expected_weight,
+			actual_weight,
+			"the block weight was unexpected, excess '{}'",
+			actual_weight as i128 - expected_weight as i128
+		);
+	});
+}

--- a/frame/ethereum/src/tests/eip2930.rs
+++ b/frame/ethereum/src/tests/eip2930.rs
@@ -332,7 +332,7 @@ fn call_should_handle_errors() {
 }
 
 #[test]
-fn transaction_with_extra_gas_should_adjust_weight() {
+fn self_contained_transaction_with_extra_gas_should_adjust_weight_with_post_dispatch() {
 	let (pairs, mut ext) = new_test_ext(1);
 	let alice = &pairs[0];
 	let base_extrinsic_weight = frame_system::limits::BlockWeights::with_sensible_defaults(

--- a/frame/ethereum/src/tests/legacy.rs
+++ b/frame/ethereum/src/tests/legacy.rs
@@ -330,3 +330,47 @@ fn call_should_handle_errors() {
 		Ethereum::execute(alice.address, &t3, None).ok().unwrap();
 	});
 }
+
+#[test]
+fn transaction_with_extra_gas_should_adjust_weight() {
+	let (pairs, mut ext) = new_test_ext(1);
+	let alice = &pairs[0];
+	let base_extrinsic_weight = frame_system::limits::BlockWeights::with_sensible_defaults(
+		2000000000000,
+		sp_runtime::Perbill::from_percent(75),
+	)
+	.per_class
+	.get(frame_support::weights::DispatchClass::Normal)
+	.base_extrinsic;
+
+	ext.execute_with(|| {
+		let mut transaction = legacy_erc20_creation_unsigned_transaction();
+		transaction.gas_limit = 9_000_000.into();
+		let signed = transaction.sign(&alice.private_key);
+		let call = crate::Call::<Test>::transact {
+			transaction: signed,
+		};
+		let source = call.check_self_contained().unwrap().unwrap();
+		let extrinsic = CheckedExtrinsic::<_, _, frame_system::CheckWeight<Test>, _> {
+			signed: fp_self_contained::CheckedSignature::SelfContained(source),
+			function: Call::Ethereum(call),
+		};
+		let dispatch_info = extrinsic.get_dispatch_info();
+		let post_dispatch_weight = extrinsic
+			.apply::<Test>(&dispatch_info, 0)
+			.unwrap()
+			.unwrap()
+			.actual_weight
+			.unwrap();
+
+		let expected_weight = base_extrinsic_weight.saturating_add(post_dispatch_weight);
+		let actual_weight = *frame_system::Pallet::<Test>::block_weight()
+			.get(frame_support::weights::DispatchClass::Normal);
+		assert_eq!(
+			expected_weight,
+			actual_weight,
+			"the block weight was unexpected, excess '{}'",
+			actual_weight as i128 - expected_weight as i128
+		);
+	});
+}

--- a/frame/ethereum/src/tests/legacy.rs
+++ b/frame/ethereum/src/tests/legacy.rs
@@ -332,7 +332,7 @@ fn call_should_handle_errors() {
 }
 
 #[test]
-fn transaction_with_extra_gas_should_adjust_weight() {
+fn self_contained_transaction_with_extra_gas_should_adjust_weight_with_post_dispatch() {
 	let (pairs, mut ext) = new_test_ext(1);
 	let alice = &pairs[0];
 	let base_extrinsic_weight = frame_system::limits::BlockWeights::with_sensible_defaults(

--- a/primitives/self-contained/src/checked_extrinsic.rs
+++ b/primitives/self-contained/src/checked_extrinsic.rs
@@ -144,9 +144,23 @@ where
 					.ok_or(TransactionValidityError::Invalid(
 						InvalidTransaction::BadProof,
 					))??;
-				Ok(self.function.apply_self_contained(signed_info).ok_or(
+				let res = self.function.apply_self_contained(signed_info).ok_or(
 					TransactionValidityError::Invalid(InvalidTransaction::BadProof),
-				)?)
+				)?;
+				let post_info = match res {
+					Ok(info) => info,
+					Err(err) => err.post_info,
+				};
+
+				Extra::post_dispatch(
+					None,
+					info,
+					&post_info,
+					len,
+					&res.map(|_| ()).map_err(|e| e.error),
+				)?;
+
+				Ok(res)
 			}
 		}
 	}

--- a/primitives/self-contained/src/checked_extrinsic.rs
+++ b/primitives/self-contained/src/checked_extrinsic.rs
@@ -151,7 +151,6 @@ where
 					Ok(info) => info,
 					Err(err) => err.post_info,
 				};
-
 				Extra::post_dispatch(
 					None,
 					info,
@@ -159,7 +158,6 @@ where
 					len,
 					&res.map(|_| ()).map_err(|e| e.error),
 				)?;
-
 				Ok(res)
 			}
 		}


### PR DESCRIPTION
This fixes a bug where weight was not refunded after execution, which meant that the worst-case weight (based on `gas_limit`) was accounted for in all cases. This change calls `Extra::post_dispatch` which can invoke `CheckWeight::post_dispatch`, which will properly refund any extra weight.

Note that this only applies to `weight` accounting, the currency used for fees was already working as designed.

Thanks to @nbaztec for adding tests.