### PR TITLE
Fix bug estimate used gas and estimation for WeightV2

### DIFF
--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -683,7 +683,10 @@ impl<T: Config> Pallet<T> {
 		Ok(PostDispatchInfo {
 			actual_weight: {
 				let mut gas_to_weight = T::GasWeightMapping::gas_to_weight(
-					used_gas.standard.unique_saturated_into(),
+					sp_std::cmp::max(
+						used_gas.standard.unique_saturated_into(),
+						used_gas.effective.unique_saturated_into(),
+					),
 					true,
 				);
 				if let Some(weight_info) = weight_info {


### PR DESCRIPTION
Solves https://github.com/paritytech/frontier/issues/1100

Some changes that we included on Moonbeam were missing upstream:

- Currently pallet-ethereum `PostDispatchInfo` included the legacy/standard used gas but the block includes the effective gas data. This is an issue for producing blocks, as we hint the block builder way less available resources left than actually are.
- Gas estimation using binary search need to be updated to WeightV2 (basically the ethereum `call` runtime api).   