### PR TITLE
`BlockId` removal in `fc-rpc`

### DIFF
--- a/client/rpc/src/eth/block.rs
+++ b/client/rpc/src/eth/block.rs
@@ -27,7 +27,10 @@ use sc_transaction_pool::ChainApi;
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_core::hashing::keccak_256;
-use sp_runtime::traits::{BlakeTwo256, Block as BlockT};
+use sp_runtime::{
+	generic::BlockId,
+	traits::{BlakeTwo256, Block as BlockT},
+};
 // Frontier
 use fc_rpc_core::types::*;
 use fp_rpc::EthereumRuntimeRPCApi;
@@ -51,7 +54,7 @@ where
 		let block_data_cache = Arc::clone(&self.block_data_cache);
 		let backend = Arc::clone(&self.backend);
 
-		let id = match frontier_backend_client::load_hash::<B, C>(
+		let substrate_hash = match frontier_backend_client::load_hash::<B, C>(
 			client.as_ref(),
 			backend.as_ref(),
 			hash,
@@ -61,19 +64,21 @@ where
 			Some(hash) => hash,
 			_ => return Ok(None),
 		};
-		let substrate_hash = client
-			.expect_block_hash_from_id(&id)
-			.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
 
-		let schema =
-			frontier_backend_client::onchain_storage_schema::<B, C, BE>(client.as_ref(), id);
+		let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(
+			client.as_ref(),
+			substrate_hash,
+		);
 
 		let block = block_data_cache.current_block(schema, substrate_hash).await;
 		let statuses = block_data_cache
 			.current_transaction_statuses(schema, substrate_hash)
 			.await;
 
-		let base_fee = client.runtime_api().gas_price(&id).unwrap_or_default();
+		let base_fee = client
+			.runtime_api()
+			.gas_price(&BlockId::Hash(substrate_hash))
+			.unwrap_or_default();
 
 		match (block, statuses) {
 			(Some(block), Some(statuses)) => Ok(Some(rich_block_build(
@@ -108,8 +113,10 @@ where
 			.expect_block_hash_from_id(&id)
 			.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
 
-		let schema =
-			frontier_backend_client::onchain_storage_schema::<B, C, BE>(client.as_ref(), id);
+		let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(
+			client.as_ref(),
+			substrate_hash,
+		);
 
 		let block = block_data_cache.current_block(schema, substrate_hash).await;
 		let statuses = block_data_cache
@@ -135,7 +142,7 @@ where
 	}
 
 	pub fn block_transaction_count_by_hash(&self, hash: H256) -> Result<Option<U256>> {
-		let id = match frontier_backend_client::load_hash::<B, C>(
+		let substrate_hash = match frontier_backend_client::load_hash::<B, C>(
 			self.client.as_ref(),
 			self.backend.as_ref(),
 			hash,
@@ -145,14 +152,16 @@ where
 			Some(hash) => hash,
 			_ => return Ok(None),
 		};
-		let schema =
-			frontier_backend_client::onchain_storage_schema::<B, C, BE>(self.client.as_ref(), id);
+		let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(
+			self.client.as_ref(),
+			substrate_hash,
+		);
 		let block = self
 			.overrides
 			.schemas
 			.get(&schema)
 			.unwrap_or(&self.overrides.fallback)
-			.current_block(&id);
+			.current_block(substrate_hash);
 
 		match block {
 			Some(block) => Ok(Some(U256::from(block.transactions.len()))),
@@ -176,14 +185,20 @@ where
 			Some(id) => id,
 			None => return Ok(None),
 		};
-		let schema =
-			frontier_backend_client::onchain_storage_schema::<B, C, BE>(self.client.as_ref(), id);
+		let substrate_hash = self
+			.client
+			.expect_block_hash_from_id(&id)
+			.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
+		let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(
+			self.client.as_ref(),
+			substrate_hash,
+		);
 		let block = self
 			.overrides
 			.schemas
 			.get(&schema)
 			.unwrap_or(&self.overrides.fallback)
-			.current_block(&id);
+			.current_block(substrate_hash);
 
 		match block {
 			Some(block) => Ok(Some(U256::from(block.transactions.len()))),

--- a/client/rpc/src/eth/cache/mod.rs
+++ b/client/rpc/src/eth/cache/mod.rs
@@ -132,7 +132,7 @@ impl<B: BlockT> EthBlockDataCacheTask<B> {
 						task_tx.clone(),
 						move |handler| FetchedCurrentBlock {
 							block_hash,
-							block: handler.current_block(&BlockId::Hash(block_hash)),
+							block: handler.current_block(block_hash),
 						},
 					),
 					FetchedCurrentBlock { block_hash, block } => {
@@ -162,8 +162,7 @@ impl<B: BlockT> EthBlockDataCacheTask<B> {
 						task_tx.clone(),
 						move |handler| FetchedCurrentTransactionStatuses {
 							block_hash,
-							statuses: handler
-								.current_transaction_statuses(&BlockId::Hash(block_hash)),
+							statuses: handler.current_transaction_statuses(block_hash),
 						},
 					),
 					FetchedCurrentTransactionStatuses {
@@ -319,9 +318,8 @@ where
 			FeeHistoryCacheItem,
 			Option<u64>
 		) {
-			let id = BlockId::Hash(hash);
 			let schema =
-				frontier_backend_client::onchain_storage_schema::<B, C, BE>(client.as_ref(), id);
+				frontier_backend_client::onchain_storage_schema::<B, C, BE>(client.as_ref(), hash);
 			let handler = overrides
 				.schemas
 				.get(&schema)
@@ -343,10 +341,10 @@ where
 					.collect()
 			};
 
-			let block = handler.current_block(&id);
+			let block = handler.current_block(hash);
 			let mut block_number: Option<u64> = None;
-			let base_fee = client.runtime_api().gas_price(&id).unwrap_or_default();
-			let receipts = handler.current_receipts(&id);
+			let base_fee = client.runtime_api().gas_price(&BlockId::Hash(hash)).unwrap_or_default();
+			let receipts = handler.current_receipts(hash);
 			let mut result = FeeHistoryCacheItem {
 				base_fee: if base_fee > U256::from(u64::MAX) { u64::MAX } else { base_fee.low_u64() },
 				gas_used_ratio: 0f64,

--- a/client/rpc/src/eth/client.rs
+++ b/client/rpc/src/eth/client.rs
@@ -69,18 +69,16 @@ where
 	}
 
 	pub fn author(&self) -> Result<H160> {
-		let block = BlockId::Hash(self.client.info().best_hash);
-		let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(
-			self.client.as_ref(),
-			block,
-		);
+		let hash = self.client.info().best_hash;
+		let schema =
+			frontier_backend_client::onchain_storage_schema::<B, C, BE>(self.client.as_ref(), hash);
 
 		Ok(self
 			.overrides
 			.schemas
 			.get(&schema)
 			.unwrap_or(&self.overrides.fallback)
-			.current_block(&block)
+			.current_block(hash)
 			.ok_or_else(|| internal_err("fetching author through override failed"))?
 			.header
 			.beneficiary)

--- a/client/rpc/src/eth/execute.rs
+++ b/client/rpc/src/eth/execute.rs
@@ -325,7 +325,8 @@ where
 		const MIN_GAS_PER_TX: U256 = U256([21_000, 0, 0, 0]);
 
 		// Get best hash (TODO missing support for estimating gas historically)
-		let best_hash = client.info().best_hash;
+		let substrate_hash = client.info().best_hash;
+		let id = BlockId::Hash(substrate_hash);
 
 		// Adapt request for gas estimation.
 		let request = EGA::adapt_request(request);
@@ -339,7 +340,7 @@ where
 			if let Some(to) = request.to {
 				let to_code = client
 					.runtime_api()
-					.account_code_at(&BlockId::Hash(best_hash), to)
+					.account_code_at(&id, to)
 					.map_err(|err| internal_err(format!("runtime error: {:?}", err)))?;
 				if to_code.is_empty() {
 					return Ok(MIN_GAS_PER_TX);
@@ -361,9 +362,10 @@ where
 		};
 
 		let block_gas_limit = {
-			let substrate_hash = client.info().best_hash;
-			let id = BlockId::Hash(substrate_hash);
-			let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(&client, id);
+			let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(
+				&client,
+				substrate_hash,
+			);
 			let block = block_data_cache.current_block(schema, substrate_hash).await;
 
 			block
@@ -389,7 +391,7 @@ where
 			}
 			// If gas limit is not specified in the request we either use the multiplier if supported
 			// or fallback to the block gas limit.
-			None => match api.gas_limit_multiplier_support(&BlockId::Hash(best_hash)) {
+			None => match api.gas_limit_multiplier_support(&id) {
 				Ok(_) => max_gas_limit,
 				_ => block_gas_limit,
 			},
@@ -400,7 +402,7 @@ where
 			let gas_price = gas_price.unwrap_or_default();
 			if gas_price > U256::zero() {
 				let balance = api
-					.account_basic(&BlockId::Hash(best_hash), from)
+					.account_basic(&id, from)
 					.map_err(|err| internal_err(format!("runtime error: {:?}", err)))?
 					.balance;
 				let mut available = balance;
@@ -468,7 +470,7 @@ where
 							// Legacy pre-london
 							#[allow(deprecated)]
 							api.call_before_version_2(
-								&BlockId::Hash(best_hash),
+								&id,
 								from.unwrap_or_default(),
 								to,
 								data,
@@ -484,7 +486,7 @@ where
 							// Post-london
 							#[allow(deprecated)]
 							api.call_before_version_4(
-								&BlockId::Hash(best_hash),
+								&id,
 								from.unwrap_or_default(),
 								to,
 								data,
@@ -501,7 +503,7 @@ where
 							// Post-london + access list support
 							let access_list = access_list.unwrap_or_default();
 							api.call(
-								&BlockId::Hash(best_hash),
+								&id,
 								from.unwrap_or_default(),
 								to,
 								data,
@@ -529,7 +531,7 @@ where
 							// Legacy pre-london
 							#[allow(deprecated)]
 							api.create_before_version_2(
-								&BlockId::Hash(best_hash),
+								&id,
 								from.unwrap_or_default(),
 								data,
 								value.unwrap_or_default(),
@@ -544,7 +546,7 @@ where
 							// Post-london
 							#[allow(deprecated)]
 							api.create_before_version_4(
-								&BlockId::Hash(best_hash),
+								&id,
 								from.unwrap_or_default(),
 								data,
 								value.unwrap_or_default(),
@@ -560,7 +562,7 @@ where
 							// Post-london + access list support
 							let access_list = access_list.unwrap_or_default();
 							api.create(
-								&BlockId::Hash(best_hash),
+								&id,
 								from.unwrap_or_default(),
 								data,
 								value.unwrap_or_default(),
@@ -592,7 +594,7 @@ where
 		let api_version = if let Ok(Some(api_version)) =
 			client
 				.runtime_api()
-				.api_version::<dyn EthereumRuntimeRPCApi<B>>(&BlockId::Hash(best_hash))
+				.api_version::<dyn EthereumRuntimeRPCApi<B>>(&id)
 		{
 			api_version
 		} else {

--- a/client/rpc/src/eth/fee.rs
+++ b/client/rpc/src/eth/fee.rs
@@ -131,9 +131,13 @@ where
 					response.gas_used_ratio.last(),
 					response.base_fee_per_gas.last(),
 				) {
+					let substrate_hash =
+						self.client.expect_block_hash_from_id(&id).map_err(|_| {
+							internal_err(format!("Expect block number from id: {}", id))
+						})?;
 					let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(
 						self.client.as_ref(),
-						id,
+						substrate_hash,
 					);
 					let handler = self
 						.overrides
@@ -142,7 +146,7 @@ where
 						.unwrap_or(&self.overrides.fallback);
 					let default_elasticity = sp_runtime::Permill::from_parts(125_000);
 					let elasticity = handler
-						.elasticity(&id)
+						.elasticity(substrate_hash)
 						.unwrap_or(default_elasticity)
 						.deconstruct();
 					let elasticity = elasticity as f64 / 1_000_000f64;

--- a/client/rpc/src/eth/filter.rs
+++ b/client/rpc/src/eth/filter.rs
@@ -249,7 +249,7 @@ where
 
 					let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(
 						client.as_ref(),
-						id,
+						substrate_hash,
 					);
 
 					let block = block_data_cache.current_block(schema, substrate_hash).await;
@@ -366,7 +366,7 @@ where
 
 		let mut ret: Vec<Log> = Vec::new();
 		if let Some(hash) = filter.block_hash {
-			let id = match frontier_backend_client::load_hash::<B, C>(
+			let substrate_hash = match frontier_backend_client::load_hash::<B, C>(
 				client.as_ref(),
 				backend.as_ref(),
 				hash,
@@ -376,12 +376,10 @@ where
 				Some(hash) => hash,
 				_ => return Ok(Vec::new()),
 			};
-			let substrate_hash = client
-				.expect_block_hash_from_id(&id)
-				.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
-
-			let schema =
-				frontier_backend_client::onchain_storage_schema::<B, C, BE>(client.as_ref(), id);
+			let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(
+				client.as_ref(),
+				substrate_hash,
+			);
 
 			let block = block_data_cache.current_block(schema, substrate_hash).await;
 			let statuses = block_data_cache
@@ -462,7 +460,8 @@ where
 			.expect_block_hash_from_id(&id)
 			.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
 
-		let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(client, id);
+		let schema =
+			frontier_backend_client::onchain_storage_schema::<B, C, BE>(client, substrate_hash);
 
 		let block = block_data_cache.current_block(schema, substrate_hash).await;
 

--- a/client/rpc/src/eth/state.rs
+++ b/client/rpc/src/eth/state.rs
@@ -92,16 +92,20 @@ where
 			self.backend.as_ref(),
 			Some(number),
 		) {
+			let substrate_hash = self
+				.client
+				.expect_block_hash_from_id(&id)
+				.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
 			let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(
 				self.client.as_ref(),
-				id,
+				substrate_hash,
 			);
 			Ok(self
 				.overrides
 				.schemas
 				.get(&schema)
 				.unwrap_or(&self.overrides.fallback)
-				.storage_at(&id, address, index)
+				.storage_at(substrate_hash, address, index)
 				.unwrap_or_default())
 		} else {
 			Ok(H256::default())
@@ -165,9 +169,13 @@ where
 			self.backend.as_ref(),
 			Some(number),
 		) {
+			let substrate_hash = self
+				.client
+				.expect_block_hash_from_id(&id)
+				.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
 			let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(
 				self.client.as_ref(),
-				id,
+				substrate_hash,
 			);
 
 			Ok(self
@@ -175,7 +183,7 @@ where
 				.schemas
 				.get(&schema)
 				.unwrap_or(&self.overrides.fallback)
-				.account_code_at(&id, address)
+				.account_code_at(substrate_hash, address)
 				.unwrap_or_default()
 				.into())
 		} else {

--- a/client/rpc/src/eth/transaction.rs
+++ b/client/rpc/src/eth/transaction.rs
@@ -126,7 +126,7 @@ where
 			}
 		};
 
-		let id = match frontier_backend_client::load_hash::<B, C>(
+		let substrate_hash = match frontier_backend_client::load_hash::<B, C>(
 			client.as_ref(),
 			backend.as_ref(),
 			hash,
@@ -136,19 +136,21 @@ where
 			Some(hash) => hash,
 			_ => return Ok(None),
 		};
-		let substrate_hash = client
-			.expect_block_hash_from_id(&id)
-			.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
 
-		let schema =
-			frontier_backend_client::onchain_storage_schema::<B, C, BE>(client.as_ref(), id);
+		let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(
+			client.as_ref(),
+			substrate_hash,
+		);
 
 		let block = block_data_cache.current_block(schema, substrate_hash).await;
 		let statuses = block_data_cache
 			.current_transaction_statuses(schema, substrate_hash)
 			.await;
 
-		let base_fee = client.runtime_api().gas_price(&id).unwrap_or_default();
+		let base_fee = client
+			.runtime_api()
+			.gas_price(&BlockId::Hash(substrate_hash))
+			.unwrap_or_default();
 
 		match (block, statuses) {
 			(Some(block), Some(statuses)) => Ok(Some(transaction_build(
@@ -170,7 +172,7 @@ where
 		let block_data_cache = Arc::clone(&self.block_data_cache);
 		let backend = Arc::clone(&self.backend);
 
-		let id = match frontier_backend_client::load_hash::<B, C>(
+		let substrate_hash = match frontier_backend_client::load_hash::<B, C>(
 			client.as_ref(),
 			backend.as_ref(),
 			hash,
@@ -180,21 +182,23 @@ where
 			Some(hash) => hash,
 			_ => return Ok(None),
 		};
-		let substrate_hash = client
-			.expect_block_hash_from_id(&id)
-			.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
 
 		let index = index.value();
 
-		let schema =
-			frontier_backend_client::onchain_storage_schema::<B, C, BE>(client.as_ref(), id);
+		let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(
+			client.as_ref(),
+			substrate_hash,
+		);
 
 		let block = block_data_cache.current_block(schema, substrate_hash).await;
 		let statuses = block_data_cache
 			.current_transaction_statuses(schema, substrate_hash)
 			.await;
 
-		let base_fee = client.runtime_api().gas_price(&id).unwrap_or_default();
+		let base_fee = client
+			.runtime_api()
+			.gas_price(&BlockId::Hash(substrate_hash))
+			.unwrap_or_default();
 
 		match (block, statuses) {
 			(Some(block), Some(statuses)) => {
@@ -237,8 +241,10 @@ where
 			.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
 
 		let index = index.value();
-		let schema =
-			frontier_backend_client::onchain_storage_schema::<B, C, BE>(client.as_ref(), id);
+		let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(
+			client.as_ref(),
+			substrate_hash,
+		);
 
 		let block = block_data_cache.current_block(schema, substrate_hash).await;
 		let statuses = block_data_cache
@@ -284,7 +290,7 @@ where
 			None => return Ok(None),
 		};
 
-		let id = match frontier_backend_client::load_hash::<B, C>(
+		let substrate_hash = match frontier_backend_client::load_hash::<B, C>(
 			client.as_ref(),
 			backend.as_ref(),
 			hash,
@@ -294,12 +300,11 @@ where
 			Some(hash) => hash,
 			_ => return Ok(None),
 		};
-		let substrate_hash = client
-			.expect_block_hash_from_id(&id)
-			.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
 
-		let schema =
-			frontier_backend_client::onchain_storage_schema::<B, C, BE>(client.as_ref(), id);
+		let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(
+			client.as_ref(),
+			substrate_hash,
+		);
 		let handler = overrides
 			.schemas
 			.get(&schema)
@@ -309,8 +314,9 @@ where
 		let statuses = block_data_cache
 			.current_transaction_statuses(schema, substrate_hash)
 			.await;
-		let receipts = handler.current_receipts(&id);
-		let is_eip1559 = handler.is_eip1559(&id);
+
+		let receipts = handler.current_receipts(substrate_hash);
+		let is_eip1559 = handler.is_eip1559(substrate_hash);
 
 		match (block, statuses, receipts) {
 			(Some(block), Some(statuses), Some(receipts)) => {
@@ -385,7 +391,7 @@ where
 					EthereumTransaction::EIP2930(t) => t.gas_price,
 					EthereumTransaction::EIP1559(t) => client
 						.runtime_api()
-						.gas_price(&id)
+						.gas_price(&BlockId::Hash(substrate_hash))
 						.unwrap_or_default()
 						.checked_add(t.max_priority_fee_per_gas)
 						.unwrap_or_else(U256::max_value)

--- a/client/rpc/src/eth_pubsub.rs
+++ b/client/rpc/src/eth_pubsub.rs
@@ -229,20 +229,20 @@ where
 						.import_notification_stream()
 						.filter_map(move |notification| {
 							if notification.is_new_best {
-								let id = BlockId::Hash(notification.hash);
+								let substrate_hash = notification.hash;
 
 								let schema = frontier_backend_client::onchain_storage_schema::<
 									B,
 									C,
 									BE,
-								>(client.as_ref(), id);
+								>(client.as_ref(), notification.hash);
 								let handler = overrides
 									.schemas
 									.get(&schema)
 									.unwrap_or(&overrides.fallback);
 
-								let block = handler.current_block(&id);
-								let receipts = handler.current_receipts(&id);
+								let block = handler.current_block(substrate_hash);
+								let receipts = handler.current_receipts(substrate_hash);
 
 								match (receipts, block) {
 									(Some(receipts), Some(block)) => {
@@ -269,19 +269,17 @@ where
 						.import_notification_stream()
 						.filter_map(move |notification| {
 							if notification.is_new_best {
-								let id = BlockId::Hash(notification.hash);
-
 								let schema = frontier_backend_client::onchain_storage_schema::<
 									B,
 									C,
 									BE,
-								>(client.as_ref(), id);
+								>(client.as_ref(), notification.hash);
 								let handler = overrides
 									.schemas
 									.get(&schema)
 									.unwrap_or(&overrides.fallback);
 
-								let block = handler.current_block(&id);
+								let block = handler.current_block(notification.hash);
 								futures::future::ready(block)
 							} else {
 								futures::future::ready(None)

--- a/client/rpc/src/overrides/mod.rs
+++ b/client/rpc/src/overrides/mod.rs
@@ -48,22 +48,22 @@ pub struct OverrideHandle<Block: BlockT> {
 /// optimized implementation avoids spawning a runtime and the overhead associated with it.
 pub trait StorageOverride<Block: BlockT> {
 	/// For a given account address, returns pallet_evm::AccountCodes.
-	fn account_code_at(&self, block: &BlockId<Block>, address: H160) -> Option<Vec<u8>>;
+	fn account_code_at(&self, block_hash: Block::Hash, address: H160) -> Option<Vec<u8>>;
 	/// For a given account address and index, returns pallet_evm::AccountStorages.
-	fn storage_at(&self, block: &BlockId<Block>, address: H160, index: U256) -> Option<H256>;
+	fn storage_at(&self, block_hash: Block::Hash, address: H160, index: U256) -> Option<H256>;
 	/// Return the current block.
-	fn current_block(&self, block: &BlockId<Block>) -> Option<EthereumBlock>;
+	fn current_block(&self, block_hash: Block::Hash) -> Option<EthereumBlock>;
 	/// Return the current receipt.
-	fn current_receipts(&self, block: &BlockId<Block>) -> Option<Vec<ethereum::ReceiptV3>>;
+	fn current_receipts(&self, block_hash: Block::Hash) -> Option<Vec<ethereum::ReceiptV3>>;
 	/// Return the current transaction status.
 	fn current_transaction_statuses(
 		&self,
-		block: &BlockId<Block>,
+		block_hash: Block::Hash,
 	) -> Option<Vec<TransactionStatus>>;
 	/// Return the base fee at the given height.
-	fn elasticity(&self, block: &BlockId<Block>) -> Option<Permill>;
+	fn elasticity(&self, block_hash: Block::Hash) -> Option<Permill>;
 	/// Return `true` if the request BlockId is post-eip1559.
-	fn is_eip1559(&self, block: &BlockId<Block>) -> bool;
+	fn is_eip1559(&self, block_hash: Block::Hash) -> bool;
 }
 
 fn storage_prefix_build(module: &[u8], storage: &[u8]) -> Vec<u8> {
@@ -99,27 +99,27 @@ where
 	C::Api: EthereumRuntimeRPCApi<Block>,
 {
 	/// For a given account address, returns pallet_evm::AccountCodes.
-	fn account_code_at(&self, block: &BlockId<Block>, address: H160) -> Option<Vec<u8>> {
+	fn account_code_at(&self, block_hash: Block::Hash, address: H160) -> Option<Vec<u8>> {
 		self.client
 			.runtime_api()
-			.account_code_at(block, address)
+			.account_code_at(&BlockId::Hash(block_hash), address)
 			.ok()
 	}
 
 	/// For a given account address and index, returns pallet_evm::AccountStorages.
-	fn storage_at(&self, block: &BlockId<Block>, address: H160, index: U256) -> Option<H256> {
+	fn storage_at(&self, block_hash: Block::Hash, address: H160, index: U256) -> Option<H256> {
 		self.client
 			.runtime_api()
-			.storage_at(block, address, index)
+			.storage_at(&BlockId::Hash(block_hash), address, index)
 			.ok()
 	}
 
 	/// Return the current block.
-	fn current_block(&self, block: &BlockId<Block>) -> Option<ethereum::BlockV2> {
+	fn current_block(&self, block_hash: Block::Hash) -> Option<ethereum::BlockV2> {
 		let api = self.client.runtime_api();
 
 		let api_version = if let Ok(Some(api_version)) =
-			api.api_version::<dyn EthereumRuntimeRPCApi<Block>>(block)
+			api.api_version::<dyn EthereumRuntimeRPCApi<Block>>(&BlockId::Hash(block_hash))
 		{
 			api_version
 		} else {
@@ -127,19 +127,21 @@ where
 		};
 		if api_version == 1 {
 			#[allow(deprecated)]
-			let old_block = api.current_block_before_version_2(block).ok()?;
+			let old_block = api
+				.current_block_before_version_2(&BlockId::Hash(block_hash))
+				.ok()?;
 			old_block.map(|block| block.into())
 		} else {
-			api.current_block(block).ok()?
+			api.current_block(&BlockId::Hash(block_hash)).ok()?
 		}
 	}
 
 	/// Return the current receipt.
-	fn current_receipts(&self, block: &BlockId<Block>) -> Option<Vec<ethereum::ReceiptV3>> {
+	fn current_receipts(&self, block_hash: Block::Hash) -> Option<Vec<ethereum::ReceiptV3>> {
 		let api = self.client.runtime_api();
 
 		let api_version = if let Ok(Some(api_version)) =
-			api.api_version::<dyn EthereumRuntimeRPCApi<Block>>(block)
+			api.api_version::<dyn EthereumRuntimeRPCApi<Block>>(&BlockId::Hash(block_hash))
 		{
 			api_version
 		} else {
@@ -147,7 +149,9 @@ where
 		};
 		if api_version < 4 {
 			#[allow(deprecated)]
-			let old_receipts = api.current_receipts_before_version_4(block).ok()?;
+			let old_receipts = api
+				.current_receipts_before_version_4(&BlockId::Hash(block_hash))
+				.ok()?;
 			old_receipts.map(|receipts| {
 				receipts
 					.into_iter()
@@ -162,35 +166,41 @@ where
 					.collect()
 			})
 		} else {
-			self.client.runtime_api().current_receipts(block).ok()?
+			self.client
+				.runtime_api()
+				.current_receipts(&BlockId::Hash(block_hash))
+				.ok()?
 		}
 	}
 
 	/// Return the current transaction status.
 	fn current_transaction_statuses(
 		&self,
-		block: &BlockId<Block>,
+		block_hash: Block::Hash,
 	) -> Option<Vec<TransactionStatus>> {
 		self.client
 			.runtime_api()
-			.current_transaction_statuses(block)
+			.current_transaction_statuses(&BlockId::Hash(block_hash))
 			.ok()?
 	}
 
 	/// Return the elasticity multiplier at the give post-eip1559 height.
-	fn elasticity(&self, block: &BlockId<Block>) -> Option<Permill> {
-		if self.is_eip1559(block) {
-			self.client.runtime_api().elasticity(block).ok()?
+	fn elasticity(&self, block_hash: Block::Hash) -> Option<Permill> {
+		if self.is_eip1559(block_hash) {
+			self.client
+				.runtime_api()
+				.elasticity(&BlockId::Hash(block_hash))
+				.ok()?
 		} else {
 			None
 		}
 	}
 
-	fn is_eip1559(&self, block: &BlockId<Block>) -> bool {
+	fn is_eip1559(&self, block_hash: Block::Hash) -> bool {
 		if let Ok(Some(api_version)) = self
 			.client
 			.runtime_api()
-			.api_version::<dyn EthereumRuntimeRPCApi<Block>>(block)
+			.api_version::<dyn EthereumRuntimeRPCApi<Block>>(&BlockId::Hash(block_hash))
 		{
 			return api_version >= 2;
 		}

--- a/client/rpc/src/overrides/schema_v1_override.rs
+++ b/client/rpc/src/overrides/schema_v1_override.rs
@@ -22,7 +22,6 @@ use ethereum_types::{H160, H256, U256};
 use scale_codec::Decode;
 // Substrate
 use sc_client_api::backend::{Backend, StateBackend, StorageProvider};
-use sp_api::BlockId;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{
 	traits::{BlakeTwo256, Block as BlockT},
@@ -57,12 +56,10 @@ where
 	BE: Backend<B> + 'static,
 	BE::State: StateBackend<BlakeTwo256>,
 {
-	fn query_storage<T: Decode>(&self, id: &BlockId<B>, key: &StorageKey) -> Option<T> {
-		if let Ok(Some(hash)) = self.client.block_hash_from_id(id) {
-			if let Ok(Some(data)) = self.client.storage(hash, key) {
-				if let Ok(result) = Decode::decode(&mut &data.0[..]) {
-					return Some(result);
-				}
+	fn query_storage<T: Decode>(&self, block_hash: B::Hash, key: &StorageKey) -> Option<T> {
+		if let Ok(Some(data)) = self.client.storage(block_hash, key) {
+			if let Ok(result) = Decode::decode(&mut &data.0[..]) {
+				return Some(result);
 			}
 		}
 		None
@@ -77,14 +74,14 @@ where
 	BE::State: StateBackend<BlakeTwo256>,
 {
 	/// For a given account address, returns pallet_evm::AccountCodes.
-	fn account_code_at(&self, block: &BlockId<B>, address: H160) -> Option<Vec<u8>> {
+	fn account_code_at(&self, block_hash: B::Hash, address: H160) -> Option<Vec<u8>> {
 		let mut key: Vec<u8> = storage_prefix_build(PALLET_EVM, EVM_ACCOUNT_CODES);
 		key.extend(blake2_128_extend(address.as_bytes()));
-		self.query_storage::<Vec<u8>>(block, &StorageKey(key))
+		self.query_storage::<Vec<u8>>(block_hash, &StorageKey(key))
 	}
 
 	/// For a given account address and index, returns pallet_evm::AccountStorages.
-	fn storage_at(&self, block: &BlockId<B>, address: H160, index: U256) -> Option<H256> {
+	fn storage_at(&self, block_hash: B::Hash, address: H160, index: U256) -> Option<H256> {
 		let tmp: &mut [u8; 32] = &mut [0; 32];
 		index.to_big_endian(tmp);
 
@@ -92,13 +89,13 @@ where
 		key.extend(blake2_128_extend(address.as_bytes()));
 		key.extend(blake2_128_extend(tmp));
 
-		self.query_storage::<H256>(block, &StorageKey(key))
+		self.query_storage::<H256>(block_hash, &StorageKey(key))
 	}
 
 	/// Return the current block.
-	fn current_block(&self, block: &BlockId<B>) -> Option<ethereum::BlockV2> {
+	fn current_block(&self, block_hash: B::Hash) -> Option<ethereum::BlockV2> {
 		self.query_storage::<ethereum::BlockV0>(
-			block,
+			block_hash,
 			&StorageKey(storage_prefix_build(
 				PALLET_ETHEREUM,
 				ETHEREUM_CURRENT_BLOCK,
@@ -108,9 +105,9 @@ where
 	}
 
 	/// Return the current receipt.
-	fn current_receipts(&self, block: &BlockId<B>) -> Option<Vec<ethereum::ReceiptV3>> {
+	fn current_receipts(&self, block_hash: B::Hash) -> Option<Vec<ethereum::ReceiptV3>> {
 		self.query_storage::<Vec<ethereum::ReceiptV0>>(
-			block,
+			block_hash,
 			&StorageKey(storage_prefix_build(
 				PALLET_ETHEREUM,
 				ETHEREUM_CURRENT_RECEIPTS,
@@ -132,9 +129,9 @@ where
 	}
 
 	/// Return the current transaction status.
-	fn current_transaction_statuses(&self, block: &BlockId<B>) -> Option<Vec<TransactionStatus>> {
+	fn current_transaction_statuses(&self, block_hash: B::Hash) -> Option<Vec<TransactionStatus>> {
 		self.query_storage::<Vec<TransactionStatus>>(
-			block,
+			block_hash,
 			&StorageKey(storage_prefix_build(
 				PALLET_ETHEREUM,
 				ETHEREUM_CURRENT_TRANSACTION_STATUS,
@@ -143,11 +140,11 @@ where
 	}
 
 	/// Prior to eip-1559 there is no elasticity.
-	fn elasticity(&self, _block: &BlockId<B>) -> Option<Permill> {
+	fn elasticity(&self, _block_hash: B::Hash) -> Option<Permill> {
 		None
 	}
 
-	fn is_eip1559(&self, _block: &BlockId<B>) -> bool {
+	fn is_eip1559(&self, _block_hash: B::Hash) -> bool {
 		false
 	}
 }

--- a/client/rpc/src/overrides/schema_v2_override.rs
+++ b/client/rpc/src/overrides/schema_v2_override.rs
@@ -22,7 +22,6 @@ use ethereum_types::{H160, H256, U256};
 use scale_codec::Decode;
 // Substrate
 use sc_client_api::backend::{Backend, StateBackend, StorageProvider};
-use sp_api::BlockId;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{
 	traits::{BlakeTwo256, Block as BlockT},
@@ -57,12 +56,10 @@ where
 	BE: Backend<B> + 'static,
 	BE::State: StateBackend<BlakeTwo256>,
 {
-	fn query_storage<T: Decode>(&self, id: &BlockId<B>, key: &StorageKey) -> Option<T> {
-		if let Ok(Some(hash)) = self.client.block_hash_from_id(id) {
-			if let Ok(Some(data)) = self.client.storage(hash, key) {
-				if let Ok(result) = Decode::decode(&mut &data.0[..]) {
-					return Some(result);
-				}
+	fn query_storage<T: Decode>(&self, block_hash: B::Hash, key: &StorageKey) -> Option<T> {
+		if let Ok(Some(data)) = self.client.storage(block_hash, key) {
+			if let Ok(result) = Decode::decode(&mut &data.0[..]) {
+				return Some(result);
 			}
 		}
 		None
@@ -77,14 +74,14 @@ where
 	BE::State: StateBackend<BlakeTwo256>,
 {
 	/// For a given account address, returns pallet_evm::AccountCodes.
-	fn account_code_at(&self, block: &BlockId<B>, address: H160) -> Option<Vec<u8>> {
+	fn account_code_at(&self, block_hash: B::Hash, address: H160) -> Option<Vec<u8>> {
 		let mut key: Vec<u8> = storage_prefix_build(PALLET_EVM, EVM_ACCOUNT_CODES);
 		key.extend(blake2_128_extend(address.as_bytes()));
-		self.query_storage::<Vec<u8>>(block, &StorageKey(key))
+		self.query_storage::<Vec<u8>>(block_hash, &StorageKey(key))
 	}
 
 	/// For a given account address and index, returns pallet_evm::AccountStorages.
-	fn storage_at(&self, block: &BlockId<B>, address: H160, index: U256) -> Option<H256> {
+	fn storage_at(&self, block_hash: B::Hash, address: H160, index: U256) -> Option<H256> {
 		let tmp: &mut [u8; 32] = &mut [0; 32];
 		index.to_big_endian(tmp);
 
@@ -92,13 +89,13 @@ where
 		key.extend(blake2_128_extend(address.as_bytes()));
 		key.extend(blake2_128_extend(tmp));
 
-		self.query_storage::<H256>(block, &StorageKey(key))
+		self.query_storage::<H256>(block_hash, &StorageKey(key))
 	}
 
 	/// Return the current block.
-	fn current_block(&self, block: &BlockId<B>) -> Option<ethereum::BlockV2> {
+	fn current_block(&self, block_hash: B::Hash) -> Option<ethereum::BlockV2> {
 		self.query_storage::<ethereum::BlockV2>(
-			block,
+			block_hash,
 			&StorageKey(storage_prefix_build(
 				PALLET_ETHEREUM,
 				ETHEREUM_CURRENT_BLOCK,
@@ -107,9 +104,9 @@ where
 	}
 
 	/// Return the current receipt.
-	fn current_receipts(&self, block: &BlockId<B>) -> Option<Vec<ethereum::ReceiptV3>> {
+	fn current_receipts(&self, block_hash: B::Hash) -> Option<Vec<ethereum::ReceiptV3>> {
 		self.query_storage::<Vec<ethereum::ReceiptV0>>(
-			block,
+			block_hash,
 			&StorageKey(storage_prefix_build(
 				PALLET_ETHEREUM,
 				ETHEREUM_CURRENT_RECEIPTS,
@@ -131,9 +128,9 @@ where
 	}
 
 	/// Return the current transaction status.
-	fn current_transaction_statuses(&self, block: &BlockId<B>) -> Option<Vec<TransactionStatus>> {
+	fn current_transaction_statuses(&self, block_hash: B::Hash) -> Option<Vec<TransactionStatus>> {
 		self.query_storage::<Vec<TransactionStatus>>(
-			block,
+			block_hash,
 			&StorageKey(storage_prefix_build(
 				PALLET_ETHEREUM,
 				ETHEREUM_CURRENT_TRANSACTION_STATUS,
@@ -142,10 +139,10 @@ where
 	}
 
 	/// Return the elasticity at the given height.
-	fn elasticity(&self, block: &BlockId<B>) -> Option<Permill> {
+	fn elasticity(&self, block_hash: B::Hash) -> Option<Permill> {
 		let default_elasticity = Some(Permill::from_parts(125_000));
 		let elasticity = self.query_storage::<Permill>(
-			block,
+			block_hash,
 			&StorageKey(storage_prefix_build(PALLET_BASE_FEE, BASE_FEE_ELASTICITY)),
 		);
 		if elasticity.is_some() {
@@ -155,7 +152,7 @@ where
 		}
 	}
 
-	fn is_eip1559(&self, _block: &BlockId<B>) -> bool {
+	fn is_eip1559(&self, _block_hash: B::Hash) -> bool {
 		true
 	}
 }

--- a/client/rpc/src/overrides/schema_v3_override.rs
+++ b/client/rpc/src/overrides/schema_v3_override.rs
@@ -22,7 +22,6 @@ use ethereum_types::{H160, H256, U256};
 use scale_codec::Decode;
 // Substrate
 use sc_client_api::backend::{Backend, StateBackend, StorageProvider};
-use sp_api::BlockId;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{
 	traits::{BlakeTwo256, Block as BlockT},
@@ -57,12 +56,10 @@ where
 	BE: Backend<B> + 'static,
 	BE::State: StateBackend<BlakeTwo256>,
 {
-	fn query_storage<T: Decode>(&self, id: &BlockId<B>, key: &StorageKey) -> Option<T> {
-		if let Ok(Some(hash)) = self.client.block_hash_from_id(id) {
-			if let Ok(Some(data)) = self.client.storage(hash, key) {
-				if let Ok(result) = Decode::decode(&mut &data.0[..]) {
-					return Some(result);
-				}
+	fn query_storage<T: Decode>(&self, block_hash: B::Hash, key: &StorageKey) -> Option<T> {
+		if let Ok(Some(data)) = self.client.storage(block_hash, key) {
+			if let Ok(result) = Decode::decode(&mut &data.0[..]) {
+				return Some(result);
 			}
 		}
 		None
@@ -77,14 +74,14 @@ where
 	BE::State: StateBackend<BlakeTwo256>,
 {
 	/// For a given account address, returns pallet_evm::AccountCodes.
-	fn account_code_at(&self, block: &BlockId<B>, address: H160) -> Option<Vec<u8>> {
+	fn account_code_at(&self, block_hash: B::Hash, address: H160) -> Option<Vec<u8>> {
 		let mut key: Vec<u8> = storage_prefix_build(PALLET_EVM, EVM_ACCOUNT_CODES);
 		key.extend(blake2_128_extend(address.as_bytes()));
-		self.query_storage::<Vec<u8>>(block, &StorageKey(key))
+		self.query_storage::<Vec<u8>>(block_hash, &StorageKey(key))
 	}
 
 	/// For a given account address and index, returns pallet_evm::AccountStorages.
-	fn storage_at(&self, block: &BlockId<B>, address: H160, index: U256) -> Option<H256> {
+	fn storage_at(&self, block_hash: B::Hash, address: H160, index: U256) -> Option<H256> {
 		let tmp: &mut [u8; 32] = &mut [0; 32];
 		index.to_big_endian(tmp);
 
@@ -92,13 +89,13 @@ where
 		key.extend(blake2_128_extend(address.as_bytes()));
 		key.extend(blake2_128_extend(tmp));
 
-		self.query_storage::<H256>(block, &StorageKey(key))
+		self.query_storage::<H256>(block_hash, &StorageKey(key))
 	}
 
 	/// Return the current block.
-	fn current_block(&self, block: &BlockId<B>) -> Option<ethereum::BlockV2> {
+	fn current_block(&self, block_hash: B::Hash) -> Option<ethereum::BlockV2> {
 		self.query_storage::<ethereum::BlockV2>(
-			block,
+			block_hash,
 			&StorageKey(storage_prefix_build(
 				PALLET_ETHEREUM,
 				ETHEREUM_CURRENT_BLOCK,
@@ -107,9 +104,9 @@ where
 	}
 
 	/// Return the current receipt.
-	fn current_receipts(&self, block: &BlockId<B>) -> Option<Vec<ethereum::ReceiptV3>> {
+	fn current_receipts(&self, block_hash: B::Hash) -> Option<Vec<ethereum::ReceiptV3>> {
 		self.query_storage::<Vec<ethereum::ReceiptV3>>(
-			block,
+			block_hash,
 			&StorageKey(storage_prefix_build(
 				PALLET_ETHEREUM,
 				ETHEREUM_CURRENT_RECEIPTS,
@@ -118,9 +115,9 @@ where
 	}
 
 	/// Return the current transaction status.
-	fn current_transaction_statuses(&self, block: &BlockId<B>) -> Option<Vec<TransactionStatus>> {
+	fn current_transaction_statuses(&self, block_hash: B::Hash) -> Option<Vec<TransactionStatus>> {
 		self.query_storage::<Vec<TransactionStatus>>(
-			block,
+			block_hash,
 			&StorageKey(storage_prefix_build(
 				PALLET_ETHEREUM,
 				ETHEREUM_CURRENT_TRANSACTION_STATUS,
@@ -129,10 +126,10 @@ where
 	}
 
 	/// Return the elasticity at the given height.
-	fn elasticity(&self, block: &BlockId<B>) -> Option<Permill> {
+	fn elasticity(&self, block_hash: B::Hash) -> Option<Permill> {
 		let default_elasticity = Some(Permill::from_parts(125_000));
 		let elasticity = self.query_storage::<Permill>(
-			block,
+			block_hash,
 			&StorageKey(storage_prefix_build(PALLET_BASE_FEE, BASE_FEE_ELASTICITY)),
 		);
 		if elasticity.is_some() {
@@ -142,7 +139,7 @@ where
 		}
 	}
 
-	fn is_eip1559(&self, _block: &BlockId<B>) -> bool {
+	fn is_eip1559(&self, _block_hash: B::Hash) -> bool {
 		true
 	}
 }


### PR DESCRIPTION
Substrate [refactored](https://github.com/paritytech/substrate/issues/11292) away `BlockId` usage in favor of `Hash`. This PR aims to align `fc-rpc` with that strategy whenever possible.