### PR TITLE
Align `GasWeightMapping` with Substrate `do_pre_dispatch` logic

### DIFF
--- a/frame/ethereum/src/mock.rs
+++ b/frame/ethereum/src/mock.rs
@@ -138,6 +138,7 @@ parameter_types! {
 	pub const ChainId: u64 = 42;
 	pub const EVMModuleId: PalletId = PalletId(*b"py/evmpa");
 	pub const BlockGasLimit: U256 = U256::MAX;
+	pub const WeightPerGas: u64 = 20_000;
 }
 
 pub struct HashedAddressMapping;
@@ -152,7 +153,8 @@ impl AddressMapping<AccountId32> for HashedAddressMapping {
 
 impl pallet_evm::Config for Test {
 	type FeeCalculator = FixedGasPrice;
-	type GasWeightMapping = ();
+	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
+	type WeightPerGas = WeightPerGas;
 	type CallOrigin = EnsureAddressTruncated;
 	type WithdrawOrigin = EnsureAddressTruncated;
 	type AddressMapping = HashedAddressMapping;

--- a/frame/ethereum/src/tests/eip1559.rs
+++ b/frame/ethereum/src/tests/eip1559.rs
@@ -83,8 +83,10 @@ fn transaction_with_gas_limit_greater_than_max_extrinsic_should_fail_pre_dispatc
 	let limits: frame_system::limits::BlockWeights =
 		<Test as frame_system::Config>::BlockWeights::get();
 	let max_extrinsic = limits.get(DispatchClass::Normal).max_extrinsic.unwrap();
-	let max_extrinsic_gas =
-		<Test as pallet_evm::Config>::GasWeightMapping::weight_to_gas(max_extrinsic);
+	let base_extrinsic = limits.get(DispatchClass::Normal).base_extrinsic;
+	let max_extrinsic_gas = <Test as pallet_evm::Config>::GasWeightMapping::weight_to_gas(
+		max_extrinsic + base_extrinsic,
+	);
 
 	ext.execute_with(|| {
 		let transaction = EIP1559UnsignedTransaction {

--- a/frame/evm/precompile/dispatch/src/mock.rs
+++ b/frame/evm/precompile/dispatch/src/mock.rs
@@ -136,10 +136,12 @@ impl FindAuthor<H160> for FindAuthorTruncated {
 }
 parameter_types! {
 	pub BlockGasLimit: U256 = U256::max_value();
+	pub WeightPerGas: u64 = 20_000;
 }
 impl pallet_evm::Config for Test {
 	type FeeCalculator = FixedGasPrice;
-	type GasWeightMapping = ();
+	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
+	type WeightPerGas = WeightPerGas;
 
 	type CallOrigin = EnsureAddressRoot<Self::AccountId>;
 	type WithdrawOrigin = EnsureAddressNever<Self::AccountId>;

--- a/frame/evm/src/mock.rs
+++ b/frame/evm/src/mock.rs
@@ -124,10 +124,12 @@ impl FindAuthor<H160> for FindAuthorTruncated {
 }
 parameter_types! {
 	pub BlockGasLimit: U256 = U256::max_value();
+	pub WeightPerGas: u64 = 20_000;
 }
 impl crate::Config for Test {
 	type FeeCalculator = FixedGasPrice;
-	type GasWeightMapping = ();
+	type GasWeightMapping = crate::FixedGasWeightMapping<Self>;
+	type WeightPerGas = WeightPerGas;
 
 	type CallOrigin = EnsureAddressRoot<Self::AccountId>;
 	type WithdrawOrigin = EnsureAddressNever<Self::AccountId>;

--- a/ts-tests/tests/test-gas.ts
+++ b/ts-tests/tests/test-gas.ts
@@ -40,8 +40,8 @@ describeWithFrontier("Frontier RPC (Gas)", (context) => {
 	// Those test are ordered. In general this should be avoided, but due to the time it takes
 	// to spin up a frontier node, it saves a lot of time.
 
-	// EXTRINSIC_GAS_LIMIT = [BLOCK_GAS_LIMIT - BLOCK_GAS_LIMIT * (NORMAL_DISPATCH_RATIO - AVERAGE_ON_INITIALIZE_RATIO) - EXTRINSIC_BASE_Weight] / WEIGHT_PER_GAS = (1_000_000_000_000 * 2 * (0.75-0.1) - 125_000_000) / 20000
-	const EXTRINSIC_GAS_LIMIT = 64995685;
+	// EXTRINSIC_GAS_LIMIT = [BLOCK_GAS_LIMIT - BLOCK_GAS_LIMIT * (NORMAL_DISPATCH_RATIO - AVERAGE_ON_INITIALIZE_RATIO)] / WEIGHT_PER_GAS = (1_000_000_000_000 * 2 * (0.75-0.1) - 125_000_000) / 20000
+	const EXTRINSIC_GAS_LIMIT = 65000000;
 
 	it("eth_estimateGas for contract creation", async function () {
 		// The value returned as an estimation by the evm with estimate mode ON.


### PR DESCRIPTION
This is a followup PR for what was mentioned by @notlesh in https://github.com/paritytech/frontier/pull/851#discussion_r968723541

This PR proposes:

- Removing the original implementation in `pallet-evm` that treated Gas and Weight as the same unit.
- Introduces `WeightPerGas` associated type to `pallet-evm`.
- Implements `GasWeightMapping` for an arbitrary struct in `pallet-evm` in which's `gas_to_weight` implementation the base base extrinsic weight is substracted to the result. 

The goal is align with how `CheckWeight::do_pre_dispatch` works. In there, (pre-dispatch) `DispatchInfoOf + base_extrinsic` is put in `frame_system::BlockWeights` storage. After (post-dispatch), `PostInfo` (the actual gas/weight used by the evm) is used to correct the accounted `Weight`, but the `base_extrinsic` still over-accounted. By subtracting the `base_extrinsic` in the `gas_to_weight` we fix that.

### Note

This proposal assumes:

- Base extrinsic weight is a constant set at runtime.
- The constant base extrinsic weight is set to a value LTE to `21_000 * WeigthPerGas`.