### PR TITLE
Give error message out

### DIFF
--- a/frame/evm/precompile/dispatch/src/lib.rs
+++ b/frame/evm/precompile/dispatch/src/lib.rs
@@ -94,8 +94,10 @@ where
 					output: Default::default(),
 				})
 			}
-			Err(_) => Err(PrecompileFailure::Error {
-				exit_status: ExitError::Other("dispatch execution failed".into()),
+			Err(e) => Err(PrecompileFailure::Error {
+				exit_status: ExitError::Other(
+					format!("dispatch execution failed: {}", <&'static str>::from(e)).into(),
+				),
 			}),
 		}
 	}


### PR DESCRIPTION
It is better to give the dispatch error message out, this is very useful when debugging.