### PR TITLE
[cli] Using from_args() to have --version

### DIFF
--- a/template/node/src/command.rs
+++ b/template/node/src/command.rs
@@ -15,7 +15,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use clap::Parser;
 // Substrate
 use sc_cli::{ChainSpec, RuntimeVersion, SubstrateCli};
 use sc_service::DatabaseSource;
@@ -73,7 +72,7 @@ impl SubstrateCli for Cli {
 
 /// Parse and run command line arguments
 pub fn run() -> sc_cli::Result<()> {
-	let cli = Cli::parse();
+	let cli = Cli::from_args();
 
 	match &cli.subcommand {
 		Some(Subcommand::Key(cmd)) => cmd.run(&cli),


### PR DESCRIPTION
Current `cli` is not handling `--version`:

```
./target/release/frontier-template-node --version
error: unexpected argument '--version' found

Usage: frontier-template-node [OPTIONS] [COMMAND]

For more information, try '--help'.
```

This PR uses `Cli::from_args()` as substrate does ([ref](https://github.com/paritytech/substrate/blob/master/bin/node/cli/src/command.rs#L84)).  So we can have it, like:
```
./target/release/frontier-template-node --version                                                    
frontier-template-node 0.0.0-08dfe8986e3
```