### PR TITLE
Add `pending` support for `eth_getBlockByNumber`

### DIFF
--- a/client/rpc/src/eth/block.rs
+++ b/client/rpc/src/eth/block.rs
@@ -139,11 +139,6 @@ where
 				let api = client.runtime_api();
 				let best_hash = client.info().best_hash;
 
-				let parent_header = client
-					.header(best_hash)
-					.map_err(|_| internal_err(format!("Runtime access error at {}", best_hash)))?
-					.ok_or_else(|| internal_err(format!("Block not found at {}", best_hash)))?;
-
 				// Get current in-pool transactions
 				let mut xts: Vec<<B as BlockT>::Extrinsic> = Vec::new();
 				// ready validated pool
@@ -166,7 +161,7 @@ where
 				);
 
 				let (block, statuses) = api
-					.pending_block(best_hash, &parent_header, xts)
+					.pending_block(best_hash, xts)
 					.map_err(|_| internal_err(format!("Runtime access error at {}", best_hash)))?;
 
 				let base_fee = api.gas_price(best_hash).unwrap_or_default();

--- a/client/rpc/src/eth/block.rs
+++ b/client/rpc/src/eth/block.rs
@@ -24,7 +24,9 @@ use jsonrpsee::core::RpcResult as Result;
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_network_common::ExHashT;
 use sc_transaction_pool::ChainApi;
+use sc_transaction_pool_api::InPoolTransaction;
 use sp_api::ProvideRuntimeApi;
+use sp_block_builder::BlockBuilder as BlockBuilderApi;
 use sp_blockchain::HeaderBackend;
 use sp_core::hashing::keccak_256;
 use sp_runtime::traits::Block as BlockT;
@@ -41,9 +43,10 @@ impl<B, C, P, CT, BE, H: ExHashT, A: ChainApi, EC: EthConfig<B, C>> Eth<B, C, P,
 where
 	B: BlockT,
 	C: ProvideRuntimeApi<B>,
-	C::Api: EthereumRuntimeRPCApi<B>,
+	C::Api: BlockBuilderApi<B> + EthereumRuntimeRPCApi<B>,
 	C: HeaderBackend<B> + StorageProvider<B, BE> + 'static,
 	BE: Backend<B>,
+	A: ChainApi<Block = B> + 'static,
 {
 	pub async fn block_by_hash(&self, hash: H256, full: bool) -> Result<Option<RichBlock>> {
 		let client = Arc::clone(&self.client);
@@ -93,44 +96,93 @@ where
 		let client = Arc::clone(&self.client);
 		let block_data_cache = Arc::clone(&self.block_data_cache);
 		let backend = Arc::clone(&self.backend);
+		let graph = Arc::clone(&self.graph);
 
-		let id = match frontier_backend_client::native_block_id::<B, C>(
+		match frontier_backend_client::native_block_id::<B, C>(
 			client.as_ref(),
 			backend.as_ref(),
 			Some(number),
 		)? {
-			Some(id) => id,
-			None => return Ok(None),
-		};
-		let substrate_hash = client
-			.expect_block_hash_from_id(&id)
-			.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
+			Some(id) => {
+				let substrate_hash = client
+					.expect_block_hash_from_id(&id)
+					.map_err(|_| internal_err(format!("Expect block number from id: {}", id)))?;
 
-		let schema = fc_storage::onchain_storage_schema(client.as_ref(), substrate_hash);
+				let schema = fc_storage::onchain_storage_schema(client.as_ref(), substrate_hash);
 
-		let block = block_data_cache.current_block(schema, substrate_hash).await;
-		let statuses = block_data_cache
-			.current_transaction_statuses(schema, substrate_hash)
-			.await;
+				let block = block_data_cache.current_block(schema, substrate_hash).await;
+				let statuses = block_data_cache
+					.current_transaction_statuses(schema, substrate_hash)
+					.await;
 
-		let base_fee = client
-			.runtime_api()
-			.gas_price(substrate_hash)
-			.unwrap_or_default();
+				let base_fee = client
+					.runtime_api()
+					.gas_price(substrate_hash)
+					.unwrap_or_default();
 
-		match (block, statuses) {
-			(Some(block), Some(statuses)) => {
-				let hash = H256::from(keccak_256(&rlp::encode(&block.header)));
+				match (block, statuses) {
+					(Some(block), Some(statuses)) => {
+						let hash = H256::from(keccak_256(&rlp::encode(&block.header)));
 
-				Ok(Some(rich_block_build(
-					block,
-					statuses.into_iter().map(Option::Some).collect(),
-					Some(hash),
-					full,
-					Some(base_fee),
-				)))
+						Ok(Some(rich_block_build(
+							block,
+							statuses.into_iter().map(Option::Some).collect(),
+							Some(hash),
+							full,
+							Some(base_fee),
+						)))
+					}
+					_ => Ok(None),
+				}
 			}
-			_ => Ok(None),
+			None if number == BlockNumber::Pending => {
+				let api = client.runtime_api();
+				let best_hash = client.info().best_hash;
+
+				let parent_header = client
+					.header(best_hash)
+					.map_err(|_| internal_err(format!("Runtime access error at {}", best_hash)))?
+					.ok_or_else(|| internal_err(format!("Block not found at {}", best_hash)))?;
+
+				// Get current in-pool transactions
+				let mut xts: Vec<<B as BlockT>::Extrinsic> = Vec::new();
+				// ready validated pool
+				xts.extend(
+					graph
+						.validated_pool()
+						.ready()
+						.map(|in_pool_tx| in_pool_tx.data().clone())
+						.collect::<Vec<<B as BlockT>::Extrinsic>>(),
+				);
+
+				// future validated pool
+				xts.extend(
+					graph
+						.validated_pool()
+						.futures()
+						.iter()
+						.map(|(_hash, extrinsic)| extrinsic.clone())
+						.collect::<Vec<<B as BlockT>::Extrinsic>>(),
+				);
+
+				let (block, statuses) = api
+					.pending_block(best_hash, &parent_header, xts)
+					.map_err(|_| internal_err(format!("Runtime access error at {}", best_hash)))?;
+
+				let base_fee = api.gas_price(best_hash).unwrap_or_default();
+
+				match (block, statuses) {
+					(Some(block), Some(statuses)) => Ok(Some(rich_block_build(
+						block,
+						statuses.into_iter().map(Option::Some).collect(),
+						None,
+						full,
+						Some(base_fee),
+					))),
+					_ => Ok(None),
+				}
+			}
+			None => Ok(None),
 		}
 	}
 

--- a/primitives/rpc/src/lib.rs
+++ b/primitives/rpc/src/lib.rs
@@ -209,7 +209,6 @@ sp_api::decl_runtime_apis! {
 		fn gas_limit_multiplier_support();
 		/// Return the pending block.
 		fn pending_block(
-			parent_header: &<Block as BlockT>::Header,
 			xts: Vec<<Block as BlockT>::Extrinsic>,
 		) -> (Option<ethereum::BlockV2>, Option<Vec<TransactionStatus>>);
 	}

--- a/primitives/rpc/src/lib.rs
+++ b/primitives/rpc/src/lib.rs
@@ -207,6 +207,11 @@ sp_api::decl_runtime_apis! {
 		/// Used to determine if gas limit multiplier for non-transactional calls (eth_call/estimateGas)
 		/// is supported.
 		fn gas_limit_multiplier_support();
+		/// Return the pending block.
+		fn pending_block(
+			parent_header: &<Block as BlockT>::Header,
+			xts: Vec<<Block as BlockT>::Extrinsic>,
+		) -> (Option<ethereum::BlockV2>, Option<Vec<TransactionStatus>>);
 	}
 
 	#[api_version(2)]

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -35,7 +35,7 @@ use frame_support::weights::constants::ParityDbWeight as RuntimeDbWeight;
 use frame_support::weights::constants::RocksDbWeight as RuntimeDbWeight;
 use frame_support::{
 	construct_runtime, parameter_types,
-	traits::{ConstU32, ConstU8, FindAuthor, KeyOwnerProofSystem, OnTimestampSet},
+	traits::{ConstU32, ConstU8, FindAuthor, KeyOwnerProofSystem, OnFinalize, OnTimestampSet},
 	weights::{constants::WEIGHT_REF_TIME_PER_MILLIS, ConstantMultiplier, IdentityFee, Weight},
 };
 use pallet_grandpa::{
@@ -766,6 +766,29 @@ impl_runtime_apis! {
 		}
 
 		fn gas_limit_multiplier_support() {}
+
+		fn pending_block(
+			parent_header: &<Block as BlockT>::Header,
+			xts: Vec<<Block as BlockT>::Extrinsic>,
+		) -> (Option<pallet_ethereum::Block>, Option<Vec<TransactionStatus>>) {
+			let block_number = parent_header.number + 1;
+			System::initialize(
+				&block_number,
+				&parent_header.hash(),
+				&parent_header.digest,
+			);
+
+			for ext in xts.into_iter() {
+				let _ = Executive::apply_extrinsic(ext);
+			}
+
+			Ethereum::on_finalize(block_number);
+
+			(
+				pallet_ethereum::CurrentBlock::<Runtime>::get(),
+				pallet_ethereum::CurrentTransactionStatuses::<Runtime>::get()
+			)
+		}
 	}
 
 	impl fp_rpc::ConvertTransactionRuntimeApi<Block> for Runtime {

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -768,21 +768,13 @@ impl_runtime_apis! {
 		fn gas_limit_multiplier_support() {}
 
 		fn pending_block(
-			parent_header: &<Block as BlockT>::Header,
 			xts: Vec<<Block as BlockT>::Extrinsic>,
 		) -> (Option<pallet_ethereum::Block>, Option<Vec<TransactionStatus>>) {
-			let block_number = parent_header.number + 1;
-			System::initialize(
-				&block_number,
-				&parent_header.hash(),
-				&parent_header.digest,
-			);
-
 			for ext in xts.into_iter() {
 				let _ = Executive::apply_extrinsic(ext);
 			}
 
-			Ethereum::on_finalize(block_number);
+			Ethereum::on_finalize(System::block_number() + 1);
 
 			(
 				pallet_ethereum::CurrentBlock::<Runtime>::get(),

--- a/ts-tests/tests/test-block.ts
+++ b/ts-tests/tests/test-block.ts
@@ -1,8 +1,8 @@
 import { expect } from "chai";
 import { step } from "mocha-steps";
 
-import { BLOCK_TIMESTAMP, ETH_BLOCK_GAS_LIMIT } from "./config";
-import { createAndFinalizeBlock, describeWithFrontier } from "./util";
+import { BLOCK_TIMESTAMP, ETH_BLOCK_GAS_LIMIT, GENESIS_ACCOUNT, GENESIS_ACCOUNT_PRIVATE_KEY } from "./config";
+import { createAndFinalizeBlock, describeWithFrontier, customRequest } from "./util";
 
 describeWithFrontier("Frontier RPC (Block)", (context) => {
 	let previousBlock;
@@ -143,5 +143,49 @@ describeWithFrontier("Frontier RPC (Block)", (context) => {
 		const block = await context.web3.eth.getBlock("latest");
 		expect(block.hash).to.not.equal(previousBlock.hash);
 		expect(block.parentHash).to.equal(previousBlock.hash);
+	});
+});
+
+describeWithFrontier("Frontier RPC (Pending Block)", (context) => {
+	const TEST_ACCOUNT = "0x1111111111111111111111111111111111111111";
+
+	it("should return pending block", async function () {
+		var nonce = 0;
+		let sendTransaction = async () => {
+			const tx = await context.web3.eth.accounts.signTransaction(
+				{
+					from: GENESIS_ACCOUNT,
+					to: TEST_ACCOUNT,
+					value: "0x200", // Must be higher than ExistentialDeposit
+					gasPrice: "0x3B9ACA00",
+					gas: "0x100000",
+					nonce: nonce,
+				},
+				GENESIS_ACCOUNT_PRIVATE_KEY
+			);
+			nonce = nonce + 1;
+			return (await customRequest(context.web3, "eth_sendRawTransaction", [tx.rawTransaction])).result;
+		};
+
+		// block 1 send 5 transactions
+		const expectedXtsNumber = 5;
+		for (var _ of Array(expectedXtsNumber)) {
+			await sendTransaction();
+		}
+
+		// do not seal, get pendign block
+		let pending_transactions = [];
+		{
+			const pending = (
+				await customRequest(context.web3, "eth_getBlockByNumber", ["pending", false])
+			).result;
+			pending_transactions = pending.transactions;
+			expect(pending_transactions.length).to.be.eq(expectedXtsNumber);
+		}
+
+		// seal and compare latest blocks transactions with the previously pending
+		await createAndFinalizeBlock(context.web3);
+		const latest_block = await context.web3.eth.getBlock("latest", false);
+		expect(pending_transactions).to.be.deep.eq(latest_block.transactions);
 	});
 });


### PR DESCRIPTION
Using `BlockNumber::Earliest` as part of `eth_getBlockByNumber` rpc returns `None`. This pr adds support for it adding a new runtime api that applies the _current_ pool and finalizes `pallet-ethereum`, returning the overlayed/pending ethereum block and statuses.