### PR TITLE
Add force-debug feature to pallet-evm and fp-evm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2181,7 +2181,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "evm"
 version = "0.39.1"
-source = "git+https://github.com/rust-blockchain/evm?rev=b7b82c7e1fc57b7449d6dfa6826600de37cc1e65#b7b82c7e1fc57b7449d6dfa6826600de37cc1e65"
+source = "git+https://github.com/rust-blockchain/evm?rev=a33ac87ad7462b7e7029d12c385492b2a8311d1c#a33ac87ad7462b7e7029d12c385492b2a8311d1c"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -2201,8 +2201,9 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.39.0"
-source = "git+https://github.com/rust-blockchain/evm?rev=b7b82c7e1fc57b7449d6dfa6826600de37cc1e65#b7b82c7e1fc57b7449d6dfa6826600de37cc1e65"
+source = "git+https://github.com/rust-blockchain/evm?rev=a33ac87ad7462b7e7029d12c385492b2a8311d1c#a33ac87ad7462b7e7029d12c385492b2a8311d1c"
 dependencies = [
+ "log",
  "parity-scale-codec",
  "primitive-types",
  "scale-info",
@@ -2212,18 +2213,19 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.39.0"
-source = "git+https://github.com/rust-blockchain/evm?rev=b7b82c7e1fc57b7449d6dfa6826600de37cc1e65#b7b82c7e1fc57b7449d6dfa6826600de37cc1e65"
+source = "git+https://github.com/rust-blockchain/evm?rev=a33ac87ad7462b7e7029d12c385492b2a8311d1c#a33ac87ad7462b7e7029d12c385492b2a8311d1c"
 dependencies = [
  "environmental",
  "evm-core",
  "evm-runtime",
+ "log",
  "primitive-types",
 ]
 
 [[package]]
 name = "evm-runtime"
 version = "0.39.0"
-source = "git+https://github.com/rust-blockchain/evm?rev=b7b82c7e1fc57b7449d6dfa6826600de37cc1e65#b7b82c7e1fc57b7449d6dfa6826600de37cc1e65"
+source = "git+https://github.com/rust-blockchain/evm?rev=a33ac87ad7462b7e7029d12c385492b2a8311d1c#a33ac87ad7462b7e7029d12c385492b2a8311d1c"
 dependencies = [
  "auto_impl",
  "environmental",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ derive_more = "0.99"
 environmental = { version = "1.1.4", default-features = false }
 ethereum = { version = "0.14.0", default-features = false }
 ethereum-types = { version = "0.14.1", default-features = false }
-evm = { git = "https://github.com/rust-blockchain/evm", rev = "b7b82c7e1fc57b7449d6dfa6826600de37cc1e65", default-features = false }
+evm = { git = "https://github.com/rust-blockchain/evm", rev = "a33ac87ad7462b7e7029d12c385492b2a8311d1c", default-features = false }
 futures = "0.3.28"
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 hex-literal = "0.4.1"

--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -73,3 +73,4 @@ try-runtime = [
 	"frame-system/try-runtime",
 ]
 forbid-evm-reentrancy = ["dep:environmental"]
+force-debug = [ "evm/force-debug" ]

--- a/primitives/evm/Cargo.toml
+++ b/primitives/evm/Cargo.toml
@@ -43,3 +43,4 @@ serde = [
 	"sp-core/serde",
 	"sp-runtime/serde",
 ]
+force-debug = ["evm/force-debug"]

--- a/template/runtime/Cargo.toml
+++ b/template/runtime/Cargo.toml
@@ -123,3 +123,4 @@ runtime-benchmarks = [
 	"pallet-evm/runtime-benchmarks",
 	"pallet-hotfix-sufficients/runtime-benchmarks",
 ]
+force-debug = [ "fp-evm/force-debug" ]


### PR DESCRIPTION
Marked as draft because updating the version of `evm` breaks the build.