### PR TITLE
Update author field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-authors = ["Parity Technologies <admin@parity.io>"]
+authors = ["Frontier developers <legal@bitarray.dev>"]
 edition = "2021"
 repository = "https://github.com/polkadot-evm/frontier/"
 

--- a/frame/evm/precompile/curve25519/Cargo.toml
+++ b/frame/evm/precompile/curve25519/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pallet-evm-precompile-curve25519"
 version = "1.0.0-dev"
-authors = ["Parity Technologies <admin@parity.io>", "Drew Stone <drew@webb.tools>"]
+authors = { workspace = true }
 license = "Apache-2.0"
 description = "Curve25519 elliptic curve precompiles for EVM pallet."
 edition = { workspace = true }

--- a/frame/evm/precompile/sha3fips/Cargo.toml
+++ b/frame/evm/precompile/sha3fips/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-authors = ["Parity Technologies <admin@parity.io>", "Drew Stone <drew@commonwealth.im>"]
+authors = { workspace = true }
 license = "Apache-2.0"
 description = "SHA3 FIPS202 precompile for EVM pallet."
 edition = { workspace = true }


### PR DESCRIPTION
On 25 Jan 2024, "Parity Technologies Limited" and me signed an "Intellectual Property Rights Assignment Agreement" which assigned the IP of the whole Frontier project to me.

This PR changes the author field in Cargo.toml to properly reflect that to avoid any potential future problems.

It is however important to note that Frontier has not required CLA, and therefore the actual copyright is never owned by a single person or entity but by all contributors. So there's a long list of actual "authors". For practical reasons we simply write "Frontier developers".