### PR TITLE
add feature forbid-evm-reentrancy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4508,6 +4508,7 @@ dependencies = [
 name = "pallet-evm"
 version = "6.0.0-dev"
 dependencies = [
+ "environmental",
  "evm",
  "fp-evm",
  "frame-benchmarking",

--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/paritytech/frontier/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+environmental = { version = "1.1.3", default-features = false, optional = true }
 evm = { git = "https://github.com/rust-blockchain/evm", rev = "51b8c2ce3104265e1fd5bb0fe5cdfd2e0938239c", default-features = false, features = ["with-codec"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 log = { version = "0.4.17", default-features = false }
@@ -43,6 +44,7 @@ pallet-balances = { version = "4.0.0-dev", git = "https://github.com/paritytech/
 [features]
 default = ["std"]
 std = [
+	"environmental/std",
 	"evm/std",
 	"evm/with-serde",
 	"hex/std",
@@ -72,3 +74,4 @@ runtime-benchmarks = [
 	"frame-system/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
 ]
+forbid-evm-reentrancy = ["environmental"]

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -53,6 +53,7 @@
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::too_many_arguments)]
+#![cfg_attr(test, feature(assert_matches))]
 
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarking;
@@ -417,6 +418,8 @@ pub mod pallet {
 		GasLimitTooHigh,
 		/// Undefined error.
 		Undefined,
+		/// EVM reentrancy
+		EvmReentrancy,
 	}
 
 	impl<T> From<InvalidEvmTransactionError> for Error<T> {


### PR DESCRIPTION
The goal of this PR is to provide a mechanism that guarantees that it's not possible to re-enter the EVM runner recursively.

We need this kind of security on moonbeam because in some special cases it may be possible: for example, with a precompile allowing to execute any XCM message locally, and the XCM to EVM feature, it becomes possible to re-enter the EVM runner recursively.

I coded this feature as an option because I don't know if it's annoying to impose it to all projects, even if I don't see why a project would need to allow a recursive re-entry in the evm runner.
