### PR TITLE
Clear error type

### DIFF
--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -488,12 +488,16 @@ pub mod pallet {
 		GasLimitTooLow,
 		/// Gas limit is too high.
 		GasLimitTooHigh,
-		/// Undefined error.
-		Undefined,
+		/// The chain id is invalid.
+		InvalidChainId,
+		/// the signature is invalid.
+		InvalidSignature,
 		/// EVM reentrancy
 		Reentrancy,
 		/// EIP-3607,
 		TransactionMustComeFromEOA,
+		/// Undefined error.
+		Undefined,
 	}
 
 	impl<T> From<TransactionValidationError> for Error<T> {
@@ -507,7 +511,9 @@ pub mod pallet {
 				TransactionValidationError::GasPriceTooLow => Error::<T>::GasPriceTooLow,
 				TransactionValidationError::PriorityFeeTooHigh => Error::<T>::GasPriceTooLow,
 				TransactionValidationError::InvalidFeeInput => Error::<T>::GasPriceTooLow,
-				_ => Error::<T>::Undefined,
+				TransactionValidationError::InvalidChainId => Error::<T>::InvalidChainId,
+				TransactionValidationError::InvalidSignature => Error::<T>::InvalidSignature,
+				TransactionValidationError::UnknownError => Error::<T>::Undefined,
 			}
 		}
 	}

--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -156,7 +156,7 @@ where
 		let maybe_weight_info =
 			WeightInfo::new_from_weight_limit(weight_limit, proof_size_base_cost).map_err(
 				|_| RunnerError {
-					error: Error::<T>::Undefined,
+					error: Error::<T>::GasLimitTooLow,
 					weight,
 				},
 			)?;


### PR DESCRIPTION
```rs
// Used to record the external costs in the evm through the StackState implementation
let maybe_weight_info =
	WeightInfo::new_from_weight_limit(weight_limit, proof_size_base_cost).map_err(
		|_| RunnerError {
			error: Error::<T>::Undefined,
			weight,
		},
	)?;
```

The `weight_limit.proof_size() < proof_size_base_cost` case deserves a better error message with clear meaning.
