### PR TITLE
Fix genesis block sync

### DIFF
--- a/client/mapping-sync/src/lib.rs
+++ b/client/mapping-sync/src/lib.rs
@@ -71,12 +71,11 @@ where
 {
 	let id = BlockId::Hash(header.hash());
 
-	let has_api = client
+	if let Some(_) = client
 		.runtime_api()
-		.has_api::<dyn EthereumRuntimeRPCApi<Block>>(&id)
-		.map_err(|e| format!("{:?}", e))?;
-
-	if has_api {
+		.api_version::<dyn EthereumRuntimeRPCApi<Block>>(&id)
+		.map_err(|e| format!("{:?}", e))?
+	{
 		let block = client
 			.runtime_api()
 			.current_block(&id)
@@ -93,7 +92,7 @@ where
 		backend.mapping().write_hashes(mapping_commitment)?;
 	} else {
 		backend.mapping().write_none(header.hash())?;
-	}
+	};
 
 	Ok(())
 }


### PR DESCRIPTION
This PR fixes genesis block not accessible issue (https://github.com/paritytech/frontier/issues/78) which blockchains started even before `EthereumRuntimeRPCApi` runtime API version `4` (current latest version) still have.

Because some blockchains has runtime API version lower than `4` at genesis block, `has_api` conditional becomes `false` for those blockchains. That means, ethereum genesis block cannot be properly mapped. (For example, our chains have runtime API version `1` at genesis block). Regardless of the runtime version it has at genesis block, genesis block should be properly synced.