### PR TITLE
feat: add a new post log type into header digest and provide a compatible mapping-sync worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,6 +1928,7 @@ name = "fc-mapping-sync"
 version = "2.0.0-dev"
 dependencies = [
  "fc-db",
+ "fc-storage",
  "fp-consensus",
  "fp-rpc",
  "futures",

--- a/client/mapping-sync/Cargo.toml
+++ b/client/mapping-sync/Cargo.toml
@@ -21,5 +21,6 @@ sp-blockchain = { workspace = true }
 sp-runtime = { workspace = true }
 # Frontier
 fc-db = { workspace = true }
+fc-storage = { workspace = true }
 fp-consensus = { workspace = true, features = ["default"] }
 fp-rpc = { workspace = true, features = ["default"] }

--- a/primitives/consensus/src/lib.rs
+++ b/primitives/consensus/src/lib.rs
@@ -34,16 +34,6 @@ pub enum Log {
 	Post(PostLog),
 }
 
-impl Log {
-	pub fn into_hashes(self) -> Hashes {
-		match self {
-			Log::Post(PostLog::Hashes(post_hashes)) => post_hashes,
-			Log::Post(PostLog::Block(block)) => Hashes::from_block(block),
-			Log::Pre(PreLog::Block(block)) => Hashes::from_block(block),
-		}
-	}
-}
-
 #[derive(Decode, Encode, Clone, PartialEq, Eq)]
 pub enum PreLog {
 	#[codec(index = 3)]
@@ -52,10 +42,15 @@ pub enum PreLog {
 
 #[derive(Decode, Encode, Clone, PartialEq, Eq)]
 pub enum PostLog {
+	/// Ethereum block hash and txn hashes.
 	#[codec(index = 1)]
 	Hashes(Hashes),
+	/// Ethereum block.
 	#[codec(index = 2)]
 	Block(ethereum::BlockV2),
+	/// Ethereum block hash.
+	#[codec(index = 3)]
+	BlockHash(H256),
 }
 
 #[derive(Decode, Encode, Clone, PartialEq, Eq)]
@@ -68,17 +63,13 @@ pub struct Hashes {
 
 impl Hashes {
 	pub fn from_block(block: ethereum::BlockV2) -> Self {
-		let mut transaction_hashes = Vec::new();
-
-		for t in &block.transactions {
-			transaction_hashes.push(t.hash());
-		}
-
-		let block_hash = block.header.hash();
-
 		Hashes {
-			transaction_hashes,
-			block_hash,
+			block_hash: block.header.hash(),
+			transaction_hashes: block
+				.transactions
+				.into_iter()
+				.map(|txn| txn.hash())
+				.collect(),
 		}
 	}
 }

--- a/template/node/src/eth.rs
+++ b/template/node/src/eth.rs
@@ -128,6 +128,7 @@ pub fn spawn_frontier_tasks<RuntimeApi, Executor>(
 			Duration::new(6, 0),
 			client.clone(),
 			backend,
+			overrides.clone(),
 			frontier_backend,
 			3,
 			0,


### PR DESCRIPTION
## Motivation

When using frontier to build project, I found that when a block contains more ethereum transactions, the substrate block header also gets bigger, it is caused by frontier consensus digests, which contains all ethereum txn hashes.

We currently use the frontier consensus digests for syncing block-to-transaction-hash mapping.

In this PR, I added a new `PostLog::BlockHash(H256)` and provide a compatible `MappingSyncWorker`.
It provides a way to solve the problem I mentioned above, but for pruning nodes, they won't be able to know old transaction hashes.

If you want to use this new post log, you also need to change some code of the `pallet-ethereum` like below.
Maybe later we can provide `pallet-ethereum` with genesis-based configuration to choose which `PostLog` to use.

```diff
fn store_block(post_log: bool, block_number: U256) {
	let mut transactions = Vec::new();
	let mut statuses = Vec::new();
	let mut receipts = Vec::new();
	let mut logs_bloom = Bloom::default();
	let mut cumulative_gas_used = U256::zero();
	for (transaction, status, receipt) in Pending::<T>::get() {
		transactions.push(transaction);
		statuses.push(status);
		receipts.push(receipt.clone());
                 ...
	}

	let ommers = Vec::<ethereum::Header>::new();
	let receipts_root = ethereum::util::ordered_trie_root(
		receipts.iter().map(ethereum::EnvelopedEncodable::encode),
	);
	let partial_header = ethereum::PartialHeader { ... };
	let block = ethereum::Block::new(partial_header, transactions.clone(), ommers);

	CurrentBlock::<T>::put(block.clone());
	CurrentReceipts::<T>::put(receipts.clone());
	CurrentTransactionStatuses::<T>::put(statuses.clone());
	BlockHash::<T>::insert(block_number, block.header.hash());

	if post_log {
		let digest = DigestItem::Consensus(
			FRONTIER_ENGINE_ID,
-			PostLog::Hashes(fp_consensus::Hashes::from_block(block)).encode(),
+			PostLog::BlockHash(block.header.hash()).encode(),
		);
		frame_system::Pallet::<T>::deposit_log(digest);
	}
}
```