### PR TITLE
chore: remove deprecated trait Store for all pallets

### DIFF
--- a/frame/base-fee/src/lib.rs
+++ b/frame/base-fee/src/lib.rs
@@ -41,8 +41,6 @@ pub mod pallet {
 	use frame_system::pallet_prelude::*;
 
 	#[pallet::pallet]
-	#[pallet::generate_store(pub(super) trait Store)]
-	#[pallet::without_storage_info]
 	pub struct Pallet<T>(PhantomData<T>);
 
 	#[pallet::config]

--- a/frame/dynamic-fee/src/lib.rs
+++ b/frame/dynamic-fee/src/lib.rs
@@ -39,8 +39,6 @@ pub mod pallet {
 	use frame_system::pallet_prelude::*;
 
 	#[pallet::pallet]
-	#[pallet::generate_store(pub(super) trait Store)]
-	#[pallet::without_storage_info]
 	pub struct Pallet<T>(PhantomData<T>);
 
 	#[pallet::config]

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -181,7 +181,6 @@ pub mod pallet {
 	use frame_system::pallet_prelude::*;
 
 	#[pallet::pallet]
-	#[pallet::generate_store(pub(super) trait Store)]
 	#[pallet::without_storage_info]
 	pub struct Pallet<T>(PhantomData<T>);
 

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -106,7 +106,6 @@ pub mod pallet {
 	use frame_system::pallet_prelude::*;
 
 	#[pallet::pallet]
-	#[pallet::generate_store(pub(super) trait Store)]
 	#[pallet::without_storage_info]
 	pub struct Pallet<T>(PhantomData<T>);
 

--- a/frame/hotfix-sufficients/src/lib.rs
+++ b/frame/hotfix-sufficients/src/lib.rs
@@ -24,17 +24,17 @@ pub mod benchmarking;
 mod mock;
 #[cfg(test)]
 mod tests;
-
 pub mod weights;
-pub use weights::WeightInfo;
 
+// Substrate
 use frame_support::dispatch::PostDispatchInfo;
-pub use pallet_evm::AddressMapping;
 use sp_core::H160;
 use sp_runtime::traits::Zero;
 use sp_std::vec::Vec;
+// Frontier
+pub use pallet_evm::AddressMapping;
 
-pub use self::pallet::*;
+pub use self::{pallet::*, weights::WeightInfo};
 
 #[frame_support::pallet]
 pub mod pallet {
@@ -43,8 +43,6 @@ pub mod pallet {
 	use frame_system::pallet_prelude::*;
 
 	#[pallet::pallet]
-	#[pallet::generate_store(pub(super) trait Store)]
-	#[pallet::without_storage_info]
 	pub struct Pallet<T>(PhantomData<T>);
 
 	#[pallet::config]


### PR DESCRIPTION
- remove deprecated `trait Store` for all pallets (https://github.com/paritytech/substrate/pull/13535)
- remove `pallet::without_storage_info` if it's unnecessary