### PR TITLE
Handling `data` and `input` fields in `TransactionRequest` and `CallRequest`

### DIFF
--- a/client/rpc-core/src/types/call_request.rs
+++ b/client/rpc-core/src/types/call_request.rs
@@ -23,6 +23,7 @@ use ethereum_types::{H160, H256, U256};
 use serde::Deserialize;
 
 use crate::types::Bytes;
+use super::transaction_request::deserialize_data_input;
 
 /// Call request
 #[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize)]
@@ -44,7 +45,7 @@ pub struct CallRequest {
 	/// Value
 	pub value: Option<U256>,
 	/// Data
-	#[serde(alias = "input")]
+	#[serde(deserialize_with = "deserialize_data_input")]
 	pub data: Option<Bytes>,
 	/// Nonce
 	pub nonce: Option<U256>,

--- a/client/rpc-core/src/types/call_request.rs
+++ b/client/rpc-core/src/types/call_request.rs
@@ -20,15 +20,32 @@ use std::collections::BTreeMap;
 
 use ethereum::AccessListItem;
 use ethereum_types::{H160, H256, U256};
-use serde::{
-	de::{self, MapAccess, Visitor},
-	Deserialize, Deserializer,
-};
+use serde::{de::Error, Deserialize, Deserializer};
 
 use crate::types::Bytes;
 
+#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize)]
+pub struct CallOrInputData {
+	data: Option<Bytes>,
+	input: Option<Bytes>,
+}
+
+fn deserialize_data_or_input<'d, D: Deserializer<'d>>(d: D) -> Result<Option<Bytes>, D::Error> {
+    let CallOrInputData { data, input } = CallOrInputData::deserialize(d)?;
+	match (&data, &input) {
+		(Some(data), Some(input)) => if data == input {
+			Ok(Some(data.clone()))
+		} else {
+			Err(D::Error::custom("Ambiguous value for `data` and `input`".to_string()))
+		},
+		(_, _) => Ok(data.or(input))
+	}
+}
+
 /// Call request
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 pub struct CallRequest {
 	/// From
 	pub from: Option<H160>,
@@ -45,14 +62,14 @@ pub struct CallRequest {
 	/// Value
 	pub value: Option<U256>,
 	/// Data
+	#[serde(deserialize_with = "deserialize_data_or_input", flatten)]
 	pub data: Option<Bytes>,
-	/// Input
-	pub input: Option<Bytes>,
 	/// Nonce
 	pub nonce: Option<U256>,
 	/// AccessList
 	pub access_list: Option<Vec<AccessListItem>>,
 	/// EIP-2718 type
+	#[serde(rename = "type")]
 	pub transaction_type: Option<U256>,
 }
 
@@ -75,184 +92,8 @@ pub struct CallStateOverride {
 	pub state_diff: Option<BTreeMap<H256, H256>>,
 }
 
-impl<'de> Deserialize<'de> for CallRequest {
-	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-	where
-		D: Deserializer<'de>,
-	{
-		#[derive(Deserialize)]
-		#[serde(field_identifier, rename_all = "camelCase")]
-		enum Field {
-			From,
-			To,
-			GasPrice,
-			MaxFeePerGas,
-			MaxPriorityFeePerGas,
-			Gas,
-			Value,
-			Data,
-			Input,
-			Nonce,
-			AccessList,
-			Type,
-		}
-
-		struct CallRequestVisitor;
-
-		impl<'de> Visitor<'de> for CallRequestVisitor {
-			type Value = CallRequest;
-
-			fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-				formatter.write_str("struct CallRequest")
-			}
-
-			fn visit_map<V>(self, mut map: V) -> Result<CallRequest, V::Error>
-			where
-				V: MapAccess<'de>,
-			{
-				let mut from = None;
-				let mut to = None;
-				let mut gas_price = None;
-				let mut max_fee_per_gas = None;
-				let mut max_priority_fee_per_gas = None;
-				let mut gas = None;
-				let mut value = None;
-				let mut data = None;
-				let mut input = None;
-				let mut nonce = None;
-				let mut access_list = None;
-				let mut transaction_type = None;
-
-				while let Some(key) = map.next_key()? {
-					match key {
-						Field::From => {
-							if from.is_some() {
-								return Err(de::Error::duplicate_field("from"));
-							}
-							from = Some(map.next_value()?);
-						}
-						Field::To => {
-							if to.is_some() {
-								return Err(de::Error::duplicate_field("to"));
-							}
-							to = Some(map.next_value()?);
-						}
-						Field::GasPrice => {
-							if gas_price.is_some() {
-								return Err(de::Error::duplicate_field("gasPrice"));
-							}
-							gas_price = Some(map.next_value()?);
-						}
-						Field::MaxFeePerGas => {
-							if max_fee_per_gas.is_some() {
-								return Err(de::Error::duplicate_field("maxFeePerGas"));
-							}
-							max_fee_per_gas = Some(map.next_value()?);
-						}
-						Field::MaxPriorityFeePerGas => {
-							if max_priority_fee_per_gas.is_some() {
-								return Err(de::Error::duplicate_field("maxPriorityFeePerGas"));
-							}
-							max_priority_fee_per_gas = Some(map.next_value()?);
-						}
-						Field::Gas => {
-							if gas.is_some() {
-								return Err(de::Error::duplicate_field("gas"));
-							}
-							gas = Some(map.next_value()?);
-						}
-						Field::Value => {
-							if value.is_some() {
-								return Err(de::Error::duplicate_field("value"));
-							}
-							value = Some(map.next_value()?);
-						}
-						Field::Data => {
-							if data.is_some() {
-								return Err(de::Error::duplicate_field("data"));
-							}
-							data = Some(map.next_value()?);
-						}
-						Field::Input => {
-							if input.is_some() {
-								return Err(de::Error::duplicate_field("input"));
-							}
-							input = Some(map.next_value()?);
-						}
-						Field::Nonce => {
-							if nonce.is_some() {
-								return Err(de::Error::duplicate_field("nonce"));
-							}
-							nonce = Some(map.next_value()?);
-						}
-						Field::AccessList => {
-							if access_list.is_some() {
-								return Err(de::Error::duplicate_field("accessList"));
-							}
-							access_list = Some(map.next_value()?);
-						}
-						Field::Type => {
-							if transaction_type.is_some() {
-								return Err(de::Error::duplicate_field("type"));
-							}
-							transaction_type = Some(map.next_value()?);
-						}
-					}
-				}
-
-				match (data.as_ref(), input.as_ref()) {
-					(Some(data), Some(input)) if data != input => {
-						return Err(de::Error::custom(
-							"data and input must be equal when both are present",
-						))
-					}
-					// Assume that the data field is the input field if the data field is not present
-					// and the input field is present.
-					(None, Some(_)) => data = input.take(),
-					_ => {}
-				}
-
-				Ok(CallRequest {
-					from,
-					to,
-					gas_price,
-					max_fee_per_gas,
-					max_priority_fee_per_gas,
-					gas,
-					value,
-					data,
-					input,
-					nonce,
-					access_list,
-					transaction_type,
-				})
-			}
-		}
-
-		deserializer.deserialize_struct(
-			"CallRequest",
-			&[
-				"from",
-				"to",
-				"gasPrice",
-				"maxFeePerGas",
-				"maxPriorityFeePerGas",
-				"gas",
-				"value",
-				"data",
-				"input",
-				"nonce",
-				"accessList",
-				"type",
-			],
-			CallRequestVisitor,
-		)
-	}
-}
-
 #[cfg(test)]
 mod tests {
-	use std::str::FromStr;
 
 	use super::*;
 	use serde_json::json;
@@ -274,51 +115,6 @@ mod tests {
 			"type": "0x70"
 		});
 
-		let tr: CallRequest = serde_json::from_value(data).unwrap();
-
-		assert_eq!(
-			tr.from.unwrap(),
-			H160::from_str("0x60be2d1d3665660d22ff9624b7be0551ee1ac91b").unwrap()
-		);
-		assert_eq!(
-			tr.to.unwrap(),
-			H160::from_str("0x13fe2d1d3665660d22ff9624b7be0551ee1ac91b").unwrap()
-		);
-		assert_eq!(tr.gas_price.unwrap(), U256::from(0x10));
-		assert_eq!(tr.max_fee_per_gas.unwrap(), U256::from(0x20));
-		assert_eq!(tr.max_priority_fee_per_gas.unwrap(), U256::from(0x30));
-		assert_eq!(tr.gas.unwrap(), U256::from(0x40));
-		assert_eq!(tr.value.unwrap(), U256::from(0x50));
-		assert_eq!(tr.nonce.unwrap(), U256::from(0x60));
-		assert_eq!(tr.access_list.unwrap().len(), 1);
-		assert_eq!(tr.transaction_type.unwrap(), U256::from(0x70));
-	}
-
-	#[test]
-	fn test_deserialize_call_request_data_input_mismatch_error() {
-		let data = json!({
-			"data": "0xabc2",
-			"input": "0xdef1",
-		});
-
-		let result: Result<CallRequest, _> = serde_json::from_value(data);
-
-		assert!(result.is_err());
-		assert_eq!(
-			result.unwrap_err().to_string(),
-			"data and input must be equal when both are present"
-		);
-	}
-
-	#[test]
-	fn test_deserialize_call_request_data_input_equal() {
-		let data = json!({
-			"data": "0xabc2",
-			"input": "0xabc2",
-		});
-
-		let result: Result<CallRequest, _> = serde_json::from_value(data);
-
-		assert!(result.is_ok());
+		let _: CallRequest = serde_json::from_value(data).unwrap();
 	}
 }

--- a/client/rpc-core/src/types/call_request.rs
+++ b/client/rpc-core/src/types/call_request.rs
@@ -201,6 +201,8 @@ impl<'de> Deserialize<'de> for CallRequest {
 					(Some(data), Some(input)) if data != input => {
 						return Err(de::Error::custom("data and input must be equal when both are present"))
 					}
+					// Assume that the data field is the input field if the data field is not present
+					// and the input field is present.
 					(None, Some(_)) => data = input.take(),
 					_ => {}
 				}
@@ -240,5 +242,78 @@ impl<'de> Deserialize<'de> for CallRequest {
 			],
 			CallRequestVisitor,
 		)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::str::FromStr;
+
+	use super::*;
+	use serde_json::json;
+
+	#[test]
+	fn test_deserialize_call_request() {
+		let data = json!({
+			"from": "0x60be2d1d3665660d22ff9624b7be0551ee1ac91b",
+			"to": "0x13fe2d1d3665660d22ff9624b7be0551ee1ac91b",
+			"gasPrice": "0x10",
+			"maxFeePerGas": "0x20",
+			"maxPriorityFeePerGas": "0x30",
+			"gas": "0x40",
+			"value": "0x50",
+			"data": "0x123abc",
+			"input": "0x123abc",
+			"nonce": "0x60",
+			"accessList": [{"address": "0x60be2d1d3665660d22ff9624b7be0551ee1ac91b", "storageKeys": []}],
+			"type": "0x70"
+		});
+
+		let tr: CallRequest = serde_json::from_value(data).unwrap();
+
+		assert_eq!(
+			tr.from.unwrap(),
+			H160::from_str("0x60be2d1d3665660d22ff9624b7be0551ee1ac91b").unwrap()
+		);
+		assert_eq!(
+			tr.to.unwrap(),
+			H160::from_str("0x13fe2d1d3665660d22ff9624b7be0551ee1ac91b").unwrap()
+		);
+		assert_eq!(tr.gas_price.unwrap(), U256::from(0x10));
+		assert_eq!(tr.max_fee_per_gas.unwrap(), U256::from(0x20));
+		assert_eq!(tr.max_priority_fee_per_gas.unwrap(), U256::from(0x30));
+		assert_eq!(tr.gas.unwrap(), U256::from(0x40));
+		assert_eq!(tr.value.unwrap(), U256::from(0x50));
+		assert_eq!(tr.nonce.unwrap(), U256::from(0x60));
+		assert_eq!(tr.access_list.unwrap().len(), 1);
+		assert_eq!(tr.transaction_type.unwrap(), U256::from(0x70));
+	}
+
+	#[test]
+	fn test_deserialize_call_request_data_input_mismatch_error() {
+		let data = json!({
+			"data": "0xabc2",
+			"input": "0xdef1",
+		});
+
+		let result: Result<CallRequest, _> = serde_json::from_value(data);
+
+		assert!(result.is_err());
+		assert_eq!(
+			result.unwrap_err().to_string(),
+			"data and input must be equal when both are present"
+		);
+	}
+
+	#[test]
+	fn test_deserialize_call_request_data_input_equal() {
+		let data = json!({
+			"data": "0xabc2",
+			"input": "0xabc2",
+		});
+
+		let result: Result<CallRequest, _> = serde_json::from_value(data);
+
+		assert!(result.is_ok());
 	}
 }

--- a/client/rpc-core/src/types/call_request.rs
+++ b/client/rpc-core/src/types/call_request.rs
@@ -20,7 +20,10 @@ use std::collections::BTreeMap;
 
 use ethereum::AccessListItem;
 use ethereum_types::{H160, H256, U256};
-use serde::{de::{Visitor, MapAccess, self}, Deserialize, Deserializer};
+use serde::{
+	de::{self, MapAccess, Visitor},
+	Deserialize, Deserializer,
+};
 
 use crate::types::Bytes;
 
@@ -199,7 +202,9 @@ impl<'de> Deserialize<'de> for CallRequest {
 
 				match (data.as_ref(), input.as_ref()) {
 					(Some(data), Some(input)) if data != input => {
-						return Err(de::Error::custom("data and input must be equal when both are present"))
+						return Err(de::Error::custom(
+							"data and input must be equal when both are present",
+						))
 					}
 					// Assume that the data field is the input field if the data field is not present
 					// and the input field is present.

--- a/client/rpc-core/src/types/call_request.rs
+++ b/client/rpc-core/src/types/call_request.rs
@@ -30,15 +30,21 @@ pub(crate) struct CallOrInputData {
 	input: Option<Bytes>,
 }
 
-pub(crate) fn deserialize_data_or_input<'d, D: Deserializer<'d>>(d: D) -> Result<Option<Bytes>, D::Error> {
-    let CallOrInputData { data, input } = CallOrInputData::deserialize(d)?;
+pub(crate) fn deserialize_data_or_input<'d, D: Deserializer<'d>>(
+	d: D,
+) -> Result<Option<Bytes>, D::Error> {
+	let CallOrInputData { data, input } = CallOrInputData::deserialize(d)?;
 	match (&data, &input) {
-		(Some(data), Some(input)) => if data == input {
-			Ok(Some(data.clone()))
-		} else {
-			Err(D::Error::custom("Ambiguous value for `data` and `input`".to_string()))
-		},
-		(_, _) => Ok(data.or(input))
+		(Some(data), Some(input)) => {
+			if data == input {
+				Ok(Some(data.clone()))
+			} else {
+				Err(D::Error::custom(
+					"Ambiguous value for `data` and `input`".to_string(),
+				))
+			}
+		}
+		(_, _) => Ok(data.or(input)),
 	}
 }
 

--- a/client/rpc-core/src/types/call_request.rs
+++ b/client/rpc-core/src/types/call_request.rs
@@ -20,15 +20,12 @@ use std::collections::BTreeMap;
 
 use ethereum::AccessListItem;
 use ethereum_types::{H160, H256, U256};
-use serde::Deserialize;
+use serde::{de::{Visitor, MapAccess, self}, Deserialize, Deserializer};
 
 use crate::types::Bytes;
-use super::transaction_request::deserialize_data_input;
 
 /// Call request
-#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize)]
-#[serde(deny_unknown_fields)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct CallRequest {
 	/// From
 	pub from: Option<H160>,
@@ -45,14 +42,14 @@ pub struct CallRequest {
 	/// Value
 	pub value: Option<U256>,
 	/// Data
-	#[serde(deserialize_with = "deserialize_data_input")]
 	pub data: Option<Bytes>,
+	/// Input
+	pub input: Option<Bytes>,
 	/// Nonce
 	pub nonce: Option<U256>,
 	/// AccessList
 	pub access_list: Option<Vec<AccessListItem>>,
 	/// EIP-2718 type
-	#[serde(rename = "type")]
 	pub transaction_type: Option<U256>,
 }
 
@@ -73,4 +70,175 @@ pub struct CallStateOverride {
 	/// Fake key-value mapping to override individual slots in the account storage before
 	/// executing the call.
 	pub state_diff: Option<BTreeMap<H256, H256>>,
+}
+
+impl<'de> Deserialize<'de> for CallRequest {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		#[derive(Deserialize)]
+		#[serde(field_identifier, rename_all = "camelCase")]
+		enum Field {
+			From,
+			To,
+			GasPrice,
+			MaxFeePerGas,
+			MaxPriorityFeePerGas,
+			Gas,
+			Value,
+			Data,
+			Input,
+			Nonce,
+			AccessList,
+			Type,
+		}
+
+		struct CallRequestVisitor;
+
+		impl<'de> Visitor<'de> for CallRequestVisitor {
+			type Value = CallRequest;
+
+			fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+				formatter.write_str("struct CallRequest")
+			}
+
+			fn visit_map<V>(self, mut map: V) -> Result<CallRequest, V::Error>
+			where
+				V: MapAccess<'de>,
+			{
+				let mut from = None;
+				let mut to = None;
+				let mut gas_price = None;
+				let mut max_fee_per_gas = None;
+				let mut max_priority_fee_per_gas = None;
+				let mut gas = None;
+				let mut value = None;
+				let mut data = None;
+				let mut input = None;
+				let mut nonce = None;
+				let mut access_list = None;
+				let mut transaction_type = None;
+
+				while let Some(key) = map.next_key()? {
+					match key {
+						Field::From => {
+							if from.is_some() {
+								return Err(de::Error::duplicate_field("from"));
+							}
+							from = Some(map.next_value()?);
+						}
+						Field::To => {
+							if to.is_some() {
+								return Err(de::Error::duplicate_field("to"));
+							}
+							to = Some(map.next_value()?);
+						}
+						Field::GasPrice => {
+							if gas_price.is_some() {
+								return Err(de::Error::duplicate_field("gasPrice"));
+							}
+							gas_price = Some(map.next_value()?);
+						}
+						Field::MaxFeePerGas => {
+							if max_fee_per_gas.is_some() {
+								return Err(de::Error::duplicate_field("maxFeePerGas"));
+							}
+							max_fee_per_gas = Some(map.next_value()?);
+						}
+						Field::MaxPriorityFeePerGas => {
+							if max_priority_fee_per_gas.is_some() {
+								return Err(de::Error::duplicate_field("maxPriorityFeePerGas"));
+							}
+							max_priority_fee_per_gas = Some(map.next_value()?);
+						}
+						Field::Gas => {
+							if gas.is_some() {
+								return Err(de::Error::duplicate_field("gas"));
+							}
+							gas = Some(map.next_value()?);
+						}
+						Field::Value => {
+							if value.is_some() {
+								return Err(de::Error::duplicate_field("value"));
+							}
+							value = Some(map.next_value()?);
+						}
+						Field::Data => {
+							if data.is_some() {
+								return Err(de::Error::duplicate_field("data"));
+							}
+							data = Some(map.next_value()?);
+						}
+						Field::Input => {
+							if input.is_some() {
+								return Err(de::Error::duplicate_field("input"));
+							}
+							input = Some(map.next_value()?);
+						}
+						Field::Nonce => {
+							if nonce.is_some() {
+								return Err(de::Error::duplicate_field("nonce"));
+							}
+							nonce = Some(map.next_value()?);
+						}
+						Field::AccessList => {
+							if access_list.is_some() {
+								return Err(de::Error::duplicate_field("accessList"));
+							}
+							access_list = Some(map.next_value()?);
+						}
+						Field::Type => {
+							if transaction_type.is_some() {
+								return Err(de::Error::duplicate_field("type"));
+							}
+							transaction_type = Some(map.next_value()?);
+						}
+					}
+				}
+
+				match (data.as_ref(), input.as_ref()) {
+					(Some(data), Some(input)) if data != input => {
+						return Err(de::Error::custom("data and input must be equal when both are present"))
+					}
+					(None, Some(_)) => data = input.take(),
+					_ => {}
+				}
+
+				Ok(CallRequest {
+					from,
+					to,
+					gas_price,
+					max_fee_per_gas,
+					max_priority_fee_per_gas,
+					gas,
+					value,
+					data,
+					input,
+					nonce,
+					access_list,
+					transaction_type,
+				})
+			}
+		}
+
+		deserializer.deserialize_struct(
+			"CallRequest",
+			&[
+				"from",
+				"to",
+				"gasPrice",
+				"maxFeePerGas",
+				"maxPriorityFeePerGas",
+				"gas",
+				"value",
+				"data",
+				"input",
+				"nonce",
+				"accessList",
+				"type",
+			],
+			CallRequestVisitor,
+		)
+	}
 }

--- a/client/rpc-core/src/types/transaction_request.rs
+++ b/client/rpc-core/src/types/transaction_request.rs
@@ -121,7 +121,6 @@ impl From<TransactionRequest> for Option<TransactionMessage> {
 	}
 }
 
-
 #[cfg(test)]
 mod tests {
 

--- a/client/rpc-core/src/types/transaction_request.rs
+++ b/client/rpc-core/src/types/transaction_request.rs
@@ -123,7 +123,7 @@ impl From<TransactionRequest> for Option<TransactionMessage> {
 }
 
 
-fn deserialize_data_input<'de, D>(deserializer: D) -> Result<Option<Bytes>, D::Error>
+pub(crate) fn deserialize_data_input<'de, D>(deserializer: D) -> Result<Option<Bytes>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -158,7 +158,7 @@ where
                         value = new_value;
                     }
                     Field::Other => {
-                        let _: serde::de::IgnoredAny = map.next_value()?;
+                        let _ = map.next_value()?;
                     }
                 }
             }

--- a/ts-tests/tests/test-execute.ts
+++ b/ts-tests/tests/test-execute.ts
@@ -261,6 +261,6 @@ describeWithFrontier("Frontier RPC (RPC execution)", (context) => {
 				input: "0x12345678",
 			},
 		]);
-		expect((result as any).error.message).to.match(/^data and input must be equal when both are present/);
+		expect((result as any).error.message).to.match(/^Ambiguous value for `data` and `input`/);
 	});
 });

--- a/ts-tests/tests/test-execute.ts
+++ b/ts-tests/tests/test-execute.ts
@@ -238,4 +238,29 @@ describeWithFrontier("Frontier RPC (RPC execution)", (context) => {
 
 		expect(result.result).to.be.equal(TEST_CONTRACT_DEPLOYED_BYTECODE);
 	});
+
+	step("Deserializes correctly when data and input are equal", async function () {
+		const result = await customRequest(context.web3, "eth_call", [
+			{
+				from: GENESIS_ACCOUNT,
+				gas: `0x${(ETH_BLOCK_GAS_LIMIT - 1).toString(16)}`,
+				data: TEST_CONTRACT_BYTECODE,
+				input: TEST_CONTRACT_BYTECODE,
+			},
+		]);
+
+		expect(result.result).to.be.equal(TEST_CONTRACT_DEPLOYED_BYTECODE);
+	});
+
+	step("Throws error when data and input are both present and not equal", async function () {
+		const result = await customRequest(context.web3, "eth_call", [
+			{
+				from: GENESIS_ACCOUNT,
+				gas: `0x${(ETH_BLOCK_GAS_LIMIT - 1).toString(16)}`,
+				data: TEST_CONTRACT_BYTECODE,
+				input: "0x12345678",
+			},
+		]);
+		expect((result as any).error.message).to.match(/^data and input must be equal when both are present/);
+	});
 });


### PR DESCRIPTION
This PR refines the handling of `data` and `input` fields in TransactionRequest and CallRequest. Previously, provision of both fields resulted in errors. 

Key updates in this PR:

1. Identical `data` and `input` fields no longer throw errors.
2. If `data` and `input` fields differ, an error is returned to prevent ambiguity.
3. If only `input` is provided, its value is used for `data`.
   