### PR TITLE
Fix overflow in reading gas_price

### DIFF
--- a/client/rpc/src/eth/cache/mod.rs
+++ b/client/rpc/src/eth/cache/mod.rs
@@ -348,7 +348,7 @@ where
 			let base_fee = client.runtime_api().gas_price(&id).unwrap_or_default();
 			let receipts = handler.current_receipts(&id);
 			let mut result = FeeHistoryCacheItem {
-				base_fee: base_fee.as_u64(),
+				base_fee: base_fee.low_u64(),
 				gas_used_ratio: 0f64,
 				rewards: Vec::new(),
 			};


### PR DESCRIPTION
Fixes a potential overflow when reading `gas_price` as a `u64`. (Yes, that would be quite expensive...)

Question: would it make sense to bump the data type in `FeeHistoryCacheItem` to a `u128`? 