### PR TITLE
Allow for precompiles to have arbitrary addresses, potentially more than one. 

### DIFF
--- a/frame/evm/precompile/dispatch/src/tests.rs
+++ b/frame/evm/precompile/dispatch/src/tests.rs
@@ -73,8 +73,14 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	}
 	.assimilate_storage(&mut t)
 	.expect("Pallet balances storage can be assimilated");
-	GenesisBuild::<Test>::assimilate_storage(&pallet_evm::GenesisConfig { accounts }, &mut t)
-		.unwrap();
+	GenesisBuild::<Test>::assimilate_storage(
+		&pallet_evm::GenesisConfig {
+			accounts,
+			precompiles: vec![],
+		},
+		&mut t,
+	)
+	.unwrap();
 	t.into()
 }
 

--- a/frame/evm/src/tests.rs
+++ b/frame/evm/src/tests.rs
@@ -67,6 +67,8 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 		},
 	);
 
+	let precompiles = vec![];
+
 	pallet_balances::GenesisConfig::<Test> {
 		// Create the block author account with some balance.
 		balances: vec![(
@@ -76,7 +78,14 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	}
 	.assimilate_storage(&mut t)
 	.expect("Pallet balances storage can be assimilated");
-	GenesisBuild::<Test>::assimilate_storage(&crate::GenesisConfig { accounts }, &mut t).unwrap();
+	GenesisBuild::<Test>::assimilate_storage(
+		&crate::GenesisConfig {
+			accounts,
+			precompiles,
+		},
+		&mut t,
+	)
+	.unwrap();
 	t.into()
 }
 

--- a/template/node/src/chain_spec.rs
+++ b/template/node/src/chain_spec.rs
@@ -250,6 +250,17 @@ fn testnet_genesis(
 				);
 				map
 			},
+			precompiles: vec![
+				// Ethereum precompiles :
+				(b"ECRecover".to_vec(), H160::from_low_u64_be(1)),
+				(b"Sha256".to_vec(), H160::from_low_u64_be(2)),
+				(b"Ripemd160".to_vec(), H160::from_low_u64_be(3)),
+				(b"Identity".to_vec(), H160::from_low_u64_be(4)),
+				(b"Modexp".to_vec(), H160::from_low_u64_be(5)),
+				// Non-Frontier specific nor Ethereum precompiles :
+				(b"Sha3FIPS256".to_vec(), H160::from_low_u64_be(1024)),
+				(b"Sha3FIPS256".to_vec(), H160::from_low_u64_be(1025)),
+			],
 		},
 		ethereum: Default::default(),
 		dynamic_fee: Default::default(),


### PR DESCRIPTION
The main modification is the addition of a new `StorageDoubleMap` into `pallet-evm`:
https://github.com/paritytech/frontier/blob/71e440dfdbf98bab6fc6e1d64b7750b0fcfbda3f/frame/evm/src/lib.rs#L517-L527