### PR TITLE
fix format of EIP7702 transactions returned by the RPC interface

### DIFF
--- a/client/rpc-core/src/types/transaction.rs
+++ b/client/rpc-core/src/types/transaction.rs
@@ -16,13 +16,23 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use ethereum::{
-	AccessListItem, AuthorizationListItem, TransactionAction, TransactionV3 as EthereumTransaction,
-};
-use ethereum_types::{H160, H256, U256, U64};
+use ethereum::{AccessListItem, TransactionAction, TransactionV3 as EthereumTransaction};
+use ethereum_types::{Address, H160, H256, U256, U64};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 
 use crate::types::{BuildFrom, Bytes};
+
+/// AuthorizationListItem for EIP-7702 transactions
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthorizationListItem {
+	pub chain_id: U64,
+	pub address: Address,
+	pub nonce: U256,
+	pub y_parity: U64,
+	pub r: U256,
+	pub s: U256,
+}
 
 /// Transaction
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
@@ -193,7 +203,19 @@ impl BuildFrom for Transaction {
 				creates: None,
 				chain_id: Some(U64::from(t.chain_id)),
 				access_list: Some(t.access_list.clone()),
-				authorization_list: Some(t.authorization_list.clone()),
+				authorization_list: Some(
+					t.authorization_list
+						.iter()
+						.map(|item| AuthorizationListItem {
+							address: item.address,
+							chain_id: U64::from(item.chain_id),
+							nonce: item.nonce,
+							y_parity: U64::from(item.signature.odd_y_parity as u8),
+							r: U256::from_big_endian(&item.signature.r[..]),
+							s: U256::from_big_endian(&item.signature.s[..]),
+						})
+						.collect(),
+				),
 				y_parity: Some(U256::from(t.signature.odd_y_parity() as u8)),
 				v: Some(U256::from(t.signature.odd_y_parity() as u8)),
 				r: U256::from_big_endian(t.signature.r().as_bytes()),


### PR DESCRIPTION
Update the field names, casing, and types used in the `authorization_list` returned by the RPC, to match the expected format.

It also changes the types of the `r` and `s` signature components from `H256` to `U256`. This helps strip leading zeroes during serialization in a clean and consistent way, aligning frontier output with both **reth** and **geth**.

---

### Why this is needed

Right now, calling something like `cast block` against our RPC gives a different structure than what clients expect.

For example, here's what a **geth** RPC returns:

```json
{
   "authorizationList":[
      {
          "chainId":"0xaa36a7",
          "address":"0x8d101f00e7b804b69e67196da9a700ee1b0cb95e",
          "nonce":"0x42",
          "yParity":"0x1",
          "r":"0xe314f379c01725882ba1711ab879430caacb9b0c3b2c82fef6d6847ed05d7ded",
          "s":"0x6b253af0ef948b93a7aecb4406f40d352ed2b8ff536fcecd912c21b68f9d1144"
      }
   ]
}
```

But **frontier** currently returns:

```json
{
   "authorizationList":[
      {
         "address":"0xd0e0531c7ae2d078e3b69dddfe22a99b42cc0103",
         "chain_id":1287,
         "nonce":"0x0",
         "signature":{
            "odd_y_parity":false,
            "r":"0xcfb9d7d69a40794807a32aa6795a696284c455d541883dcbd2f8529d05812365",
            "s":"0x0631093625f29f2a6d540e3db4d90d33b29e63c22801bbfdd478579220df1da4"
         }
      }
   ]
}
```