### PR TITLE
make sql and its dependencies optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9996,7 +9996,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.6",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/client/db/Cargo.toml
+++ b/client/db/Cargo.toml
@@ -12,33 +12,45 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 async-trait = "0.1"
-ethereum = { workspace = true, features = ["with-codec"] }
-futures = "0.3.25"
+ethereum = { workspace = true, features = ["with-codec"], optional = true }
+futures = { version = "0.3.25", optional = true }
 kvdb-rocksdb = { workspace = true, optional = true }
 log = "0.4.17"
 parity-db = { workspace = true, optional = true }
 parking_lot = "0.12.1"
 scale-codec = { package = "parity-scale-codec", workspace = true }
 smallvec = { version = "1.10", optional = true }
-sqlx = { workspace = true, features = ["runtime-tokio-native-tls", "sqlite"] }
-tokio = { version = "1.19", features = ["macros", "sync"] }
+sqlx = { workspace = true, features = ["runtime-tokio-native-tls", "sqlite"], optional = true }
+tokio = { version = "1.19", features = ["macros", "sync"], optional = true }
 # Substrate
-sc-client-api = { workspace = true }
+sc-client-api = { workspace = true, optional = true }
 sc-client-db = { workspace = true }
-sp-api = { workspace = true }
+sp-api = { workspace = true, optional = true }
 sp-blockchain = { workspace = true }
 sp-core = { workspace = true }
 sp-database = { workspace = true }
 sp-runtime = { workspace = true }
-sp-storage = { workspace = true }
+sp-storage = { workspace = true, optional = true }
 # Frontier
-fc-storage = { workspace = true }
-fp-consensus = { workspace = true, features = ["default"] }
-fp-rpc = { workspace = true, features = ["default"] }
+fc-storage = { workspace = true, optional = true }
+fp-consensus = { workspace = true, features = ["default"], optional = true }
+fp-rpc = { workspace = true, features = ["default"], optional = true }
 fp-storage = { workspace = true, features = ["default"] }
 
 [features]
 default = ["parity-db"]
+sql = [
+	"ethereum",
+	"futures",
+	"sqlx",
+	"tokio",
+	"sc-client-api",
+	"sp-api",
+	"sp-storage",
+	"fc-storage",
+	"fp-consensus",
+	"fp-rpc",
+]
 parity-db = ["dep:parity-db"]
 rocksdb = [
 	"kvdb-rocksdb",
@@ -47,6 +59,7 @@ rocksdb = [
 ]
 
 [dev-dependencies]
+futures = { version = "0.3.25" }
 maplit = "1.0.2"
 tempfile = "3.3.0"
 # Substrate

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -25,12 +25,15 @@ use sp_core::H256;
 use sp_runtime::traits::Block as BlockT;
 
 pub mod kv;
-pub mod sql;
 use kv::{columns, static_keys};
+
+#[cfg(feature = "sql")]
+pub mod sql;
 
 #[derive(Clone)]
 pub enum Backend<Block: BlockT> {
 	KeyValue(kv::Backend<Block>),
+	#[cfg(feature = "sql")]
 	Sql(sql::Backend<Block>),
 }
 

--- a/client/mapping-sync/Cargo.toml
+++ b/client/mapping-sync/Cargo.toml
@@ -15,20 +15,27 @@ futures = "0.3.25"
 futures-timer = "3.0.2"
 log = "0.4.17"
 parking_lot = "0.12.1"
-tokio = { version = "1.19", features = ["macros", "sync"] }
+tokio = { version = "1.19", features = ["macros", "sync"], optional = true }
 # Substrate
 sc-client-api = { workspace = true }
 sc-utils = { workspace = true }
 sp-api = { workspace = true }
 sp-blockchain = { workspace = true }
 sp-consensus = { workspace = true, features = ["default"] }
-sp-core = { workspace = true }
+sp-core = { workspace = true, optional = true }
 sp-runtime = { workspace = true }
 # Frontier
 fc-db = { workspace = true }
 fc-storage = { workspace = true }
 fp-consensus = { workspace = true, features = ["default"] }
 fp-rpc = { workspace = true, features = ["default"] }
+
+[features]
+sql = [
+	"tokio",
+	"sp-core",
+	"fc-db/sql",
+]
 
 [dev-dependencies]
 ethereum = { workspace = true }

--- a/client/mapping-sync/src/lib.rs
+++ b/client/mapping-sync/src/lib.rs
@@ -20,6 +20,7 @@
 #![allow(clippy::too_many_arguments)]
 
 pub mod kv;
+#[cfg(feature = "sql")]
 pub mod sql;
 
 use sp_api::BlockT;

--- a/template/node/Cargo.toml
+++ b/template/node/Cargo.toml
@@ -70,8 +70,8 @@ pallet-transaction-payment = { workspace = true }
 # Frontier
 fc-cli = { workspace = true }
 fc-consensus = { workspace = true }
-fc-db = { workspace = true }
-fc-mapping-sync = { workspace = true }
+fc-db = { workspace = true, features = ["default", "sql"] }
+fc-mapping-sync = { workspace = true, features = ["sql"] }
 fc-rpc = { workspace = true }
 fc-rpc-core = { workspace = true }
 fc-storage = { workspace = true }


### PR DESCRIPTION
Making SQL optional would be great and does not brings unwanted dependencies when SQL is not used. Here is an example: https://github.com/paritytech/frontier/issues/1086