### PR TITLE
Move the `weight_per_gas` function into `fp-evm`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2134,6 +2134,7 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-core",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -2453,6 +2454,7 @@ dependencies = [
 name = "frontier-template-runtime"
 version = "0.0.0"
 dependencies = [
+ "fp-evm",
  "fp-rpc",
  "fp-self-contained",
  "frame-benchmarking",

--- a/primitives/evm/Cargo.toml
+++ b/primitives/evm/Cargo.toml
@@ -17,6 +17,7 @@ serde = { workspace = true, optional = true }
 # Substrate
 frame-support = { workspace = true }
 sp-core = { workspace = true }
+sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 
 [features]
@@ -29,5 +30,6 @@ std = [
 	# Substrate
 	"frame-support/std",
 	"sp-core/std",
+	"sp-runtime/std",
 	"sp-std/std",
 ]

--- a/primitives/evm/src/lib.rs
+++ b/primitives/evm/src/lib.rs
@@ -20,11 +20,12 @@
 mod precompile;
 mod validation;
 
-use frame_support::weights::Weight;
+use frame_support::weights::{constants::WEIGHT_REF_TIME_PER_MILLIS, Weight};
 use scale_codec::{Decode, Encode};
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 use sp_core::{H160, U256};
+use sp_runtime::Perbill;
 use sp_std::vec::Vec;
 
 pub use evm::{
@@ -96,5 +97,50 @@ pub trait FeeCalculator {
 impl FeeCalculator for () {
 	fn min_gas_price() -> (U256, Weight) {
 		(U256::zero(), Weight::zero())
+	}
+}
+
+/// `WeightPerGas` is an approximate ratio of the amount of Weight per Gas.
+/// u64 works for approximations because Weight is a very small unit compared to gas.
+///
+/// `GAS_PER_MILLIS * WEIGHT_MILLIS_PER_BLOCK * TXN_RATIO ~= BLOCK_GAS_LIMIT`
+/// `WEIGHT_PER_GAS = WEIGHT_REF_TIME_PER_MILLIS / GAS_PER_MILLIS
+///                 = WEIGHT_REF_TIME_PER_MILLIS / (BLOCK_GAS_LIMIT / TXN_RATIO / WEIGHT_MILLIS_PER_BLOCK)
+///                 = TXN_RATIO * (WEIGHT_REF_TIME_PER_MILLIS * WEIGHT_MILLIS_PER_BLOCK) / BLOCK_GAS_LIMIT`
+///
+/// For example, given the 2000ms Weight, from which 75% only are used for transactions,
+/// the total EVM execution gas limit is `GAS_PER_MILLIS * 2000 * 75% = BLOCK_GAS_LIMIT`.
+pub fn weight_per_gas(
+	block_gas_limit: u64,
+	txn_ratio: Perbill,
+	weight_millis_per_block: u64,
+) -> u64 {
+	let weight_per_block = WEIGHT_REF_TIME_PER_MILLIS.saturating_mul(weight_millis_per_block);
+	let weight_per_gas = (txn_ratio * weight_per_block).saturating_div(block_gas_limit);
+	assert!(
+		weight_per_gas >= 1,
+		"WeightPerGas must greater than or equal with 1"
+	);
+	weight_per_gas
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_weight_per_gas() {
+		assert_eq!(
+			weight_per_gas(15_000_000, Perbill::from_percent(75), 500),
+			25_000
+		);
+		assert_eq!(
+			weight_per_gas(75_000_000, Perbill::from_percent(75), 2_000),
+			20_000
+		);
+		assert_eq!(
+			weight_per_gas(1_500_000_000_000, Perbill::from_percent(75), 2_000),
+			1
+		);
 	}
 }

--- a/template/runtime/Cargo.toml
+++ b/template/runtime/Cargo.toml
@@ -43,6 +43,7 @@ pallet-transaction-payment = { workspace = true }
 pallet-transaction-payment-rpc-runtime-api = { workspace = true }
 
 # Frontier
+fp-evm = { workspace = true }
 fp-rpc = { workspace = true }
 fp-self-contained = { workspace = true }
 # Frontier FRAME
@@ -94,6 +95,7 @@ std = [
 	"pallet-transaction-payment/std",
 	"pallet-transaction-payment-rpc-runtime-api/std",
 	# Frontier
+	"fp-evm/std",
 	"fp-rpc/std",
 	"fp-self-contained/std",
 	# Frontier FRAME

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -42,6 +42,7 @@ use pallet_grandpa::{
 };
 use pallet_transaction_payment::CurrencyAdapter;
 // Frontier
+use fp_evm::weight_per_gas;
 use fp_rpc::TransactionStatus;
 use pallet_ethereum::{Call::transact, Transaction as EthereumTransaction};
 use pallet_evm::{
@@ -313,30 +314,6 @@ impl<F: FindAuthor<u32>> FindAuthor<H160> for FindAuthorTruncated<F> {
 		}
 		None
 	}
-}
-
-/// `WeightPerGas` is an approximate ratio of the amount of Weight per Gas.
-/// u64 works for approximations because Weight is a very small unit compared to gas.
-///
-/// `GAS_PER_MILLIS * WEIGHT_MILLIS_PER_BLOCK * TXN_RATIO ~= BLOCK_GAS_LIMIT`
-/// `WEIGHT_PER_GAS = WEIGHT_REF_TIME_PER_MILLIS / GAS_PER_MILLIS
-///                 = WEIGHT_REF_TIME_PER_MILLIS / (BLOCK_GAS_LIMIT / TXN_RATIO / WEIGHT_MILLIS_PER_BLOCK)
-///                 = TXN_RATIO * (WEIGHT_REF_TIME_PER_MILLIS * WEIGHT_MILLIS_PER_BLOCK) / BLOCK_GAS_LIMIT`
-///
-/// For example, given the 2000ms Weight, from which 75% only are used for transactions,
-/// the total EVM execution gas limit is `GAS_PER_MILLIS * 2000 * 75% = BLOCK_GAS_LIMIT`.
-pub fn weight_per_gas(
-	block_gas_limit: u64,
-	txn_ratio: Perbill,
-	weight_millis_per_block: u64,
-) -> u64 {
-	let weight_per_block = WEIGHT_REF_TIME_PER_MILLIS.saturating_mul(weight_millis_per_block);
-	let weight_per_gas = (txn_ratio * weight_per_block).saturating_div(block_gas_limit);
-	assert!(
-		weight_per_gas >= 1,
-		"WeightPerGas must greater than or equal with 1"
-	);
-	weight_per_gas
 }
 
 const BLOCK_GAS_LIMIT: u64 = 75_000_000;


### PR DESCRIPTION
Move the `weight_per_gas` function into `fp-evm` to make downstream users can use it directly