### PR TITLE
Fix broken link to Substrate Node Template

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -4,7 +4,7 @@ A [FRAME](https://docs.substrate.io/v3/runtime/frame)-based [Substrate](https://
 
 ## Generation & Upstream
 
-This template was originally forked from the [Substrate Node Template](https://github.com/substrate-developer-hub/substrate-node-template). You can find more information on features of this template there, and more detailed usage on the [Substrate Developer Hub Tutorials](https://docs.substrate.io/tutorials/v3/) that use this heavily.
+This template was originally forked from the [Substrate Node Template](https://github.com/paritytech/substrate-node-template). You can find more information on features of this template there, and more detailed usage on the [Substrate Developer Hub Tutorials](https://docs.substrate.io/tutorials/v3/) that use this heavily.
 
 ## Build & Run
 


### PR DESCRIPTION
Replaced the outdated link to the Substrate Node Template in the README with the current official repository URL: https://github.com/paritytech/substrate-node-template. This ensures users are directed to the correct and maintained source for the template and related documentation.