### PR TITLE
Initial support for asynchronous suiciding

### DIFF
--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -811,7 +811,7 @@ impl<T: Config> Pallet<T> {
 
 	/// Create an account.
 	pub fn create_account(address: H160, code: Vec<u8>) {
-		if <Suicided<T>>::contains_key(&address) {
+		if <Suicided<T>>::contains_key(address) {
 			// This branch should never trigger, because when Suicided
 			// contains an address, then its nonce will be at least one,
 			// which causes CreateCollision error in EVM, but we add it

--- a/frame/evm/src/tests.rs
+++ b/frame/evm/src/tests.rs
@@ -1037,8 +1037,7 @@ fn handle_sufficient_reference() {
 		assert_eq!(account_2.sufficients, 1);
 		EVM::remove_account(&addr_2);
 		let account_2 = frame_system::Account::<Test>::get(substrate_addr_2);
-		// We decreased the sufficient reference by 1 on removing the account.
-		assert_eq!(account_2.sufficients, 0);
+		assert_eq!(account_2.sufficients, 1);
 	});
 }
 


### PR DESCRIPTION
Add initial support for async suiciding. We might also want to add a governance dispatchable in the future so that storages can be cleared, if needed.