### PR TITLE
Add isEthereum to chain_spec.rs properties() for polkdot frontend usability

### DIFF
--- a/template/node/src/chain_spec.rs
+++ b/template/node/src/chain_spec.rs
@@ -47,6 +47,7 @@ fn properties() -> Properties {
 	let mut properties = Properties::new();
 	properties.insert("tokenDecimals".into(), 18.into());
 	properties.insert("ss58Format".into(), SS58Prefix::get().into());
+	properties.insert("isEthereum".into(), true.into());
 	properties
 }
 


### PR DESCRIPTION
When using the polkadot.js.org/apps explorer for development when running a chain with multiple validators, the polkadot frontend requires the property `isEthereum`. They have this defaulted when using `spec_name: Cow::Borrowed("frontier-template"),` in the runtime, but if you change this, it doesn't know to use the ethereum frontend.

What this pr does is simple, it puts `isEthereum` in the chain properties:

```rust
fn properties() -> Properties {
	let mut properties = Properties::new();
	properties.insert("tokenDecimals".into(), 18.into());
	properties.insert("ss58Format".into(), SS58Prefix::get().into());
	properties.insert("isEthereum".into(), true.into());
	properties
}
```

**Here's an image of what this looks like:**

**Without `isEthereum`:**

<img width="2144" height="696" alt="Screenshot 2025-12-04 210529" src="https://github.com/user-attachments/assets/7ff15200-804d-4a69-b984-f20de4826438" />

**With `isEthereum`:**

<img width="2132" height="578" alt="Screenshot 2025-12-04 210643" src="https://github.com/user-attachments/assets/1c823d5f-26e2-4346-b7db-4bac8991a3c7" />

This can be reproduced by changing the spec_name in the runtime and running the blockchain locally with multiple validators.