### PR TITLE
track only unique block hashes when writing to DB

### DIFF
--- a/client/db/src/kv/mod.rs
+++ b/client/db/src/kv/mod.rs
@@ -308,13 +308,15 @@ impl<Block: BlockT> MappingDb<Block> {
 
 		let substrate_hashes = match self.block_hash(&commitment.ethereum_block_hash) {
 			Ok(Some(mut data)) => {
-				data.push(commitment.block_hash);
-				log::warn!(
-					target: "fc-db",
-					"Possible equivocation at ethereum block hash {} {:?}",
-					&commitment.ethereum_block_hash,
-					&data
-				);
+				if !data.contains(&commitment.block_hash) {
+					data.push(commitment.block_hash);
+					log::warn!(
+						target: "fc-db",
+						"Possible equivocation at ethereum block hash {} {:?}",
+						&commitment.ethereum_block_hash,
+						&data
+					);
+				}
 				data
 			}
 			_ => vec![commitment.block_hash],


### PR DESCRIPTION
Seems like import notifications is sending the block hash multiple times and everytime its called, even the same hash gets written to DB event though the DB has already seen it. This change should ensure we only write unique fork hashes