### PR TITLE
feat: only use substrate-wasm-builder when `std` feature is enabled

### DIFF
--- a/template/runtime/Cargo.toml
+++ b/template/runtime/Cargo.toml
@@ -57,7 +57,7 @@ pallet-evm-precompile-simple = { workspace = true }
 pallet-hotfix-sufficients = { workspace = true }
 
 [build-dependencies]
-substrate-wasm-builder = { workspace = true }
+substrate-wasm-builder = { workspace = true, optional = true }
 
 [features]
 default = ["std", "with-rocksdb-weights"]
@@ -78,6 +78,7 @@ std = [
 	"sp-std/std",
 	"sp-transaction-pool/std",
 	"sp-version/std",
+	"substrate-wasm-builder",
 	# Substrate FRAME
 	"frame-benchmarking/std",
 	"frame-executive/std",

--- a/template/runtime/build.rs
+++ b/template/runtime/build.rs
@@ -1,7 +1,6 @@
-use substrate_wasm_builder::WasmBuilder;
-
 fn main() {
-	WasmBuilder::new()
+	#[cfg(feature = "std")]
+	substrate_wasm_builder::WasmBuilder::new()
 		.with_current_project()
 		.export_heap_base()
 		.import_memory()


### PR DESCRIPTION
related PR: paritytech/substrate#12790