### PR TITLE
Check ec pairing precompile input size is a multiple of 192 (like in geth)

### DIFF
--- a/frame/evm/precompile/bn128/src/lib.rs
+++ b/frame/evm/precompile/bn128/src/lib.rs
@@ -173,6 +173,12 @@ impl Precompile for Bn128Pairing {
 			handle.record_cost(Bn128Pairing::BASE_GAS_COST)?;
 			U256::one()
 		} else {
+			if handle.input().len() % 192 > 0 {
+				return Err(PrecompileFailure::Error {
+					exit_status: ExitError::Other("bad elliptic curve pairing size".into()),
+				});
+			}
+
 			// (a, b_a, b_b - each 64-byte affine coordinates)
 			let elements = handle.input().len() / 192;
 


### PR DESCRIPTION
Current implementation differs from [geth implementation](https://github.com/ethereum/go-ethereum/blob/v1.10.26/core/vm/contracts.go#L506) and returns different output.