### PR TITLE
serde `input` alias support for `data` field in call/send

### DIFF
--- a/client/rpc-core/src/types/call_request.rs
+++ b/client/rpc-core/src/types/call_request.rs
@@ -42,6 +42,7 @@ pub struct CallRequest {
 	/// Value
 	pub value: Option<U256>,
 	/// Data
+	#[serde(alias = "input")]
 	pub data: Option<Bytes>,
 	/// Nonce
 	pub nonce: Option<U256>,

--- a/client/rpc-core/src/types/transaction_request.rs
+++ b/client/rpc-core/src/types/transaction_request.rs
@@ -54,6 +54,7 @@ pub struct TransactionRequest {
 	/// Value of transaction in wei
 	pub value: Option<U256>,
 	/// Additional data sent with transaction
+	#[serde(alias = "input")]
 	pub data: Option<Bytes>,
 	/// Transaction's nonce
 	pub nonce: Option<U256>,

--- a/ts-tests/package.json
+++ b/ts-tests/package.json
@@ -23,7 +23,7 @@
     "truffle": "^5.7.0",
     "ts-node": "^8.10.2",
     "typescript": "^3.9.6",
-    "web3": "^1.8.0"
+    "web3": "^1.9.0"
   },
   "devDependencies": {
     "@types/chai-as-promised": "^7.1.5",

--- a/ts-tests/tests/test-execute.ts
+++ b/ts-tests/tests/test-execute.ts
@@ -131,4 +131,16 @@ describeWithFrontier("Frontier RPC (RPC execution)", (context) => {
 			id: 1,
 		});
 	});
+
+	step("`input` field alias is properly deserialized", async function () {
+		const result = await customRequest(context.web3, "eth_call", [
+			{
+				from: GENESIS_ACCOUNT,
+				gas: `0x${(ETH_BLOCK_GAS_LIMIT - 1).toString(16)}`,
+				input: TEST_CONTRACT_BYTECODE,
+			},
+		]);
+
+		expect(result.result).to.be.equal(TEST_CONTRACT_DEPLOYED_BYTECODE);
+	});
 });


### PR DESCRIPTION
rel https://github.com/web3/web3.js/pull/5915