### PR TITLE
Fix account metadata checks

### DIFF
--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -992,28 +992,17 @@ impl<T: Config> Pallet<T> {
 	/// Get the account metadata (hash and size) from storage if it exists,
 	/// or compute it from code and store it if it doesn't exist.
 	pub fn account_code_metadata(address: H160) -> CodeMetadata {
-		if let Some(meta) = <AccountCodesMetadata<T>>::get(address) {
-			return meta;
-		}
-
-		let code = <AccountCodes<T>>::get(address);
-
-		// If code is empty we return precomputed hash for empty code.
-		// We don't store it as this address could get code deployed in the future.
-		if code.is_empty() {
+		<AccountCodesMetadata<T>>::get(address).unwrap_or_else(|| {
+			// If there is no codeMetadata, we assume that the code is empty,
+			// we then return precomputed hash for empty code.
 			const EMPTY_CODE_HASH: [u8; 32] = hex_literal::hex!(
 				"c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
 			);
-			return CodeMetadata {
+			CodeMetadata {
 				size: 0,
 				hash: EMPTY_CODE_HASH.into(),
-			};
-		}
-
-		let meta = CodeMetadata::from_code(&code);
-
-		<AccountCodesMetadata<T>>::insert(address, meta);
-		meta
+			}
+		})
 	}
 
 	/// Get the account basic in EVM format.

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -698,6 +698,7 @@ type NegativeImbalanceOf<C, T> = <C as Currency<AccountIdOf<T>>>::NegativeImbala
 	PartialEq,
 	Encode,
 	Decode,
+	Default,
 	TypeInfo,
 	MaxEncodedLen
 )]
@@ -912,7 +913,9 @@ impl<T: Config> Pallet<T> {
 	/// Check whether an account is empty.
 	pub fn is_account_empty(address: &H160) -> bool {
 		let (account, _) = Self::account_basic(address);
-		let code_len = <AccountCodes<T>>::decode_len(address).unwrap_or(0);
+		let code_len = <AccountCodesMetadata<T>>::get(address)
+			.unwrap_or_default()
+			.size;
 
 		account.nonce == U256::zero() && account.balance == U256::zero() && code_len == 0
 	}

--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -215,9 +215,9 @@ where
 		// EIP-3607: https://eips.ethereum.org/EIPS/eip-3607
 		// Do not allow transactions for which `tx.sender` has any code deployed.
 		if is_transactional
-			&& !<AccountCodesMetadata<T>>::get(source)
+			&& <AccountCodesMetadata<T>>::get(source)
 				.unwrap_or_default()
-				.size == 0
+				.size != 0
 		{
 			return Err(RunnerError {
 				error: Error::<T>::TransactionMustComeFromEOA,

--- a/primitives/evm/src/lib.rs
+++ b/primitives/evm/src/lib.rs
@@ -163,12 +163,11 @@ impl WeightInfo {
 		}
 	}
 	pub fn remaining_proof_size(&self) -> Option<u64> {
-		if let (Some(proof_size_usage), Some(proof_size_limit)) =
-			(self.proof_size_usage, self.proof_size_limit)
-		{
-			return Some(proof_size_limit.saturating_sub(proof_size_usage));
+		if let Some(proof_size_limit) = self.proof_size_limit {
+			Some(proof_size_limit.saturating_sub(self.proof_size_usage.unwrap_or_default()))
+		} else {
+			None
 		}
-		None
 	}
 
 	pub fn remaining_ref_time(&self) -> Option<u64> {


### PR DESCRIPTION
This PR fixes several issues related to account metadata checks:

- Removes an extra read (that was not charged for) when checking an empty account
- It ensures thats contracts without metadata are considered EOA
