### PR TITLE
Check EIP-3607 at transaction validation

### DIFF
--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -492,6 +492,19 @@ impl<T: Config> Pallet<T> {
 		.and_then(|v| v.with_balance_for(&who))
 		.map_err(|e| e.0)?;
 
+		// EIP-3607: https://eips.ethereum.org/EIPS/eip-3607
+		// Do not allow transactions for which `tx.sender` has any code deployed.
+		//
+		// This check should be done on the transaction validation (here) **and**
+		// on trnasaction execution, otherwise a contract tx will be included in
+		// the mempool and pollute the mempool forever.
+		if !pallet_evm::AccountCodes::<T>::get(source).is_empty() {
+			return Err(RunnerError {
+				error: Error::<T>::TransactionMustComeFromEOA,
+				weight,
+			});
+		}
+
 		let priority = match (
 			transaction_data.gas_price,
 			transaction_data.max_fee_per_gas,


### PR DESCRIPTION
The EIP-3607 check should be done on the transaction validation (here) **and**on transaction execution, otherwise a transaction from a contract key will be included in the mempool and pollute the mempool forever.