### PR TITLE
implement eth_call state override

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2476,6 +2476,7 @@ dependencies = [
  "futures",
  "jsonrpsee",
  "log",
+ "pallet-evm",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc",
  "pallet-transaction-payment-rpc-runtime-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,6 +1999,8 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
+ "sp-state-machine",
+ "sp-storage",
  "substrate-prometheus-endpoint",
  "substrate-test-runtime-client",
  "tempfile",
@@ -2210,6 +2212,7 @@ dependencies = [
  "sp-api",
  "sp-core",
  "sp-runtime",
+ "sp-state-machine",
  "sp-std",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1970,6 +1970,7 @@ dependencies = [
  "fc-rpc-core",
  "fc-storage",
  "fp-ethereum",
+ "fp-evm",
  "fp-rpc",
  "fp-storage",
  "futures",

--- a/client/rpc-core/src/eth.rs
+++ b/client/rpc-core/src/eth.rs
@@ -20,6 +20,7 @@
 
 use ethereum_types::{H160, H256, H64, U256, U64};
 use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
+use std::collections::BTreeMap;
 
 use crate::types::*;
 
@@ -151,7 +152,12 @@ pub trait EthApi {
 
 	/// Call contract, returning the output data.
 	#[method(name = "eth_call")]
-	fn call(&self, request: CallRequest, number: Option<BlockNumber>) -> Result<Bytes>;
+	fn call(
+		&self,
+		request: CallRequest,
+		number: Option<BlockNumber>,
+		state_overrides: Option<BTreeMap<H160, CallStateOverride>>,
+	) -> Result<Bytes>;
 
 	/// Estimate gas needed for execution of given contract.
 	#[method(name = "eth_estimateGas")]

--- a/client/rpc-core/src/types/call_request.rs
+++ b/client/rpc-core/src/types/call_request.rs
@@ -18,8 +18,9 @@
 
 use crate::types::Bytes;
 use ethereum::AccessListItem;
-use ethereum_types::{H160, U256};
+use ethereum_types::{H160, H256, U256};
 use serde::Deserialize;
+use std::collections::BTreeMap;
 
 /// Call request
 #[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize)]
@@ -49,7 +50,23 @@ pub struct CallRequest {
 	/// EIP-2718 type
 	#[serde(rename = "type")]
 	pub transaction_type: Option<U256>,
-	/// Call state override
-	#[serde(rename = "stateOverrides")]
-	pub state_overrides: Option<BTreeMap<H160, CallStateOverride>>,
+}
+
+// State override
+#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
+pub struct CallStateOverride {
+	/// Fake balance to set for the account before executing the call.
+	pub balance: Option<U256>,
+	/// Fake nonce to set for the account before executing the call.
+	pub nonce: Option<U256>,
+	/// Fake EVM bytecode to inject into the account before executing the call.
+	pub code: Option<Bytes>,
+	/// Fake key-value mapping to override all slots in the account storage before
+	/// executing the call.
+	pub state: Option<BTreeMap<H256, H256>>,
+	/// Fake key-value mapping to override individual slots in the account storage before
+	/// executing the call.
+	pub state_diff: Option<BTreeMap<H256, H256>>,
 }

--- a/client/rpc-core/src/types/call_request.rs
+++ b/client/rpc-core/src/types/call_request.rs
@@ -50,6 +50,6 @@ pub struct CallRequest {
 	#[serde(rename = "type")]
 	pub transaction_type: Option<U256>,
 	/// Call state override
-	#[serde(rename = "stateOverride")]
-	pub state_override: Option<CallStateOverride>,
+	#[serde(rename = "stateOverrides")]
+	pub state_overrides: Option<BTreeMap<H160, CallStateOverride>>,
 }

--- a/client/rpc-core/src/types/call_request.rs
+++ b/client/rpc-core/src/types/call_request.rs
@@ -49,4 +49,7 @@ pub struct CallRequest {
 	/// EIP-2718 type
 	#[serde(rename = "type")]
 	pub transaction_type: Option<U256>,
+	/// Call state override
+	#[serde(rename = "stateOverride")]
+	pub state_override: Option<CallStateOverride>,
 }

--- a/client/rpc-core/src/types/mod.rs
+++ b/client/rpc-core/src/types/mod.rs
@@ -40,7 +40,7 @@ pub use self::{
 	block::{Block, BlockTransactions, Header, Rich, RichBlock, RichHeader},
 	block_number::BlockNumber,
 	bytes::Bytes,
-	call_request::CallRequest,
+	call_request::{CallRequest, CallStateOverride},
 	fee::{FeeHistory, FeeHistoryCache, FeeHistoryCacheItem, FeeHistoryCacheLimit},
 	filter::{
 		Filter, FilterAddress, FilterChanges, FilterPool, FilterPoolItem, FilterType,

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -47,6 +47,7 @@ fc-db = { workspace = true }
 fc-rpc-core = { workspace = true }
 fc-storage = { workspace = true }
 fp-ethereum = { workspace = true, features = ["default"] }
+fp-evm = { workspace = true }
 fp-rpc = { workspace = true, features = ["default"] }
 fp-storage = { workspace = true, features = ["default"] }
 

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -42,6 +42,8 @@ sp-consensus = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
+sp-storage = { workspace = true }
+sp-state-machine = { workspace = true }
 # Frontier
 fc-db = { workspace = true }
 fc-rpc-core = { workspace = true }

--- a/client/rpc/src/eth/block.rs
+++ b/client/rpc/src/eth/block.rs
@@ -30,14 +30,15 @@ use sp_core::hashing::keccak_256;
 use sp_runtime::traits::Block as BlockT;
 // Frontier
 use fc_rpc_core::types::*;
-use fp_rpc::EthereumRuntimeRPCApi;
+use fp_rpc::{EthereumRuntimeAddressMapping, EthereumRuntimeRPCApi};
 
 use crate::{
 	eth::{rich_block_build, Eth},
 	frontier_backend_client, internal_err,
 };
 
-impl<B, C, P, CT, BE, H: ExHashT, A: ChainApi, EGA> Eth<B, C, P, CT, BE, H, A, EGA>
+impl<B, C, P, CT, BE, H: ExHashT, A: ChainApi, M: EthereumRuntimeAddressMapping, EGA>
+	Eth<B, C, P, CT, BE, H, A, M, EGA>
 where
 	B: BlockT,
 	C: ProvideRuntimeApi<B>,

--- a/client/rpc/src/eth/client.rs
+++ b/client/rpc/src/eth/client.rs
@@ -28,11 +28,12 @@ use sp_consensus::SyncOracle;
 use sp_runtime::traits::{Block as BlockT, UniqueSaturatedInto};
 // Frontier
 use fc_rpc_core::types::*;
-use fp_rpc::EthereumRuntimeRPCApi;
+use fp_rpc::{EthereumRuntimeAddressMapping, EthereumRuntimeRPCApi};
 
 use crate::{eth::Eth, internal_err};
 
-impl<B, C, P, CT, BE, H: ExHashT, A: ChainApi, EGA> Eth<B, C, P, CT, BE, H, A, EGA>
+impl<B, C, P, CT, BE, H: ExHashT, A: ChainApi, M: EthereumRuntimeAddressMapping, EGA>
+	Eth<B, C, P, CT, BE, H, A, M, EGA>
 where
 	B: BlockT,
 	C: ProvideRuntimeApi<B>,

--- a/client/rpc/src/eth/execute.rs
+++ b/client/rpc/src/eth/execute.rs
@@ -18,11 +18,7 @@
 
 use std::{collections::BTreeMap, sync::Arc};
 
-<<<<<<< HEAD
-use ethereum_types::U256;
-=======
 use ethereum_types::{H160, H256, U256};
->>>>>>> fe80b431b (allow overriding state in eth_call)
 use evm::{ExitError, ExitReason};
 use jsonrpsee::core::RpcResult as Result;
 use scale_codec::Encode;

--- a/client/rpc/src/eth/fee.rs
+++ b/client/rpc/src/eth/fee.rs
@@ -27,11 +27,12 @@ use sp_blockchain::HeaderBackend;
 use sp_runtime::traits::{Block as BlockT, UniqueSaturatedInto};
 // Frontier
 use fc_rpc_core::types::*;
-use fp_rpc::EthereumRuntimeRPCApi;
+use fp_rpc::{EthereumRuntimeAddressMapping, EthereumRuntimeRPCApi};
 
 use crate::{eth::Eth, frontier_backend_client, internal_err};
 
-impl<B, C, P, CT, BE, H: ExHashT, A: ChainApi, EGA> Eth<B, C, P, CT, BE, H, A, EGA>
+impl<B, C, P, CT, BE, H: ExHashT, A: ChainApi, M: EthereumRuntimeAddressMapping, EGA>
+	Eth<B, C, P, CT, BE, H, A, M, EGA>
 where
 	B: BlockT,
 	C: ProvideRuntimeApi<B>,

--- a/client/rpc/src/eth/mining.rs
+++ b/client/rpc/src/eth/mining.rs
@@ -24,10 +24,13 @@ use sc_transaction_pool::ChainApi;
 use sp_runtime::traits::Block as BlockT;
 // Frontier
 use fc_rpc_core::types::*;
+use fp_rpc::EthereumRuntimeAddressMapping;
 
 use crate::eth::Eth;
 
-impl<B: BlockT, C, P, CT, BE, H: ExHashT, A: ChainApi, EGA> Eth<B, C, P, CT, BE, H, A, EGA> {
+impl<B: BlockT, C, P, CT, BE, H: ExHashT, A: ChainApi, M: EthereumRuntimeAddressMapping, EGA>
+	Eth<B, C, P, CT, BE, H, A, M, EGA>
+{
 	pub fn is_mining(&self) -> Result<bool> {
 		Ok(self.is_authority)
 	}

--- a/client/rpc/src/eth/mod.rs
+++ b/client/rpc/src/eth/mod.rs
@@ -47,8 +47,8 @@ use sp_runtime::traits::{Block as BlockT, UniqueSaturatedInto};
 // Frontier
 use fc_rpc_core::{types::*, EthApiServer};
 use fp_rpc::{
-	ConvertTransactionRuntimeApi, EthereumRuntimeRPCApi, EthereumRuntimeStorageOverride,
-	TransactionStatus,
+	ConvertTransactionRuntimeApi, EthereumRuntimeAddressMapping, EthereumRuntimeRPCApi,
+	EthereumRuntimeStorageOverride, TransactionStatus,
 };
 
 use crate::{internal_err, public_key, signer::EthSigner};
@@ -60,7 +60,17 @@ pub use self::{
 };
 
 /// Eth API implementation.
-pub struct Eth<B: BlockT, C, P, CT, BE, H: ExHashT, A: ChainApi, EGA = ()> {
+pub struct Eth<
+	B: BlockT,
+	C,
+	P,
+	CT,
+	BE,
+	H: ExHashT,
+	A: ChainApi,
+	M: EthereumRuntimeAddressMapping,
+	EGA = (),
+> {
 	pool: Arc<P>,
 	graph: Arc<Pool<A>>,
 	client: Arc<C>,
@@ -76,11 +86,14 @@ pub struct Eth<B: BlockT, C, P, CT, BE, H: ExHashT, A: ChainApi, EGA = ()> {
 	/// When using eth_call/eth_estimateGas, the maximum allowed gas limit will be
 	/// block.gas_limit * execute_gas_limit_multiplier
 	execute_gas_limit_multiplier: u64,
-	runtime_state_override: Option<Arc<dyn EthereumRuntimeStorageOverride<B, C>>>,
+	runtime_state_override:
+		Option<Arc<dyn EthereumRuntimeStorageOverride<B, C, AddressMapping = M>>>,
 	_marker: PhantomData<(B, BE, EGA)>,
 }
 
-impl<B: BlockT, C, P, CT, BE, H: ExHashT, A: ChainApi> Eth<B, C, P, CT, BE, H, A, ()> {
+impl<B: BlockT, C, P, CT, BE, H: ExHashT, A: ChainApi, M: EthereumRuntimeAddressMapping>
+	Eth<B, C, P, CT, BE, H, A, M, ()>
+{
 	pub fn new(
 		client: Arc<C>,
 		pool: Arc<P>,
@@ -95,7 +108,9 @@ impl<B: BlockT, C, P, CT, BE, H: ExHashT, A: ChainApi> Eth<B, C, P, CT, BE, H, A
 		fee_history_cache: FeeHistoryCache,
 		fee_history_cache_limit: FeeHistoryCacheLimit,
 		execute_gas_limit_multiplier: u64,
-		runtime_state_override: Option<Arc<dyn EthereumRuntimeStorageOverride<B, C>>>,
+		runtime_state_override: Option<
+			Arc<dyn EthereumRuntimeStorageOverride<B, C, AddressMapping = M>>,
+		>,
 	) -> Self {
 		Self {
 			client,
@@ -117,10 +132,12 @@ impl<B: BlockT, C, P, CT, BE, H: ExHashT, A: ChainApi> Eth<B, C, P, CT, BE, H, A
 	}
 }
 
-impl<B: BlockT, C, P, CT, BE, H: ExHashT, A: ChainApi, EGA> Eth<B, C, P, CT, BE, H, A, EGA> {
+impl<B: BlockT, C, P, CT, BE, H: ExHashT, A: ChainApi, M: EthereumRuntimeAddressMapping, EGA>
+	Eth<B, C, P, CT, BE, H, A, M, EGA>
+{
 	pub fn with_estimate_gas_adapter<EGA2: EstimateGasAdapter>(
 		self,
-	) -> Eth<B, C, P, CT, BE, H, A, EGA2> {
+	) -> Eth<B, C, P, CT, BE, H, A, M, EGA2> {
 		let Self {
 			client,
 			pool,
@@ -160,7 +177,7 @@ impl<B: BlockT, C, P, CT, BE, H: ExHashT, A: ChainApi, EGA> Eth<B, C, P, CT, BE,
 }
 
 #[async_trait]
-impl<B, C, P, CT, BE, H: ExHashT, A, EGA> EthApiServer for Eth<B, C, P, CT, BE, H, A, EGA>
+impl<B, C, P, CT, BE, H: ExHashT, A, M, EGA> EthApiServer for Eth<B, C, P, CT, BE, H, A, M, EGA>
 where
 	B: BlockT,
 	C: ProvideRuntimeApi<B>,
@@ -170,6 +187,7 @@ where
 	P: TransactionPool<Block = B> + 'static,
 	CT: ConvertTransaction<<B as BlockT>::Extrinsic> + Send + Sync + 'static,
 	A: ChainApi<Block = B> + 'static,
+	M: EthereumRuntimeAddressMapping + 'static,
 	EGA: EstimateGasAdapter + Send + Sync + 'static,
 {
 	// ########################################################################
@@ -294,7 +312,6 @@ where
 	// ########################################################################
 
 	fn call(&self, request: CallRequest, number: Option<BlockNumber>) -> Result<Bytes> {
-		log::info!("CALL");
 		self.call(request, number)
 	}
 

--- a/client/rpc/src/eth/state.rs
+++ b/client/rpc/src/eth/state.rs
@@ -30,14 +30,15 @@ use sp_blockchain::HeaderBackend;
 use sp_runtime::traits::Block as BlockT;
 // Frontier
 use fc_rpc_core::types::*;
-use fp_rpc::EthereumRuntimeRPCApi;
+use fp_rpc::{EthereumRuntimeAddressMapping, EthereumRuntimeRPCApi};
 
 use crate::{
 	eth::{pending_runtime_api, Eth},
 	frontier_backend_client, internal_err,
 };
 
-impl<B, C, P, CT, BE, H: ExHashT, A: ChainApi, EGA> Eth<B, C, P, CT, BE, H, A, EGA>
+impl<B, C, P, CT, BE, H: ExHashT, A: ChainApi, M: EthereumRuntimeAddressMapping, EGA>
+	Eth<B, C, P, CT, BE, H, A, M, EGA>
 where
 	B: BlockT,
 	C: ProvideRuntimeApi<B>,

--- a/client/rpc/src/eth/submit.rs
+++ b/client/rpc/src/eth/submit.rs
@@ -32,14 +32,18 @@ use sp_runtime::{
 };
 // Frontier
 use fc_rpc_core::types::*;
-use fp_rpc::{ConvertTransaction, ConvertTransactionRuntimeApi, EthereumRuntimeRPCApi};
+use fp_rpc::{
+	ConvertTransaction, ConvertTransactionRuntimeApi, EthereumRuntimeAddressMapping,
+	EthereumRuntimeRPCApi,
+};
 
 use crate::{
 	eth::{format, Eth},
 	internal_err,
 };
 
-impl<B, C, P, CT, BE, H: ExHashT, A: ChainApi, EGA> Eth<B, C, P, CT, BE, H, A, EGA>
+impl<B, C, P, CT, BE, H: ExHashT, A: ChainApi, M: EthereumRuntimeAddressMapping, EGA>
+	Eth<B, C, P, CT, BE, H, A, M, EGA>
 where
 	B: BlockT,
 	C: ProvideRuntimeApi<B>,

--- a/client/rpc/src/eth/transaction.rs
+++ b/client/rpc/src/eth/transaction.rs
@@ -32,14 +32,15 @@ use sp_core::hashing::keccak_256;
 use sp_runtime::traits::Block as BlockT;
 // Frontier
 use fc_rpc_core::types::*;
-use fp_rpc::EthereumRuntimeRPCApi;
+use fp_rpc::{EthereumRuntimeAddressMapping, EthereumRuntimeRPCApi};
 
 use crate::{
 	eth::{transaction_build, Eth},
 	frontier_backend_client, internal_err,
 };
 
-impl<B, C, P, CT, BE, H: ExHashT, A: ChainApi, EGA> Eth<B, C, P, CT, BE, H, A, EGA>
+impl<B, C, P, CT, BE, H: ExHashT, A: ChainApi, M: EthereumRuntimeAddressMapping, EGA>
+	Eth<B, C, P, CT, BE, H, A, M, EGA>
 where
 	B: BlockT,
 	C: ProvideRuntimeApi<B>,

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -52,8 +52,9 @@ pub mod frontier_backend_client {
 
 	use ethereum_types::{H160, H256, U256};
 	use jsonrpsee::core::RpcResult;
-	use scale_codec::{Decode, Encode};
+	use scale_codec::Encode;
 	// Substrate
+	use sc_client_api::{StorageKey, StorageProvider};
 	use sp_blockchain::HeaderBackend;
 	use sp_io::hashing::{blake2_128, twox_128};
 	use sp_runtime::{

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -50,10 +50,12 @@ pub use fc_storage::{
 pub mod frontier_backend_client {
 	use super::internal_err;
 
-	use ethereum_types::H256;
+	use ethereum_types::{H160, H256, U256};
 	use jsonrpsee::core::RpcResult;
+	use scale_codec::{Decode, Encode};
 	// Substrate
 	use sp_blockchain::HeaderBackend;
+	use sp_io::hashing::{blake2_128, twox_128};
 	use sp_runtime::{
 		generic::BlockId,
 		traits::{Block as BlockT, UniqueSaturatedInto, Zero},
@@ -61,6 +63,47 @@ pub mod frontier_backend_client {
 	// Frontier
 	use fc_rpc_core::types::BlockNumber;
 	use fp_storage::EthereumStorageSchema;
+
+	/// Implements a default runtime storage override.
+	/// It assumes that the balances and nonces are stored in pallet `system.account`, and
+	/// have `nonce: Index` = `u32` for  and `free: Balance` = `u128`.
+	pub struct DefaultEthereumRuntimeStorageOverride;
+	impl<B, C> fp_rpc::EthereumRuntimeStorageOverride<B, C> for DefaultEthereumRuntimeStorageOverride
+	where
+		B: BlockT,
+		C: StorageProvider<B, sc_service::TFullBackend<B>>,
+	{
+		fn set_overlayed_changes(
+			&self,
+			client: &C,
+			overlayed_changes: &mut sp_state_machine::OverlayedChanges,
+			block: B::Hash,
+			version: u32,
+			address: H160,
+			balance: Option<U256>,
+			nonce: Option<U256>,
+		) {
+			let mut key = [twox_128(b"System"), twox_128(b"Account")]
+				.concat()
+				.to_vec();
+			key.extend(blake2_128(address.as_bytes()));
+			key.extend(address.as_bytes());
+
+			if let Ok(Some(item)) = client.storage(block, &StorageKey(key.clone())) {
+				let mut new_item = item.0;
+
+				if let Some(nonce) = nonce {
+					new_item.splice(0..4, nonce.low_u32().encode());
+				}
+
+				if let Some(balance) = balance {
+					new_item.splice(16..32, balance.low_u128().encode());
+				}
+
+				overlayed_changes.set_storage(key, Some(new_item));
+			}
+		}
+	}
 
 	pub fn native_block_id<B: BlockT, C>(
 		client: &C,

--- a/primitives/rpc/Cargo.toml
+++ b/primitives/rpc/Cargo.toml
@@ -17,6 +17,7 @@ scale-codec = { package = "parity-scale-codec", workspace = true }
 scale-info = { workspace = true }
 # Substrate
 sp-api = { workspace = true }
+sp-state-machine = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
@@ -32,6 +33,7 @@ std = [
 	"scale-info/std",
 	# Substrate
 	"sp-api/std",
+	"sp-state-machine/std",
 	"sp-core/std",
 	"sp-runtime/std",
 	"sp-std/std",

--- a/primitives/rpc/src/lib.rs
+++ b/primitives/rpc/src/lib.rs
@@ -39,7 +39,7 @@ pub struct TransactionStatus {
 	pub logs_bloom: Bloom,
 }
 
-pub trait EthereumRuntimeAddressMapper {
+pub trait EthereumRuntimeAddressMapping {
 	fn into_account_id_bytes(address: H160) -> Vec<u8>;
 }
 
@@ -47,7 +47,7 @@ pub trait EthereumRuntimeStorageOverride<B, C>: Send + Sync
 where
 	B: BlockT,
 {
-	type AddressMapping: EthereumRuntimeAddressMapper;
+	type AddressMapping: EthereumRuntimeAddressMapping;
 
 	fn set_overlayed_changes(
 		&self,

--- a/primitives/rpc/src/lib.rs
+++ b/primitives/rpc/src/lib.rs
@@ -25,6 +25,7 @@ use scale_info::TypeInfo;
 // Substrate
 use sp_core::{H160, H256, U256};
 use sp_runtime::{traits::Block as BlockT, Permill, RuntimeDebug};
+use sp_state_machine::OverlayedChanges;
 use sp_std::vec::Vec;
 
 #[derive(Clone, Eq, PartialEq, Default, RuntimeDebug, Encode, Decode, TypeInfo)]
@@ -36,6 +37,22 @@ pub struct TransactionStatus {
 	pub contract_address: Option<H160>,
 	pub logs: Vec<Log>,
 	pub logs_bloom: Bloom,
+}
+
+pub trait EthereumRuntimeStorageOverride<B, C>: Send + Sync
+where
+	B: BlockT,
+{
+	fn set_overlayed_changes(
+		&self,
+		client: &C,
+		overlayed_changes: &mut OverlayedChanges,
+		block: B::Hash,
+		version: u32,
+		address: H160,
+		balance: Option<U256>,
+		nonce: Option<U256>,
+	);
 }
 
 sp_api::decl_runtime_apis! {

--- a/primitives/rpc/src/lib.rs
+++ b/primitives/rpc/src/lib.rs
@@ -39,10 +39,16 @@ pub struct TransactionStatus {
 	pub logs_bloom: Bloom,
 }
 
+pub trait EthereumRuntimeAddressMapper {
+	fn into_account_id_bytes(address: H160) -> Vec<u8>;
+}
+
 pub trait EthereumRuntimeStorageOverride<B, C>: Send + Sync
 where
 	B: BlockT,
 {
+	type AddressMapping: EthereumRuntimeAddressMapper;
+
 	fn set_overlayed_changes(
 		&self,
 		client: &C,

--- a/template/node/Cargo.toml
+++ b/template/node/Cargo.toml
@@ -58,6 +58,7 @@ sp-trie = { workspace = true, features = ["default"] }
 frame-system-rpc-runtime-api = { workspace = true }
 pallet-transaction-payment-rpc = { workspace = true }
 pallet-transaction-payment-rpc-runtime-api = { workspace = true }
+pallet-evm = { workspace = true }
 substrate-frame-rpc-system = { workspace = true }
 # These dependencies are used for runtime benchmarking
 frame-benchmarking = { workspace = true, optional = true }

--- a/template/node/src/rpc/eth.rs
+++ b/template/node/src/rpc/eth.rs
@@ -18,8 +18,8 @@ use sp_runtime::traits::Block as BlockT;
 use fc_db::Backend as FrontierBackend;
 pub use fc_rpc::{EthBlockDataCacheTask, OverrideHandle, StorageOverride};
 pub use fc_rpc_core::types::{FeeHistoryCache, FeeHistoryCacheLimit, FilterPool};
-pub use fc_storage::overrides_handle;
-use fp_rpc::{ConvertTransaction, ConvertTransactionRuntimeApi, EthereumRuntimeRPCApi};
+use fp_rpc::EthereumRuntimeStorageOverride;
+use fp_storage::EthereumStorageSchema;
 
 /// Extra dependencies for Ethereum compatibility.
 pub struct EthDeps<C, P, A: ChainApi, CT, B: BlockT> {
@@ -54,6 +54,8 @@ pub struct EthDeps<C, P, A: ChainApi, CT, B: BlockT> {
 	/// Maximum allowed gas limit will be ` block.gas_limit * execute_gas_limit_multiplier` when
 	/// using eth_call/eth_estimateGas.
 	pub execute_gas_limit_multiplier: u64,
+	/// Ethereum runtime storage overrider impl.
+	pub runtime_storage_override: Option<Arc<dyn EthereumRuntimeStorageOverride<B, C>>>,
 }
 
 impl<C, P, A: ChainApi, CT: Clone, B: BlockT> Clone for EthDeps<C, P, A, CT, B> {
@@ -74,6 +76,7 @@ impl<C, P, A: ChainApi, CT: Clone, B: BlockT> Clone for EthDeps<C, P, A, CT, B> 
 			fee_history_cache: self.fee_history_cache.clone(),
 			fee_history_cache_limit: self.fee_history_cache_limit,
 			execute_gas_limit_multiplier: self.execute_gas_limit_multiplier,
+			runtime_storage_override: self.runtime_storage_override.clone(),
 		}
 	}
 }
@@ -116,6 +119,7 @@ where
 		fee_history_cache,
 		fee_history_cache_limit,
 		execute_gas_limit_multiplier,
+		runtime_storage_override,
 	} = deps;
 
 	let mut signers = Vec::new();
@@ -138,6 +142,7 @@ where
 			fee_history_cache,
 			fee_history_cache_limit,
 			execute_gas_limit_multiplier,
+			runtime_storage_override,
 		)
 		.into_rpc(),
 	)?;

--- a/template/node/src/rpc/eth.rs
+++ b/template/node/src/rpc/eth.rs
@@ -10,7 +10,7 @@ use sc_network::NetworkService;
 use sc_rpc::SubscriptionTaskExecutor;
 use sc_transaction_pool::{ChainApi, Pool};
 use sc_transaction_pool_api::TransactionPool;
-use sp_api::ProvideRuntimeApi;
+use sp_api::{CallApiAt, ProvideRuntimeApi};
 use sp_block_builder::BlockBuilder as BlockBuilderApi;
 use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
 use sp_runtime::traits::Block as BlockT;
@@ -19,8 +19,11 @@ use crate::rpc::AccountId32AddressMapping;
 use fc_db::Backend as FrontierBackend;
 pub use fc_rpc::{EthBlockDataCacheTask, OverrideHandle, StorageOverride};
 pub use fc_rpc_core::types::{FeeHistoryCache, FeeHistoryCacheLimit, FilterPool};
-use fp_rpc::EthereumRuntimeStorageOverride;
-use fp_storage::EthereumStorageSchema;
+pub use fc_storage::overrides_handle;
+use fp_rpc::{
+	ConvertTransaction, ConvertTransactionRuntimeApi, EthereumRuntimeRPCApi,
+	EthereumRuntimeStorageOverride,
+};
 
 /// Extra dependencies for Ethereum compatibility.
 pub struct EthDeps<C, P, A: ChainApi, CT, B: BlockT> {
@@ -95,7 +98,10 @@ where
 	C: ProvideRuntimeApi<B>,
 	C::Api: BlockBuilderApi<B> + EthereumRuntimeRPCApi<B> + ConvertTransactionRuntimeApi<B>,
 	C: BlockchainEvents<B> + 'static,
-	C: HeaderBackend<B> + HeaderMetadata<B, Error = BlockChainError> + StorageProvider<B, BE>,
+	C: HeaderBackend<B>
+		+ CallApiAt<B>
+		+ HeaderMetadata<B, Error = BlockChainError>
+		+ StorageProvider<B, BE>,
 	BE: Backend<B> + 'static,
 	P: TransactionPool<Block = B> + 'static,
 	A: ChainApi<Block = B> + 'static,

--- a/template/node/src/rpc/mod.rs
+++ b/template/node/src/rpc/mod.rs
@@ -18,13 +18,14 @@ use sp_api::ProvideRuntimeApi;
 use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
 use sp_runtime::traits::Block as BlockT;
 // Runtime
+use fp_rpc::EthereumRuntimeAddressMapper;
 use frontier_template_runtime::{opaque::Block, AccountId, Balance, Hash, Index};
 
 mod eth;
 pub use self::eth::{create_eth, overrides_handle, EthDeps};
 
 /// Full client dependencies.
-pub struct FullDeps<C, P, A: ChainApi, CT> {
+pub struct FullDeps<C, P, A: ChainApi, CT, M: EthereumRuntimeAddressMapper> {
 	/// The client instance to use.
 	pub client: Arc<C>,
 	/// Transaction pool instance.
@@ -34,12 +35,12 @@ pub struct FullDeps<C, P, A: ChainApi, CT> {
 	/// Manual seal command sink
 	pub command_sink: Option<mpsc::Sender<EngineCommand<Hash>>>,
 	/// Ethereum-compatibility specific dependencies.
-	pub eth: EthDeps<C, P, A, CT, Block>,
+	pub eth: EthDeps<C, P, A, CT, Block, M>,
 }
 
 /// Instantiate all Full RPC extensions.
-pub fn create_full<C, P, BE, A, CT>(
-	deps: FullDeps<C, P, A, CT>,
+pub fn create_full<C, P, BE, A, CT, M: EthereumRuntimeAddressMapper + 'static>(
+	deps: FullDeps<C, P, A, CT, M>,
 	subscription_task_executor: SubscriptionTaskExecutor,
 ) -> Result<RpcModule<()>, Box<dyn std::error::Error + Send + Sync>>
 where
@@ -83,7 +84,7 @@ where
 	}
 
 	// Ethereum compatibility RPCs
-	let io = create_eth::<_, _, _, _, _, _>(io, eth, subscription_task_executor)?;
+	let io = create_eth::<_, _, _, _, _, _, _>(io, eth, subscription_task_executor)?;
 
 	Ok(io)
 }

--- a/template/node/src/rpc/mod.rs
+++ b/template/node/src/rpc/mod.rs
@@ -15,7 +15,7 @@ use sc_rpc::SubscriptionTaskExecutor;
 use sc_rpc_api::DenyUnsafe;
 use sc_service::TransactionPool;
 use sc_transaction_pool::ChainApi;
-use sp_api::ProvideRuntimeApi;
+use sp_api::{CallApiAt, ProvideRuntimeApi};
 use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
 use sp_core::ByteArray;
 use sp_runtime::traits::{BlakeTwo256, Block as BlockT};
@@ -60,6 +60,7 @@ where
 	C::Api: fp_rpc::EthereumRuntimeRPCApi<Block>,
 	C: BlockchainEvents<Block> + 'static,
 	C: HeaderBackend<Block>
+		+ CallApiAt<Block>
 		+ HeaderMetadata<Block, Error = BlockChainError>
 		+ StorageProvider<Block, BE>,
 	BE: Backend<Block> + 'static,

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -366,6 +366,9 @@ where
 		fee_history_cache: fee_history_cache.clone(),
 		fee_history_cache_limit,
 		execute_gas_limit_multiplier: eth_config.execute_gas_limit_multiplier,
+		runtime_storage_override: Some(Arc::new(
+			fc_rpc::frontier_backend_client::DefaultEthereumRuntimeStorageOverride,
+		)),
 	};
 
 	let rpc_builder = {

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -4,7 +4,6 @@ use std::{cell::RefCell, sync::Arc, time::Duration};
 
 use futures::{channel::mpsc, prelude::*};
 // Substrate
-use pallet_evm::AddressMapping;
 use prometheus_endpoint::Registry;
 use sc_client_api::{BlockBackend, StateBackendFor};
 use sc_consensus::BasicQueue;
@@ -14,7 +13,7 @@ use sc_service::{error::Error as ServiceError, Configuration, PartialComponents,
 use sc_telemetry::{Telemetry, TelemetryHandle, TelemetryWorker};
 use sp_api::{ConstructRuntimeApi, TransactionFor};
 use sp_consensus_aura::sr25519::AuthorityPair as AuraPair;
-use sp_core::{ByteArray, H160, U256};
+use sp_core::U256;
 use sp_runtime::traits::BlakeTwo256;
 use sp_trie::PrefixedMemoryDB;
 // Runtime
@@ -254,13 +253,6 @@ where
 	))
 }
 
-struct AccountId32AddressMapping;
-impl fp_rpc::EthereumRuntimeAddressMapper for AccountId32AddressMapping {
-	fn into_account_id_bytes(address: H160) -> Vec<u8> {
-		pallet_evm::HashedAddressMapping::<BlakeTwo256>::into_account_id(address).to_raw_vec()
-	}
-}
-
 /// Builds a new service for a full client.
 pub fn new_full<RuntimeApi, Executor>(
 	mut config: Configuration,
@@ -376,7 +368,7 @@ where
 		execute_gas_limit_multiplier: eth_config.execute_gas_limit_multiplier,
 		runtime_storage_override: Some(Arc::new(
 			fc_rpc::frontier_backend_client::DefaultEthereumRuntimeStorageOverride(
-				std::marker::PhantomData::<AccountId32AddressMapping>::default(),
+				std::marker::PhantomData::<crate::rpc::AccountId32AddressMapping>::default(),
 			),
 		)),
 	};

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -4,6 +4,7 @@ use std::{cell::RefCell, sync::Arc, time::Duration};
 
 use futures::{channel::mpsc, prelude::*};
 // Substrate
+use pallet_evm::AddressMapping;
 use prometheus_endpoint::Registry;
 use sc_client_api::{BlockBackend, StateBackendFor};
 use sc_consensus::BasicQueue;
@@ -13,7 +14,7 @@ use sc_service::{error::Error as ServiceError, Configuration, PartialComponents,
 use sc_telemetry::{Telemetry, TelemetryHandle, TelemetryWorker};
 use sp_api::{ConstructRuntimeApi, TransactionFor};
 use sp_consensus_aura::sr25519::AuthorityPair as AuraPair;
-use sp_core::U256;
+use sp_core::{ByteArray, H160, U256};
 use sp_runtime::traits::BlakeTwo256;
 use sp_trie::PrefixedMemoryDB;
 // Runtime
@@ -253,6 +254,13 @@ where
 	))
 }
 
+struct AccountId32AddressMapping;
+impl fp_rpc::EthereumRuntimeAddressMapper for AccountId32AddressMapping {
+	fn into_account_id_bytes(address: H160) -> Vec<u8> {
+		pallet_evm::HashedAddressMapping::<BlakeTwo256>::into_account_id(address).to_raw_vec()
+	}
+}
+
 /// Builds a new service for a full client.
 pub fn new_full<RuntimeApi, Executor>(
 	mut config: Configuration,
@@ -367,7 +375,9 @@ where
 		fee_history_cache_limit,
 		execute_gas_limit_multiplier: eth_config.execute_gas_limit_multiplier,
 		runtime_storage_override: Some(Arc::new(
-			fc_rpc::frontier_backend_client::DefaultEthereumRuntimeStorageOverride,
+			fc_rpc::frontier_backend_client::DefaultEthereumRuntimeStorageOverride(
+				std::marker::PhantomData::<AccountId32AddressMapping>::default(),
+			),
 		)),
 	};
 

--- a/ts-tests/contracts/StateOverrideTest.sol
+++ b/ts-tests/contracts/StateOverrideTest.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity >=0.8.0;
+
+/// @notice Smart contract to help test state override
+contract StateOverrideTest {
+    /// @notice The maxmium allowed value
+    uint256 public MAX_ALLOWED = 3;
+    uint256 public availableFunds;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    address owner;
+
+    constructor(uint256 intialAmount) payable {
+        owner = msg.sender;
+        availableFunds = intialAmount;
+    }
+
+    function getBalance() external view returns (uint256) {
+        return address(this).balance;
+    }
+
+    function getSenderBalance() external view returns (uint256) {
+        return address(msg.sender).balance;
+    }
+
+    function getAllowance(address from, address who)
+        external
+        view
+        returns (uint256)
+    {
+        return allowance[from][who];
+    }
+
+    function setAllowance(address who, uint256 amount) external {
+        allowance[address(msg.sender)][who] = amount;
+    }
+}

--- a/ts-tests/tests/test-state-override.ts
+++ b/ts-tests/tests/test-state-override.ts
@@ -1,0 +1,246 @@
+import { expect, use as chaiUse } from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { RLP } from "ethers/lib/utils";
+import Web3 from "web3";
+import { AbiItem } from "web3-utils";
+
+import StateOverrideTest from "../build/contracts/StateOverrideTest.json";
+import Test from "../build/contracts/Test.json";
+import {
+	GENESIS_ACCOUNT,
+	GENESIS_ACCOUNT_PRIVATE_KEY,
+	FIRST_CONTRACT_ADDRESS,
+	GENESIS_ACCOUNT_BALANCE,
+} from "./config";
+import { createAndFinalizeBlock, customRequest, describeWithFrontier } from "./util";
+
+chaiUse(chaiAsPromised);
+
+describeWithFrontier("Frontier RPC (StateOverride)", (context) => {
+	const STATE_OVERRIDE_TEST_CONTRACT_BYTECODE = StateOverrideTest.bytecode;
+	const otherAddress = "0xd43593c715fdd31c61141abd04a99fd6822c8558";
+
+	let contract;
+	let contractAddress;
+	before("create the contract", async function () {
+		this.timeout(15000);
+		contract = new context.web3.eth.Contract(StateOverrideTest.abi as AbiItem[]);
+		const data = contract
+			.deploy({
+				data: STATE_OVERRIDE_TEST_CONTRACT_BYTECODE,
+				arguments: [100],
+			})
+			.encodeABI();
+		const tx = await context.web3.eth.accounts.signTransaction(
+			{
+				from: GENESIS_ACCOUNT,
+				data,
+				value: Web3.utils.numberToHex(Web3.utils.toWei("1", "ether")),
+				gas: "0x100000",
+			},
+			GENESIS_ACCOUNT_PRIVATE_KEY
+		);
+		const { result } = await customRequest(context.web3, "eth_sendRawTransaction", [tx.rawTransaction]);
+		await createAndFinalizeBlock(context.web3);
+		const receipt = await context.web3.eth.getTransactionReceipt(result);
+		contractAddress = receipt.contractAddress;
+
+		const txSetAllowance = await context.web3.eth.accounts.signTransaction(
+			{
+				from: GENESIS_ACCOUNT,
+				to: contractAddress,
+				data: await contract.methods.setAllowance(otherAddress, 10).encodeABI(),
+				gas: "0x100000",
+				gasPrice: "0x3B9ACA00",
+				value: "0x0",
+			},
+			GENESIS_ACCOUNT_PRIVATE_KEY
+		);
+		await customRequest(context.web3, "eth_sendRawTransaction", [txSetAllowance.rawTransaction]);
+		await createAndFinalizeBlock(context.web3);
+	});
+
+	it("should have balance above 1000 tether without state override", async function () {
+		const { result } = await customRequest(context.web3, "eth_call", [
+			{
+				from: GENESIS_ACCOUNT,
+				to: contractAddress,
+				data: await contract.methods.getSenderBalance().encodeABI(),
+			},
+		]);
+		const balance = Web3.utils.toBN(
+			Web3.utils.fromWei(Web3.utils.hexToNumberString(result), "tether").split(".")[0]
+		);
+		expect(balance.gten(1000), "balance was not above 1000 tether").to.be.true;
+	});
+
+	it("should have a sender balance of 150 with state override", async function () {
+		const { result } = await customRequest(context.web3, "eth_call", [
+			{
+				from: GENESIS_ACCOUNT,
+				to: contractAddress,
+				data: await contract.methods.getSenderBalance().encodeABI(),
+				stateOverrides: {
+					[GENESIS_ACCOUNT]: {
+						balance: Web3.utils.numberToHex(5000),
+					},
+				},
+			},
+		]);
+		expect(Web3.utils.hexToNumberString(result)).to.equal("4500"); // 500 is consumed as gas
+	});
+
+	it("should have availableFunds of 100 without state override", async function () {
+		const { result } = await customRequest(context.web3, "eth_call", [
+			{
+				from: GENESIS_ACCOUNT,
+				to: contractAddress,
+				data: await contract.methods.availableFunds().encodeABI(),
+			},
+		]);
+		expect(Web3.utils.hexToNumberString(result)).to.equal("100");
+	});
+
+	it("should have availableFunds of 500 with state override", async function () {
+		const availableFundsKey = Web3.utils.padLeft(Web3.utils.numberToHex(1), 64); // slot 1
+		const newValue = Web3.utils.padLeft(Web3.utils.numberToHex(500), 64);
+
+		const { result } = await customRequest(context.web3, "eth_call", [
+			{
+				from: GENESIS_ACCOUNT,
+				to: contractAddress,
+				data: await contract.methods.availableFunds().encodeABI(),
+				stateOverrides: {
+					[contractAddress]: {
+						stateDiff: {
+							[availableFundsKey]: newValue,
+						},
+					},
+				},
+			},
+		]);
+		expect(Web3.utils.hexToNumberString(result)).to.equal("500");
+	});
+
+	it("should have allowance of 10 without state override", async function () {
+		const { result } = await customRequest(context.web3, "eth_call", [
+			{
+				from: GENESIS_ACCOUNT,
+				to: contractAddress,
+				data: await contract.methods.allowance(GENESIS_ACCOUNT, otherAddress).encodeABI(),
+			},
+		]);
+		expect(Web3.utils.hexToNumberString(result)).to.equal("10");
+	});
+
+	it("should have allowance of 50 with state override", async function () {
+		const allowanceKey = Web3.utils.soliditySha3(
+			{
+				type: "uint256",
+				value: otherAddress,
+			},
+			{
+				type: "uint256",
+				value: Web3.utils.soliditySha3(
+					{
+						type: "uint256",
+						value: GENESIS_ACCOUNT,
+					},
+					{
+						type: "uint256",
+						value: "2", // slot 2
+					}
+				),
+			}
+		);
+		const newValue = Web3.utils.padLeft(Web3.utils.numberToHex(50), 64);
+
+		const { result } = await customRequest(context.web3, "eth_call", [
+			{
+				from: GENESIS_ACCOUNT,
+				to: contractAddress,
+				data: await contract.methods.allowance(GENESIS_ACCOUNT, otherAddress).encodeABI(),
+				stateOverrides: {
+					[contractAddress]: {
+						stateDiff: {
+							[allowanceKey]: newValue,
+						},
+					},
+				},
+			},
+		]);
+		expect(Web3.utils.hexToNumberString(result)).to.equal("50");
+	});
+
+	it("should have allowance of 50 but availableFunds 0 with full state override", async function () {
+		const allowanceKey = Web3.utils.soliditySha3(
+			{
+				type: "uint256",
+				value: otherAddress,
+			},
+			{
+				type: "uint256",
+				value: Web3.utils.soliditySha3(
+					{
+						type: "uint256",
+						value: GENESIS_ACCOUNT,
+					},
+					{
+						type: "uint256",
+						value: "2", // slot 2
+					}
+				),
+			}
+		);
+		const newValue = Web3.utils.padLeft(Web3.utils.numberToHex(50), 64);
+
+		const { result } = await customRequest(context.web3, "eth_call", [
+			{
+				from: GENESIS_ACCOUNT,
+				to: contractAddress,
+				data: await contract.methods.allowance(GENESIS_ACCOUNT, otherAddress).encodeABI(),
+				stateOverrides: {
+					[contractAddress]: {
+						state: {
+							[allowanceKey]: newValue,
+						},
+					},
+				},
+			},
+		]);
+		expect(Web3.utils.hexToNumberString(result)).to.equal("50");
+
+		const { result: result2 } = await customRequest(context.web3, "eth_call", [
+			{
+				from: GENESIS_ACCOUNT,
+				to: contractAddress,
+				data: await contract.methods.availableFunds().encodeABI(),
+				stateOverrides: {
+					[contractAddress]: {
+						state: {
+							[allowanceKey]: newValue,
+						},
+					},
+				},
+			},
+		]);
+		expect(Web3.utils.hexToNumberString(result2)).to.equal("0");
+	});
+
+	it("should set MultiplyBy7 deployedBytecode with state override", async function () {
+		const testContract = new context.web3.eth.Contract(Test.abi as AbiItem[]);
+		const { result } = await customRequest(context.web3, "eth_call", [
+			{
+				from: GENESIS_ACCOUNT,
+				to: contractAddress,
+				data: await testContract.methods.multiply(5).encodeABI(), // multiplies by 7
+				stateOverrides: {
+					[contractAddress]: {
+						code: Test.deployedBytecode,
+					},
+				},
+			},
+		]);
+		expect(Web3.utils.hexToNumberString(result)).to.equal("35");
+	});
+});

--- a/ts-tests/tests/test-state-override.ts
+++ b/ts-tests/tests/test-state-override.ts
@@ -80,10 +80,11 @@ describeWithFrontier("Frontier RPC (StateOverride)", (context) => {
 				from: GENESIS_ACCOUNT,
 				to: contractAddress,
 				data: await contract.methods.getSenderBalance().encodeABI(),
-				stateOverrides: {
-					[GENESIS_ACCOUNT]: {
-						balance: Web3.utils.numberToHex(5000),
-					},
+			},
+			"latest",
+			{
+				[GENESIS_ACCOUNT]: {
+					balance: Web3.utils.numberToHex(5000),
 				},
 			},
 		]);
@@ -110,11 +111,12 @@ describeWithFrontier("Frontier RPC (StateOverride)", (context) => {
 				from: GENESIS_ACCOUNT,
 				to: contractAddress,
 				data: await contract.methods.availableFunds().encodeABI(),
-				stateOverrides: {
-					[contractAddress]: {
-						stateDiff: {
-							[availableFundsKey]: newValue,
-						},
+			},
+			"latest",
+			{
+				[contractAddress]: {
+					stateDiff: {
+						[availableFundsKey]: newValue,
 					},
 				},
 			},
@@ -160,11 +162,12 @@ describeWithFrontier("Frontier RPC (StateOverride)", (context) => {
 				from: GENESIS_ACCOUNT,
 				to: contractAddress,
 				data: await contract.methods.allowance(GENESIS_ACCOUNT, otherAddress).encodeABI(),
-				stateOverrides: {
-					[contractAddress]: {
-						stateDiff: {
-							[allowanceKey]: newValue,
-						},
+			},
+			"latest",
+			{
+				[contractAddress]: {
+					stateDiff: {
+						[allowanceKey]: newValue,
 					},
 				},
 			},
@@ -199,11 +202,12 @@ describeWithFrontier("Frontier RPC (StateOverride)", (context) => {
 				from: GENESIS_ACCOUNT,
 				to: contractAddress,
 				data: await contract.methods.allowance(GENESIS_ACCOUNT, otherAddress).encodeABI(),
-				stateOverrides: {
-					[contractAddress]: {
-						state: {
-							[allowanceKey]: newValue,
-						},
+			},
+			"latest",
+			{
+				[contractAddress]: {
+					state: {
+						[allowanceKey]: newValue,
 					},
 				},
 			},
@@ -215,11 +219,12 @@ describeWithFrontier("Frontier RPC (StateOverride)", (context) => {
 				from: GENESIS_ACCOUNT,
 				to: contractAddress,
 				data: await contract.methods.availableFunds().encodeABI(),
-				stateOverrides: {
-					[contractAddress]: {
-						state: {
-							[allowanceKey]: newValue,
-						},
+			},
+			"latest",
+			{
+				[contractAddress]: {
+					state: {
+						[allowanceKey]: newValue,
 					},
 				},
 			},
@@ -234,10 +239,11 @@ describeWithFrontier("Frontier RPC (StateOverride)", (context) => {
 				from: GENESIS_ACCOUNT,
 				to: contractAddress,
 				data: await testContract.methods.multiply(5).encodeABI(), // multiplies by 7
-				stateOverrides: {
-					[contractAddress]: {
-						code: Test.deployedBytecode,
-					},
+			},
+			"latest",
+			{
+				[contractAddress]: {
+					code: Test.deployedBytecode,
 				},
 			},
 		]);


### PR DESCRIPTION
Implements call state override for eth_call as an optional parameter to be passed to override the state. Similar to [geth](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-eth).