### PR TITLE
Fixed Dockerfile

### DIFF
--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /frontier
 
 # Upcd dates core parts
 RUN apt-get update -y && \
-	apt-get install -y cmake pkg-config libssl-dev git gcc build-essential clang libclang-dev
+	apt-get install -y cmake pkg-config libssl-dev git gcc build-essential clang libclang-dev protobuf-compiler
 
 # Install rust wasm. Needed for substrate wasm engine
 RUN rustup target add wasm32-unknown-unknown


### PR DESCRIPTION
The current docker file fails with the following error message when it is being built

```bash 
#10 188.0 error: failed to run custom build command for `libp2p-core v0.38.0`
#10 188.0 
#10 188.0 Caused by:
#10 188.0   process didn't exit successfully: `/frontier/target/release/build/libp2p-core-4b7c3497a9b3bacf/build-script-build` (exit status: 101)
#10 188.0   --- stderr
#10 188.0   thread 'main' panicked at 'Could not find `protoc` installation and this build crate cannot proceed without
#10 188.0       this knowledge. If `protoc` is installed and this crate had trouble finding
#10 188.0       it, you can set the `PROTOC` environment variable with the specific path to your
#10 188.0       installed `protoc` binary.If you're on debian, try `apt-get install protobuf-compiler` or download it from https://github.com/protocolbuffers/protobuf/releases
#10 188.0 
#10 188.0   For more information: https://docs.rs/prost-build/#sourcing-protoc
#10 188.0   ', /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/prost-build-0.11.6/src/lib.rs:1387:10
#10 188.0   note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
#10 188.0 warning: build failed, waiting for other jobs to finish...
```
can be fixed by installing protobuf-compiler explicitly during the dependency installation process