### PR TITLE
fp-account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1743,7 +1743,7 @@ dependencies = [
  "fixed-hash",
  "impl-codec",
  "impl-rlp",
- "impl-serde",
+ "impl-serde 0.4.0",
  "scale-info",
  "tiny-keccak",
 ]
@@ -1776,7 +1776,7 @@ dependencies = [
  "fixed-hash",
  "impl-codec",
  "impl-rlp",
- "impl-serde",
+ "impl-serde 0.4.0",
  "primitive-types",
  "scale-info",
  "uint",
@@ -2152,6 +2152,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "fp-account"
+version = "1.0.0-dev"
+dependencies = [
+ "hex",
+ "impl-serde 0.3.2",
+ "libsecp256k1",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sha3",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+]
+
+[[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
 dependencies = [
@@ -2461,6 +2478,7 @@ dependencies = [
  "fc-rpc",
  "fc-rpc-core",
  "fc-storage",
+ "fp-account",
  "fp-dynamic-fee",
  "fp-evm",
  "fp-rpc",
@@ -2517,6 +2535,7 @@ dependencies = [
 name = "frontier-template-runtime"
 version = "0.0.0"
 dependencies = [
+ "fp-account",
  "fp-evm",
  "fp-rpc",
  "fp-self-contained",
@@ -3176,6 +3195,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
 dependencies = [
  "rlp",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4869,6 +4897,7 @@ version = "6.0.0-dev"
 dependencies = [
  "environmental",
  "evm",
+ "fp-account",
  "fp-evm",
  "frame-benchmarking",
  "frame-support",
@@ -5542,7 +5571,7 @@ dependencies = [
  "fixed-hash",
  "impl-codec",
  "impl-rlp",
- "impl-serde",
+ "impl-serde 0.4.0",
  "scale-info",
  "uint",
 ]
@@ -7887,7 +7916,7 @@ dependencies = [
  "futures",
  "hash-db",
  "hash256-std-hasher",
- "impl-serde",
+ "impl-serde 0.4.0",
  "lazy_static",
  "libsecp256k1",
  "log",
@@ -8221,7 +8250,7 @@ name = "sp-storage"
 version = "7.0.0"
 source = "git+https://github.com/paritytech/substrate?branch=master#1837f423b494254e1d27834b1c9da34b2c0c2375"
 dependencies = [
- "impl-serde",
+ "impl-serde 0.4.0",
  "parity-scale-codec",
  "ref-cast",
  "serde",
@@ -8309,7 +8338,7 @@ name = "sp-version"
 version = "5.0.0"
 source = "git+https://github.com/paritytech/substrate?branch=master#1837f423b494254e1d27834b1c9da34b2c0c2375"
 dependencies = [
- "impl-serde",
+ "impl-serde 0.4.0",
  "parity-scale-codec",
  "parity-wasm",
  "scale-info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
 	"client/db",
 	"client/storage",
 	"client/mapping-sync",
+	"primitives/account",
 	"primitives/consensus",
 	"primitives/dynamic-fee",
 	"primitives/evm",
@@ -41,15 +42,18 @@ environmental = { version = "1.1.3", default-features = false }
 ethereum = { version = "0.14.0", default-features = false }
 ethereum-types = { version = "0.14.1", default-features = false }
 evm = { version = "0.37.0", default-features = false }
+impl-serde = { version = "0.3.1", default-features = false }
 jsonrpsee = "0.16.2"
 kvdb-rocksdb = "0.17.0"
-libsecp256k1 = "0.7.1"
+libsecp256k1 = { version = "0.7.1", default-features = false }
+log = { version = "0.4.17", default-features = false }
 parity-db = "0.4.2"
 rlp = { version = "0.5", default-features = false }
 scale-codec = { package = "parity-scale-codec", version = "3.2.1", default-features = false, features = ["derive"] }
 scale-info = { version = "2.3.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha3 = { version = "0.10", default-features = false }
 # Substrate Client
 sc-basic-authorship = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-block-builder = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate", branch = "master" }
@@ -124,6 +128,7 @@ fc-rpc = { version = "2.0.0-dev", path = "client/rpc" }
 fc-rpc-core = { version = "1.1.0-dev", path = "client/rpc-core" }
 fc-storage = { version = "1.0.0-dev", path = "client/storage" }
 # Frontier Primitive
+fp-account = { version = "1.0.0-dev", path = "primitives/account", default-features = false }
 fp-consensus = { version = "2.0.0-dev", path = "primitives/consensus", default-features = false }
 fp-dynamic-fee = { version = "1.0.0", path = "primitives/dynamic-fee", default-features = false }
 fp-ethereum = { version = "1.0.0-dev", path = "primitives/ethereum", default-features = false }

--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -16,7 +16,7 @@ environmental = { workspace = true, optional = true }
 evm = { workspace = true, features = ["with-codec"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 impl-trait-for-tuples = "0.2.2"
-log = { version = "0.4.17", default-features = false }
+log = { workspace = true }
 rlp = { workspace = true }
 scale-codec = { package = "parity-scale-codec", workspace = true }
 scale-info = { workspace = true }
@@ -30,6 +30,7 @@ sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 # Frontier
+fp-account = { workspace = true }
 fp-evm = { workspace = true }
 
 [dev-dependencies]
@@ -59,6 +60,7 @@ std = [
 	"sp-std/std",
 	# Frontier
 	"fp-evm/std",
+	"fp-account/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -84,6 +84,7 @@ use sp_std::{cmp::min, vec::Vec};
 pub use evm::{
 	Config as EvmConfig, Context, ExitError, ExitFatal, ExitReason, ExitRevert, ExitSucceed,
 };
+use fp_account::AccountId20;
 #[cfg(feature = "std")]
 use fp_evm::GenesisAccount;
 pub use fp_evm::{
@@ -603,6 +604,24 @@ where
 	}
 }
 
+/// Ensure that the address is AccountId20.
+pub struct EnsureAccountId20;
+
+impl<OuterOrigin> EnsureAddressOrigin<OuterOrigin> for EnsureAccountId20
+where
+	OuterOrigin: Into<Result<RawOrigin<AccountId20>, OuterOrigin>> + From<RawOrigin<AccountId20>>,
+{
+	type Success = AccountId20;
+
+	fn try_address_origin(address: &H160, origin: OuterOrigin) -> Result<AccountId20, OuterOrigin> {
+		let acc: AccountId20 = AccountId20::from(*address);
+		origin.into().and_then(|o| match o {
+			RawOrigin::Signed(who) if who == acc => Ok(who),
+			r => Err(OuterOrigin::from(r)),
+		})
+	}
+}
+
 pub trait AddressMapping<A> {
 	fn into_account_id(address: H160) -> A;
 }
@@ -613,6 +632,16 @@ pub struct IdentityAddressMapping;
 impl AddressMapping<H160> for IdentityAddressMapping {
 	fn into_account_id(address: H160) -> H160 {
 		address
+	}
+}
+
+/// This is basically identical to IdentityAddressMapping,
+/// but it works for any type that is `Into<H160>` (e.g.: `AccountId20`).
+pub struct IntoAddressMapping;
+
+impl<T: From<H160>> AddressMapping<T> for IntoAddressMapping {
+	fn into_account_id(address: H160) -> T {
+		address.into()
 	}
 }
 

--- a/primitives/account/Cargo.toml
+++ b/primitives/account/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "fp-account"
+version = "1.0.0-dev"
+license = "Apache-2.0"
+description = "Primitives for Frontier AccountId20."
+authors = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
+
+[dependencies]
+hex = { version = "0.4.3", default-features = false }
+impl-serde = { workspace = true }
+libsecp256k1 = { workspace = true, default-features = false }
+log = { workspace = true }
+scale-codec = { package = "parity-scale-codec", workspace = true }
+scale-info = { workspace = true }
+serde = { workspace = true }
+sha3 = { workspace = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+
+[dev-dependencies]
+
+[features]
+default = ["std"]
+std = [
+	"impl-serde/std",
+	"hex/std",
+	"libsecp256k1/std",
+	"log/std",
+	"sha3/std",
+	"serde/std",
+	# Substrate
+	"sp-io/std",
+	"sp-core/std",
+	"sp-runtime/std",
+]

--- a/primitives/account/src/lib.rs
+++ b/primitives/account/src/lib.rs
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: Apache-2.0
+// This file is part of Frontier.
+//
+// Copyright (c) 2020-2023 Parity Technologies (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use scale_codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+use sha3::{Digest, Keccak256};
+use sp_core::{ecdsa, H160};
+
+#[cfg(feature = "std")]
+pub use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+#[derive(
+	Debug,
+	Eq,
+	PartialEq,
+	Copy,
+	Clone,
+	Encode,
+	Decode,
+	TypeInfo,
+	MaxEncodedLen,
+	Default,
+	PartialOrd,
+	Ord,
+)]
+pub struct AccountId20(pub [u8; 20]);
+
+#[cfg(feature = "std")]
+impl_serde::impl_fixed_hash_serde!(AccountId20, 20);
+
+#[cfg(feature = "std")]
+impl std::fmt::Display for AccountId20 {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		let address = hex::encode(self.0).trim_start_matches("0x").to_lowercase();
+		let address_hash = hex::encode(Keccak256::digest(&address.as_bytes()));
+
+		let checksum: String =
+			address
+				.char_indices()
+				.fold(String::from("0x"), |mut acc, (index, address_char)| {
+					let n = u16::from_str_radix(&address_hash[index..index + 1], 16)
+						.expect("Keccak256 hashed; qed");
+
+					if n > 7 {
+						// make char uppercase if ith character is 9..f
+						acc.push_str(&address_char.to_uppercase().to_string())
+					} else {
+						// already lowercased
+						acc.push(address_char)
+					}
+
+					acc
+				});
+		write!(f, "{}", checksum)
+	}
+}
+
+impl From<[u8; 20]> for AccountId20 {
+	fn from(bytes: [u8; 20]) -> Self {
+		Self(bytes)
+	}
+}
+
+impl Into<[u8; 20]> for AccountId20 {
+	fn into(self) -> [u8; 20] {
+		self.0
+	}
+}
+
+impl From<H160> for AccountId20 {
+	fn from(h160: H160) -> Self {
+		Self(h160.0)
+	}
+}
+
+impl Into<H160> for AccountId20 {
+	fn into(self) -> H160 {
+		H160(self.0)
+	}
+}
+
+impl From<ecdsa::Public> for AccountId20 {
+	fn from(pk: ecdsa::Public) -> Self {
+		let decompressed = libsecp256k1::PublicKey::parse_slice(
+			&pk.0,
+			Some(libsecp256k1::PublicKeyFormat::Compressed),
+		)
+		.expect("bad compressed pk")
+		.serialize();
+		let mut m = [0u8; 64];
+		m.copy_from_slice(&decompressed[1..65]);
+		let account = H160::from_slice(&Keccak256::digest(&m).as_slice()[12..32]);
+		AccountId20(account.into())
+	}
+}
+
+#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Eq, PartialEq, Clone, Encode, Decode, sp_core::RuntimeDebug, TypeInfo)]
+pub struct EthereumSignature(ecdsa::Signature);
+
+impl sp_runtime::traits::Verify for EthereumSignature {
+	type Signer = EthereumSigner;
+	fn verify<L: sp_runtime::traits::Lazy<[u8]>>(&self, mut msg: L, signer: &AccountId20) -> bool {
+		let mut m = [0u8; 32];
+		m.copy_from_slice(Keccak256::digest(msg.get()).as_slice());
+		match sp_io::crypto::secp256k1_ecdsa_recover(self.0.as_ref(), &m) {
+			Ok(pubkey) => {
+				AccountId20(H160::from_slice(&Keccak256::digest(&pubkey).as_slice()[12..32]).0)
+					== *signer
+			}
+			Err(sp_io::EcdsaVerifyError::BadRS) => {
+				log::error!(target: "evm", "Error recovering: Incorrect value of R or S");
+				false
+			}
+			Err(sp_io::EcdsaVerifyError::BadV) => {
+				log::error!(target: "evm", "Error recovering: Incorrect value of V");
+				false
+			}
+			Err(sp_io::EcdsaVerifyError::BadSignature) => {
+				log::error!(target: "evm", "Error recovering: Invalid signature");
+				false
+			}
+		}
+	}
+}
+
+impl EthereumSignature {
+	pub fn new(s: ecdsa::Signature) -> Self {
+		EthereumSignature(s)
+	}
+}
+
+pub struct EthereumSigner([u8; 20]);
+
+impl From<[u8; 20]> for EthereumSigner {
+	fn from(x: [u8; 20]) -> Self {
+		EthereumSigner(x)
+	}
+}
+
+impl sp_runtime::traits::IdentifyAccount for EthereumSigner {
+	type AccountId = AccountId20;
+	fn into_account(self) -> AccountId20 {
+		AccountId20(self.0)
+	}
+}
+
+#[cfg(feature = "std")]
+impl std::fmt::Display for EthereumSigner {
+	fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+		write!(fmt, "{:?}", H160::from_slice(&self.0))
+	}
+}
+
+impl From<ecdsa::Public> for EthereumSigner {
+	fn from(pk: ecdsa::Public) -> Self {
+		let decompressed = libsecp256k1::PublicKey::parse_slice(
+			&pk.0,
+			Some(libsecp256k1::PublicKeyFormat::Compressed),
+		)
+		.expect("bad compressed pk")
+		.serialize();
+		let mut m = [0u8; 64];
+		m.copy_from_slice(&decompressed[1..65]);
+		let account = H160::from_slice(&Keccak256::digest(&m).as_slice()[12..32]);
+		EthereumSigner(account.into())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use sp_core::{ecdsa, Pair, H256};
+	use sp_runtime::traits::IdentifyAccount;
+
+	#[test]
+	fn test_derive_from_secret_key() {
+		let sk = hex::decode("eb3d6b0b0c794f6fd8964b4a28df99d4baa5f9c8d33603c4cc62504daa259358")
+			.unwrap();
+		let hex_acc: [u8; 20] = hex::decode("98fa2838ee6471ae87135880f870a785318e6787")
+			.unwrap()
+			.try_into()
+			.unwrap();
+		let acc = AccountId20::from(hex_acc);
+
+		let pk = ecdsa::Pair::from_seed_slice(&sk).unwrap().public();
+		let signer: EthereumSigner = pk.into();
+
+		assert_eq!(signer.into_account(), acc);
+	}
+
+	#[test]
+	fn test_from_h160() {
+		let m = hex::decode("28490327ff4e60d44b8aadf5478266422ed01232cc712c2d617e5c650ca15b85")
+			.unwrap();
+		let old = AccountId20(H160::from(H256::from_slice(Keccak256::digest(&m).as_slice())).0);
+		let new = AccountId20(H160::from_slice(&Keccak256::digest(&m).as_slice()[12..32]).0);
+		assert_eq!(new, old);
+	}
+
+	#[test]
+	fn test_account_display() {
+		let pk = ecdsa::Pair::from_string("//Alice", None)
+			.expect("static values are valid; qed")
+			.public();
+		let signer: EthereumSigner = pk.into();
+		let account: AccountId20 = signer.into_account();
+		let account_fmt = format!("{}", account);
+		assert_eq!(account_fmt, "0xE04CC55ebEE1cBCE552f250e85c57B70B2E2625b");
+	}
+}

--- a/template/node/Cargo.toml
+++ b/template/node/Cargo.toml
@@ -73,6 +73,7 @@ fc-mapping-sync = { workspace = true }
 fc-rpc = { workspace = true }
 fc-rpc-core = { workspace = true }
 fc-storage = { workspace = true }
+fp-account = { workspace = true }
 fp-dynamic-fee = { workspace = true, features = ["default"] }
 fp-evm = { workspace = true, features = ["default"] }
 fp-rpc = { workspace = true, features = ["default"] }

--- a/template/node/src/benchmarking.rs
+++ b/template/node/src/benchmarking.rs
@@ -25,11 +25,11 @@ use scale_codec::Encode;
 // Substrate
 use sc_cli::Result;
 use sc_client_api::BlockBackend;
-use sp_core::{sr25519, Pair};
+use sp_core::{ecdsa, Pair};
 use sp_inherents::{InherentData, InherentDataProvider};
-use sp_keyring::Sr25519Keyring;
-use sp_runtime::{generic::Era, AccountId32, OpaqueExtrinsic, SaturatedConversion};
+use sp_runtime::{generic::Era, OpaqueExtrinsic, SaturatedConversion};
 // Frontier
+use fp_account::AccountId20;
 use frontier_template_runtime::{self as runtime, AccountId, Balance, BalancesCall, SystemCall};
 
 use crate::client::Client;
@@ -58,7 +58,7 @@ impl frame_benchmarking_cli::ExtrinsicBuilder for RemarkBuilder {
 	}
 
 	fn build(&self, nonce: u32) -> std::result::Result<OpaqueExtrinsic, &'static str> {
-		let acc = Sr25519Keyring::Bob.pair();
+		let acc = ecdsa::Pair::from_string("//Bob", None).expect("static values are valid; qed");
 		let extrinsic: OpaqueExtrinsic = create_benchmark_extrinsic(
 			self.client.as_ref(),
 			acc,
@@ -101,7 +101,7 @@ impl frame_benchmarking_cli::ExtrinsicBuilder for TransferKeepAliveBuilder {
 	}
 
 	fn build(&self, nonce: u32) -> std::result::Result<OpaqueExtrinsic, &'static str> {
-		let acc = Sr25519Keyring::Bob.pair();
+		let acc = ecdsa::Pair::from_string("//Bob", None).expect("static values are valid; qed");
 		let extrinsic: OpaqueExtrinsic = create_benchmark_extrinsic(
 			self.client.as_ref(),
 			acc,
@@ -123,7 +123,7 @@ impl frame_benchmarking_cli::ExtrinsicBuilder for TransferKeepAliveBuilder {
 /// Note: Should only be used for benchmarking.
 pub fn create_benchmark_extrinsic(
 	client: &Client,
-	sender: sr25519::Pair,
+	sender: sp_core::ecdsa::Pair,
 	call: runtime::RuntimeCall,
 	nonce: u32,
 ) -> runtime::UncheckedExtrinsic {
@@ -171,8 +171,8 @@ pub fn create_benchmark_extrinsic(
 
 	runtime::UncheckedExtrinsic::new_signed(
 		call,
-		AccountId32::from(sender.public()).into(),
-		runtime::Signature::Sr25519(signature),
+		AccountId20::from(sender.public()).into(),
+		runtime::Signature::new(signature),
 		extra,
 	)
 }

--- a/template/node/src/chain_spec.rs
+++ b/template/node/src/chain_spec.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 // Substrate
 use sc_service::ChainType;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
-use sp_core::{sr25519, storage::Storage, Pair, Public, H160, U256};
+use sp_core::{ecdsa, storage::Storage, Pair, Public, H160, U256};
 use sp_finality_grandpa::AuthorityId as GrandpaId;
 use sp_runtime::traits::{IdentifyAccount, Verify};
 use sp_state_machine::BasicExternalities;
@@ -78,13 +78,13 @@ pub fn development_config(enable_manual_seal: Option<bool>) -> DevChainSpec {
 				genesis_config: testnet_genesis(
 					wasm_binary,
 					// Sudo account
-					get_account_id_from_seed::<sr25519::Public>("Alice"),
+					get_account_id_from_seed::<ecdsa::Public>("Alice"),
 					// Pre-funded accounts
 					vec![
-						get_account_id_from_seed::<sr25519::Public>("Alice"),
-						get_account_id_from_seed::<sr25519::Public>("Bob"),
-						get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-						get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
+						get_account_id_from_seed::<ecdsa::Public>("Alice"),
+						get_account_id_from_seed::<ecdsa::Public>("Bob"),
+						get_account_id_from_seed::<ecdsa::Public>("Alice//stash"),
+						get_account_id_from_seed::<ecdsa::Public>("Bob//stash"),
 					],
 					// Initial PoA authorities
 					vec![authority_keys_from_seed("Alice")],
@@ -121,21 +121,21 @@ pub fn local_testnet_config() -> ChainSpec {
 				wasm_binary,
 				// Initial PoA authorities
 				// Sudo account
-				get_account_id_from_seed::<sr25519::Public>("Alice"),
+				get_account_id_from_seed::<ecdsa::Public>("Alice"),
 				// Pre-funded accounts
 				vec![
-					get_account_id_from_seed::<sr25519::Public>("Alice"),
-					get_account_id_from_seed::<sr25519::Public>("Bob"),
-					get_account_id_from_seed::<sr25519::Public>("Charlie"),
-					get_account_id_from_seed::<sr25519::Public>("Dave"),
-					get_account_id_from_seed::<sr25519::Public>("Eve"),
-					get_account_id_from_seed::<sr25519::Public>("Ferdie"),
-					get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-					get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
-					get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
-					get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
-					get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
-					get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
+					get_account_id_from_seed::<ecdsa::Public>("Alice"),
+					get_account_id_from_seed::<ecdsa::Public>("Bob"),
+					get_account_id_from_seed::<ecdsa::Public>("Charlie"),
+					get_account_id_from_seed::<ecdsa::Public>("Dave"),
+					get_account_id_from_seed::<ecdsa::Public>("Eve"),
+					get_account_id_from_seed::<ecdsa::Public>("Ferdie"),
+					get_account_id_from_seed::<ecdsa::Public>("Alice//stash"),
+					get_account_id_from_seed::<ecdsa::Public>("Bob//stash"),
+					get_account_id_from_seed::<ecdsa::Public>("Charlie//stash"),
+					get_account_id_from_seed::<ecdsa::Public>("Dave//stash"),
+					get_account_id_from_seed::<ecdsa::Public>("Eve//stash"),
+					get_account_id_from_seed::<ecdsa::Public>("Ferdie//stash"),
 				],
 				vec![
 					authority_keys_from_seed("Alice"),

--- a/template/node/src/command.rs
+++ b/template/node/src/command.rs
@@ -23,6 +23,7 @@ use fc_db::frontier_database_dir;
 
 use crate::{
 	chain_spec,
+	chain_spec::get_account_id_from_seed,
 	cli::{Cli, Subcommand},
 	service::{self, db_config_dir},
 };
@@ -187,7 +188,7 @@ pub fn run() -> sc_cli::Result<()> {
 						Box::new(RemarkBuilder::new(client.clone())),
 						Box::new(TransferKeepAliveBuilder::new(
 							client.clone(),
-							sp_keyring::Sr25519Keyring::Alice.to_account_id(),
+							get_account_id_from_seed::<sp_core::ecdsa::Public>("Alice"),
 							ExistentialDeposit::get(),
 						)),
 					]);

--- a/template/runtime/Cargo.toml
+++ b/template/runtime/Cargo.toml
@@ -43,6 +43,7 @@ pallet-transaction-payment = { workspace = true }
 pallet-transaction-payment-rpc-runtime-api = { workspace = true }
 
 # Frontier
+fp-account = { workspace = true }
 fp-evm = { workspace = true }
 fp-rpc = { workspace = true }
 fp-self-contained = { workspace = true }
@@ -95,6 +96,7 @@ std = [
 	"pallet-transaction-payment/std",
 	"pallet-transaction-payment-rpc-runtime-api/std",
 	# Frontier
+	"fp-account/std",
 	"fp-evm/std",
 	"fp-rpc/std",
 	"fp-self-contained/std",

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -23,7 +23,7 @@ use sp_runtime::{
 		IdentifyAccount, NumberFor, PostDispatchInfoOf, UniqueSaturatedInto, Verify,
 	},
 	transaction_validity::{TransactionSource, TransactionValidity, TransactionValidityError},
-	ApplyExtrinsicResult, ConsensusEngineId, MultiSignature, Perbill, Permill,
+	ApplyExtrinsicResult, ConsensusEngineId, Perbill, Permill,
 };
 use sp_std::{marker::PhantomData, prelude::*};
 use sp_version::RuntimeVersion;
@@ -42,11 +42,12 @@ use pallet_grandpa::{
 };
 use pallet_transaction_payment::CurrencyAdapter;
 // Frontier
+use fp_account::EthereumSignature;
 use fp_evm::weight_per_gas;
 use fp_rpc::TransactionStatus;
 use pallet_ethereum::{Call::transact, PostLogContent, Transaction as EthereumTransaction};
 use pallet_evm::{
-	Account as EVMAccount, EnsureAddressTruncated, FeeCalculator, HashedAddressMapping, Runner,
+	Account as EVMAccount, EnsureAccountId20, FeeCalculator, IntoAddressMapping, Runner,
 };
 
 // A few exports that help ease life for downstream crates.
@@ -61,7 +62,7 @@ use precompiles::FrontierPrecompiles;
 pub type BlockNumber = u32;
 
 /// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
-pub type Signature = MultiSignature;
+pub type Signature = EthereumSignature;
 
 /// Some way of identifying an account on the chain. We intentionally make it equivalent
 /// to the public key of our transaction signing scheme.
@@ -330,9 +331,9 @@ impl pallet_evm::Config for Runtime {
 	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
 	type WeightPerGas = WeightPerGas;
 	type BlockHashMapping = pallet_ethereum::EthereumBlockHashMapping<Self>;
-	type CallOrigin = EnsureAddressTruncated;
-	type WithdrawOrigin = EnsureAddressTruncated;
-	type AddressMapping = HashedAddressMapping<BlakeTwo256>;
+	type CallOrigin = EnsureAccountId20;
+	type WithdrawOrigin = EnsureAccountId20;
+	type AddressMapping = IntoAddressMapping;
 	type Currency = Balances;
 	type RuntimeEvent = RuntimeEvent;
 	type PrecompilesType = FrontierPrecompiles<Self>;
@@ -389,7 +390,7 @@ impl pallet_base_fee::Config for Runtime {
 }
 
 impl pallet_hotfix_sufficients::Config for Runtime {
-	type AddressMapping = HashedAddressMapping<BlakeTwo256>;
+	type AddressMapping = IntoAddressMapping;
 	type WeightInfo = pallet_hotfix_sufficients::weights::SubstrateWeight<Runtime>;
 }
 


### PR DESCRIPTION
Based on [Moonbeam's `AccountId20` implementation](https://github.com/PureStake/moonbeam/tree/master/primitives/account).

Introduces a new `fp-account` crate into `primitives`, as an alternative to Frontier's `H256`->`H160` truncation mapping. 

`H160` addresses live natively on the Substrate runtime, and there's no need for translation between `H256` and `H160`.