### PR TITLE
impl from<[u8;32]> for accountid20

### DIFF
--- a/primitives/account/src/lib.rs
+++ b/primitives/account/src/lib.rs
@@ -151,6 +151,14 @@ impl From<ecdsa::Public> for AccountId20 {
 	}
 }
 
+impl From<[u8; 32]> for AccountId20 {
+	fn from(bytes: [u8; 32]) -> Self {
+		let mut buffer = [0u8; 20];
+		buffer.copy_from_slice(&bytes[..20]);
+		Self(buffer)
+	}
+}
+
 #[derive(Eq, PartialEq, Clone, RuntimeDebug, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EthereumSignature(ecdsa::Signature);


### PR DESCRIPTION
It adds from<[u8;32]> for accountId20. Useful for some XCM structures like https://github.com/paritytech/polkadot/blob/6b06242190dc68385ab36d8d8f4b6c6a269f1857/xcm/xcm-builder/src/location_conversion.rs#L120