### PR TITLE
Polkadot v1.1.0 consensus data providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2618,7 +2618,7 @@ dependencies = [
  "sc-block-builder",
  "sc-client-api",
  "sc-client-db",
- "sc-consensus-aura",
+ "sc-consensus-manual-seal",
  "sc-network",
  "sc-network-common",
  "sc-network-sync",
@@ -2633,7 +2633,6 @@ dependencies = [
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-aura",
  "sp-core",
  "sp-inherents",
  "sp-io",
@@ -2644,7 +2643,6 @@ dependencies = [
  "substrate-prometheus-endpoint",
  "substrate-test-runtime-client",
  "tempfile",
- "thiserror",
  "tokio",
 ]
 

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -25,13 +25,12 @@ rlp = { workspace = true }
 scale-codec = { package = "parity-scale-codec", workspace = true }
 schnellru = "0.2.1"
 serde = { workspace = true }
-thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 
 # Substrate
 prometheus-endpoint = { workspace = true }
 sc-client-api = { workspace = true }
-sc-consensus-aura = { workspace = true }
+sc-consensus-manual-seal = { workspace = true }
 sc-network = { workspace = true }
 sc-network-common = { workspace = true }
 sc-network-sync = { workspace = true }
@@ -44,7 +43,6 @@ sp-api = { workspace = true, features = ["default"] }
 sp-block-builder = { workspace = true, features = ["default"] }
 sp-blockchain = { workspace = true }
 sp-consensus = { workspace = true }
-sp-consensus-aura = { workspace = true, features = ["default"] }
 sp-core = { workspace = true, features = ["default"] }
 sp-inherents = { workspace = true, features = ["default"] }
 sp-io = { workspace = true, features = ["default"] }

--- a/client/rpc/src/eth/mod.rs
+++ b/client/rpc/src/eth/mod.rs
@@ -92,7 +92,7 @@ pub struct Eth<B: BlockT, C, P, CT, BE, A: ChainApi, CIDP, EC: EthConfig<B, C>> 
 	forced_parent_hashes: Option<BTreeMap<H256, H256>>,
 	/// Something that can create the inherent data providers for pending state.
 	pending_create_inherent_data_providers: CIDP,
-	pending_consensus_data_provider: Option<Box<dyn pending::ConsensusDataProvider<B>>>,
+	pending_consensus_data_provider: Option<Box<dyn sc_consensus_manual_seal::ConsensusDataProvider<B, Proof = P>>>,
 	_marker: PhantomData<(BE, EC)>,
 }
 
@@ -122,7 +122,7 @@ where
 		execute_gas_limit_multiplier: u64,
 		forced_parent_hashes: Option<BTreeMap<H256, H256>>,
 		pending_create_inherent_data_providers: CIDP,
-		pending_consensus_data_provider: Option<Box<dyn pending::ConsensusDataProvider<B>>>,
+		pending_consensus_data_provider: Option<Box<dyn sc_consensus_manual_seal::ConsensusDataProvider<B, Proof = P>>>,
 	) -> Self {
 		Self {
 			client,

--- a/template/node/src/rpc/eth.rs
+++ b/template/node/src/rpc/eth.rs
@@ -94,10 +94,11 @@ where
 	EC: EthConfig<B, C>,
 {
 	use fc_rpc::{
-		pending::AuraConsensusDataProvider, Eth, EthApiServer, EthDevSigner, EthFilter,
-		EthFilterApiServer, EthPubSub, EthPubSubApiServer, EthSigner, Net, NetApiServer, Web3,
-		Web3ApiServer,
+		Eth, EthApiServer, EthDevSigner, EthFilter, EthFilterApiServer, EthPubSub,
+		EthPubSubApiServer, EthSigner, Net, NetApiServer, Web3, Web3ApiServer,
 	};
+	use sc_consensus_manual_seal::consensus::aura::AuraConsensusDataProvider;
+
 	#[cfg(feature = "txpool")]
 	use fc_rpc::{TxPool, TxPoolApiServer};
 


### PR DESCRIPTION
Using ConsensusDataProviders provided by sc-consensus-manual-seal.

This change requires updating sc-consensus-manual-seal Error enum, to this
```
pub enum Error {
	/// An error occurred while importing the block
	#[error("Block import failed: {0:?}")]
	BlockImportError(ImportResult),
	/// Transaction pool is empty, cannot create a block
	#[error(
		"Transaction pool is empty, set create_empty to true, if you want to create empty blocks"
	)]
	EmptyTransactionPool,
	/// encountered during creation of Proposer.
	#[error("Consensus Error: {0}")]
	ConsensusError(#[from] ConsensusError),
	/// Failed to create Inherents data
	#[error("Inherents Error: {0}")]
	InherentError(#[from] InherentsError),
	/// error encountered during finalization
	#[error("Finalization Error: {0}")]
	BlockchainError(#[from] BlockchainError),
	/// Supplied parent_hash doesn't exist in chain
	#[error("Supplied parent_hash: {0} doesn't exist in chain")]
	BlockNotFound(String),
	/// Some string error
	#[error("{0}")]
	StringError(String),
	/// send error
	#[error("Consensus process is terminating")]
	Canceled(#[from] oneshot::Canceled),
	/// send error
	#[error("Consensus process is terminating")]
	SendError(#[from] SendError),
	/// Some other error.
	#[error("Other error: {0}")]
	Other(#[from] Box<dyn std::error::Error + Send + Sync>),

 	#[error("Failed to call runtime API, {0}")]
 	CallApi(#[from] sp_api::ApiError),
 	#[error(transparent)]
 	ApplyExtrinsicFailed(#[from] ApplyExtrinsicFailed),
}

```