### PR TITLE
feat: make txpool rpc optional

### DIFF
--- a/client/rpc-core/Cargo.toml
+++ b/client/rpc-core/Cargo.toml
@@ -17,3 +17,6 @@ jsonrpsee = { workspace = true, features = ["server", "macros"] }
 rustc-hex = "2.1.0"
 serde = { workspace = true }
 serde_json = { workspace = true }
+
+[features]
+txpool = []

--- a/client/rpc-core/src/lib.rs
+++ b/client/rpc-core/src/lib.rs
@@ -23,13 +23,15 @@ pub mod types;
 mod eth;
 mod eth_pubsub;
 mod net;
+#[cfg(feature = "txpool")]
 mod txpool;
 mod web3;
 
+#[cfg(feature = "txpool")]
+pub use self::txpool::TxPoolApiServer;
 pub use self::{
 	eth::{EthApiServer, EthFilterApiServer},
 	eth_pubsub::EthPubSubApiServer,
 	net::NetApiServer,
-	txpool::TxPoolApiServer,
 	web3::Web3ApiServer,
 };

--- a/client/rpc-core/src/types/mod.rs
+++ b/client/rpc-core/src/types/mod.rs
@@ -31,11 +31,14 @@ mod receipt;
 mod sync;
 mod transaction;
 mod transaction_request;
+#[cfg(feature = "txpool")]
 mod txpool;
 mod work;
 
 pub mod pubsub;
 
+#[cfg(feature = "txpool")]
+pub use self::txpool::{Get, Summary, TransactionMap, TxPoolResult, TxPoolTransaction};
 pub use self::{
 	account_info::{AccountInfo, EthAccount, ExtAccountInfo, RecoveredAccount, StorageProof},
 	block::{Block, BlockTransactions, Header, Rich, RichBlock, RichHeader},
@@ -56,6 +59,5 @@ pub use self::{
 	},
 	transaction::{LocalTransactionStatus, RichRawTransaction, Transaction},
 	transaction_request::{TransactionMessage, TransactionRequest},
-	txpool::{Get, Summary, TransactionMap, TxPoolResult, TxPoolTransaction},
 	work::Work,
 };

--- a/client/rpc-core/src/types/txpool.rs
+++ b/client/rpc-core/src/types/txpool.rs
@@ -21,7 +21,7 @@ use std::collections::HashMap;
 use ethereum::{TransactionAction, TransactionV2 as EthereumTransaction};
 use ethereum_types::{H160, H256, U256};
 use serde::{Serialize, Serializer};
-// Frontier
+
 use crate::types::Bytes;
 
 pub type TransactionMap<T> = HashMap<H160, HashMap<U256, T>>;

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -73,4 +73,5 @@ rocksdb = [
 	"fc-db/rocksdb",
 	"fc-mapping-sync/rocksdb",
 ]
+txpool = ["fc-rpc-core/txpool"]
 rpc-binary-search-estimate = []

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -30,22 +30,24 @@ mod eth;
 mod eth_pubsub;
 mod net;
 mod signer;
+#[cfg(feature = "txpool")]
 mod txpool;
 mod web3;
 
+#[cfg(feature = "txpool")]
+pub use self::txpool::TxPool;
 pub use self::{
 	eth::{format, EstimateGasAdapter, Eth, EthBlockDataCacheTask, EthConfig, EthFilter, EthTask},
 	eth_pubsub::{EthPubSub, EthereumSubIdProvider},
 	net::Net,
 	signer::{EthDevSigner, EthSigner},
-	txpool::TxPool,
 	web3::Web3,
 };
-
 pub use ethereum::TransactionV2 as EthereumTransaction;
+#[cfg(feature = "txpool")]
+pub use fc_rpc_core::TxPoolApiServer;
 pub use fc_rpc_core::{
-	EthApiServer, EthFilterApiServer, EthPubSubApiServer, NetApiServer, TxPoolApiServer,
-	Web3ApiServer,
+	EthApiServer, EthFilterApiServer, EthPubSubApiServer, NetApiServer, Web3ApiServer,
 };
 pub use fc_storage::{
 	OverrideHandle, RuntimeApiStorageOverride, SchemaV1Override, SchemaV2Override,

--- a/template/node/Cargo.toml
+++ b/template/node/Cargo.toml
@@ -89,6 +89,7 @@ default = [
 	"with-rocksdb-weights",
 	"rocksdb",
 	"sql",
+	"txpool",
 ]
 rocksdb = [
 	"sc-cli/rocksdb",
@@ -104,6 +105,7 @@ sql = [
 ]
 with-rocksdb-weights = ["frontier-template-runtime/with-rocksdb-weights"]
 with-paritydb-weights = ["frontier-template-runtime/with-paritydb-weights"]
+txpool = ["fc-rpc/txpool"]
 rpc-binary-search-estimate = ["fc-rpc/rpc-binary-search-estimate"]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/template/node/src/rpc/eth.rs
+++ b/template/node/src/rpc/eth.rs
@@ -17,7 +17,7 @@ use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
 use sp_core::H256;
 use sp_runtime::traits::Block as BlockT;
 // Frontier
-pub use fc_rpc::{EthBlockDataCacheTask, EthConfig, OverrideHandle, StorageOverride, TxPool};
+pub use fc_rpc::{EthBlockDataCacheTask, EthConfig, OverrideHandle, StorageOverride};
 pub use fc_rpc_core::types::{FeeHistoryCache, FeeHistoryCacheLimit, FilterPool};
 pub use fc_storage::overrides_handle;
 use fp_rpc::{ConvertTransaction, ConvertTransactionRuntimeApi, EthereumRuntimeRPCApi};
@@ -109,8 +109,10 @@ where
 {
 	use fc_rpc::{
 		Eth, EthApiServer, EthDevSigner, EthFilter, EthFilterApiServer, EthPubSub,
-		EthPubSubApiServer, EthSigner, Net, NetApiServer, TxPoolApiServer, Web3, Web3ApiServer,
+		EthPubSubApiServer, EthSigner, Net, NetApiServer, Web3, Web3ApiServer,
 	};
+	#[cfg(feature = "txpool")]
+	use fc_rpc::{TxPool, TxPoolApiServer};
 
 	let EthDeps {
 		client,
@@ -158,13 +160,12 @@ where
 		.into_rpc(),
 	)?;
 
-	let tx_pool = TxPool::new(client.clone(), graph);
 	if let Some(filter_pool) = filter_pool {
 		io.merge(
 			EthFilter::new(
 				client.clone(),
 				frontier_backend,
-				tx_pool.clone(),
+				graph.clone(),
 				filter_pool,
 				500_usize, // max stored filters
 				max_past_logs,
@@ -196,8 +197,10 @@ where
 		.into_rpc(),
 	)?;
 
-	io.merge(Web3::new(client).into_rpc())?;
-	io.merge(tx_pool.into_rpc())?;
+	io.merge(Web3::new(client.clone()).into_rpc())?;
+
+	#[cfg(feature = "txpool")]
+	io.merge(TxPool::new(client, graph).into_rpc())?;
 
 	Ok(io)
 }


### PR DESCRIPTION
The `txpool` is a set of client-specific rpc, not core rpc, so I think it would be better to use a feature to enable it.