### PR TITLE
Rename others `transaction_len` to `proof_size_base_cost`

### DIFF
--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -353,7 +353,8 @@ pub mod pallet {
 }
 
 impl<T: Config> Pallet<T> {
-	fn transaction_len(transaction: &Transaction) -> u64 {
+	/// The call wrapped in the extrinsic is part of the PoV, record this as a base cost for the size of the proof.
+	fn proof_size_base_cost(transaction: &Transaction) -> u64 {
 		transaction
 			.encode()
 			.len()
@@ -488,9 +489,10 @@ impl<T: Config> Pallet<T> {
 				transaction_data.gas_limit.unique_saturated_into(),
 				true,
 			) {
-				weight_limit if weight_limit.proof_size() > 0 => {
-					(Some(weight_limit), Some(Self::transaction_len(transaction)))
-				}
+				weight_limit if weight_limit.proof_size() > 0 => (
+					Some(weight_limit),
+					Some(Self::proof_size_base_cost(transaction)),
+				),
 				_ => (None, None),
 			};
 
@@ -772,14 +774,15 @@ impl<T: Config> Pallet<T> {
 		let is_transactional = true;
 		let validate = false;
 
-		let (transaction_len, weight_limit) =
+		let (proof_size_base_cost, weight_limit) =
 			match <T as pallet_evm::Config>::GasWeightMapping::gas_to_weight(
 				gas_limit.unique_saturated_into(),
 				true,
 			) {
-				weight_limit if weight_limit.proof_size() > 0 => {
-					(Some(Self::transaction_len(transaction)), Some(weight_limit))
-				}
+				weight_limit if weight_limit.proof_size() > 0 => (
+					Some(Self::proof_size_base_cost(transaction)),
+					Some(weight_limit),
+				),
 				_ => (None, None),
 			};
 		match action {
@@ -797,7 +800,7 @@ impl<T: Config> Pallet<T> {
 					is_transactional,
 					validate,
 					weight_limit,
-					transaction_len,
+					proof_size_base_cost,
 					config.as_ref().unwrap_or_else(|| T::config()),
 				) {
 					Ok(res) => res,
@@ -827,7 +830,7 @@ impl<T: Config> Pallet<T> {
 					is_transactional,
 					validate,
 					weight_limit,
-					transaction_len,
+					proof_size_base_cost,
 					config.as_ref().unwrap_or_else(|| T::config()),
 				) {
 					Ok(res) => res,
@@ -865,9 +868,10 @@ impl<T: Config> Pallet<T> {
 				transaction_data.gas_limit.unique_saturated_into(),
 				true,
 			) {
-				weight_limit if weight_limit.proof_size() > 0 => {
-					(Some(weight_limit), Some(Self::transaction_len(transaction)))
-				}
+				weight_limit if weight_limit.proof_size() > 0 => (
+					Some(weight_limit),
+					Some(Self::proof_size_base_cost(transaction)),
+				),
 				_ => (None, None),
 			};
 

--- a/frame/evm/src/runner/mod.rs
+++ b/frame/evm/src/runner/mod.rs
@@ -43,7 +43,7 @@ pub trait Runner<T: Config> {
 		access_list: Vec<(H160, Vec<H256>)>,
 		is_transactional: bool,
 		weight_limit: Option<Weight>,
-		transaction_len: Option<u64>,
+		proof_size_base_cost: Option<u64>,
 		evm_config: &evm::Config,
 	) -> Result<(), RunnerError<Self::Error>>;
 
@@ -60,7 +60,7 @@ pub trait Runner<T: Config> {
 		is_transactional: bool,
 		validate: bool,
 		weight_limit: Option<Weight>,
-		transaction_len: Option<u64>,
+		proof_size_base_cost: Option<u64>,
 		config: &evm::Config,
 	) -> Result<CallInfo, RunnerError<Self::Error>>;
 
@@ -76,7 +76,7 @@ pub trait Runner<T: Config> {
 		is_transactional: bool,
 		validate: bool,
 		weight_limit: Option<Weight>,
-		transaction_len: Option<u64>,
+		proof_size_base_cost: Option<u64>,
 		config: &evm::Config,
 	) -> Result<CreateInfo, RunnerError<Self::Error>>;
 
@@ -93,7 +93,7 @@ pub trait Runner<T: Config> {
 		is_transactional: bool,
 		validate: bool,
 		weight_limit: Option<Weight>,
-		transaction_len: Option<u64>,
+		proof_size_base_cost: Option<u64>,
 		config: &evm::Config,
 	) -> Result<CreateInfo, RunnerError<Self::Error>>;
 }

--- a/primitives/evm/src/lib.rs
+++ b/primitives/evm/src/lib.rs
@@ -84,18 +84,18 @@ pub struct WeightInfo {
 impl WeightInfo {
 	pub fn new_from_weight_limit(
 		weight_limit: Option<Weight>,
-		transaction_len: Option<u64>,
+		proof_size_base_cost: Option<u64>,
 	) -> Result<Option<Self>, &'static str> {
-		Ok(match (weight_limit, transaction_len) {
+		Ok(match (weight_limit, proof_size_base_cost) {
 			(None, _) => None,
-			(Some(weight_limit), Some(transaction_len))
-				if weight_limit.proof_size() >= transaction_len =>
+			(Some(weight_limit), Some(proof_size_base_cost))
+				if weight_limit.proof_size() >= proof_size_base_cost =>
 			{
 				Some(WeightInfo {
 					ref_time_limit: Some(weight_limit.ref_time()),
 					proof_size_limit: Some(weight_limit.proof_size()),
 					ref_time_usage: Some(0u64),
-					proof_size_usage: Some(transaction_len),
+					proof_size_usage: Some(proof_size_base_cost),
 				})
 			}
 			(Some(weight_limit), None) => Some(WeightInfo {


### PR DESCRIPTION
Most of  `transaction_len` are updated in the #1039 , some of them are missing. 