### PR TITLE
`eth_getLogs` return expected error/message for unknown hash

### DIFF
--- a/client/rpc/src/eth/filter.rs
+++ b/client/rpc/src/eth/filter.rs
@@ -402,7 +402,7 @@ where
 			.map_err(|err| internal_err(format!("{:?}", err)))?
 			{
 				Some(hash) => hash,
-				_ => return Ok(Vec::new()),
+				_ => return Err(crate::err(-32000, "unknown block", None)),
 			};
 			let schema = fc_storage::onchain_storage_schema(client.as_ref(), substrate_hash);
 

--- a/ts-tests/tests/test-log-filtering.ts
+++ b/ts-tests/tests/test-log-filtering.ts
@@ -83,4 +83,16 @@ describeWithFrontier("Frontier RPC (Log filtering)", (context) => {
 			expect(request.result.length).to.be.eq(0);
 		}
 	});
+
+	step("EthApi::getLogs - should return `unknown block`.", async function () {
+		let request = await customRequest(context.web3, "eth_getLogs", [{
+			blockHash: "0x1234000000000000000000000000000000000000000000000000000000000000"
+		}]);
+		expect(request.error.message).to.be.equal(
+			"unknown block"
+		);
+		expect(request.error.code).to.be.equal(
+			-32000
+		);
+	});
 });


### PR DESCRIPTION
As reported by a project deployed on moonbeam, calls to `eth_getLogs` with a non-existing `blockHash` should return an rpc error message `unknown block` (e.g. Infura webservices). This PR fixes it.