### PR TITLE
Cache code size/hash in storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4576,6 +4576,7 @@ dependencies = [
  "rlp",
  "scale-info",
  "serde",
+ "sha3 0.10.1",
  "sp-core",
  "sp-io",
  "sp-runtime",

--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -17,6 +17,7 @@ evm = { version = "0.36.0", default-features = false, features = ["with-codec"] 
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 log = { version = "0.4.17", default-features = false }
 serde = { version = "1.0.144", optional = true, features = ["derive"] }
+sha3 = { version = "0.10", default-features = false }
 
 # Parity
 codec = { package = "parity-scale-codec", version = "3.2.1", default-features = false, features = ["derive"] }

--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -805,6 +805,14 @@ where
 		self.substate
 			.recursive_is_cold(&|a: &Accessed| a.accessed_storage.contains(&(address, key)))
 	}
+
+	fn code_size(&self, address: H160) -> U256 {
+		U256::from(<Pallet<T>>::account_code_metadata(address).size)
+	}
+
+	fn code_hash(&self, address: H160) -> H256 {
+		<Pallet<T>>::account_code_metadata(address).hash
+	}
 }
 
 #[cfg(feature = "forbid-evm-reentrancy")]


### PR DESCRIPTION
Depends on https://github.com/rust-blockchain/evm/pull/140

Cache the code size/hash of an account in storage to avoid reading the full code to compute those values. Aims to reduce storage proof size.