### PR TITLE
Add transaction size validation to RPC endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2862,8 +2862,7 @@ dependencies = [
 [[package]]
 name = "ethereum"
 version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee371ebb7479ed3258617557ab0b3247e741075cb6b02b820d188f68da44441"
+source = "git+https://github.com/rust-ethereum/ethereum.git?rev=5185fe8efa62add7e989660a69c6945c8a3ae64e#5185fe8efa62add7e989660a69c6945c8a3ae64e"
 dependencies = [
  "bytes",
  "ethereum-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,6 +228,10 @@ precompile-utils = { path = "precompiles", default-features = false }
 # Frontier Template
 frontier-template-runtime = { path = "template/runtime", default-features = false }
 
+# TODO: Remove this patch before merging once ethereum 0.19.0 is released
+[patch.crates-io]
+ethereum = { git = "https://github.com/rust-ethereum/ethereum.git", rev = "5185fe8efa62add7e989660a69c6945c8a3ae64e" }
+
 [profile.release]
 # Substrate runtime requires unwinding.
 panic = "unwind"

--- a/client/rpc-core/src/types/mod.rs
+++ b/client/rpc-core/src/types/mod.rs
@@ -63,7 +63,9 @@ pub use self::{
 		Peers, PipProtocolInfo, SyncInfo, SyncStatus, TransactionStats,
 	},
 	transaction::{LocalTransactionStatus, RichRawTransaction, Transaction},
-	transaction_request::{TransactionMessage, TransactionRequest},
+	transaction_request::{
+		TransactionMessage, TransactionRequest, DEFAULT_MAX_TX_INPUT_BYTES, TX_SLOT_BYTE_SIZE,
+	},
 	work::Work,
 };
 

--- a/client/rpc-core/src/types/transaction_request.rs
+++ b/client/rpc-core/src/types/transaction_request.rs
@@ -26,18 +26,10 @@ use serde::{Deserialize, Deserializer};
 use crate::types::Bytes;
 
 /// The default byte size of a transaction slot (32 KiB).
-///
-/// Reference:
-/// - geth: <https://github.com/ethereum/go-ethereum/blob/master/core/txpool/legacypool/legacypool.go> (`txSlotSize`)
-/// - reth: <https://github.com/paradigmxyz/reth/blob/main/crates/transaction-pool/src/validate/constants.rs#L4>
 pub const TX_SLOT_BYTE_SIZE: usize = 32 * 1024;
 
 /// The default maximum size a single transaction can have (128 KiB).
 /// This is the RLP-encoded size of the signed transaction.
-///
-/// Reference:
-/// - geth: <https://github.com/ethereum/go-ethereum/blob/master/core/txpool/legacypool/legacypool.go> (`txMaxSize`)
-/// - reth: <https://github.com/paradigmxyz/reth/blob/main/crates/transaction-pool/src/validate/constants.rs#L11>
 pub const DEFAULT_MAX_TX_INPUT_BYTES: usize = 4 * TX_SLOT_BYTE_SIZE;
 
 /// Transaction request from the RPC.
@@ -195,11 +187,6 @@ impl TransactionRequest {
 	/// This mirrors geth's `tx.Size()` and reth's `transaction.encoded_length()` which use
 	/// actual RLP encoding to determine transaction size. We convert the request to its
 	/// transaction message type and use the `encoded_len()` method from the ethereum crate.
-	///
-	/// Reference:
-	/// - geth: <https://github.com/ethereum/go-ethereum/blob/master/core/types/transaction.go> (`tx.Size()`)
-	/// - reth: <https://github.com/paradigmxyz/reth/blob/main/crates/transaction-pool/src/traits.rs> (`PoolTransaction::encoded_length()`)
-	/// - alloy: <https://github.com/alloy-rs/alloy/blob/main/crates/consensus/src/transaction/eip1559.rs> (`rlp_encoded_fields_length()`)
 	pub fn encoded_length(&self) -> usize {
 		// Convert to transaction message and use the ethereum crate's encoded_len()
 		let message: Option<TransactionMessage> = self.clone().into();

--- a/client/rpc-core/src/types/transaction_request.rs
+++ b/client/rpc-core/src/types/transaction_request.rs
@@ -243,17 +243,12 @@ impl TransactionRequest {
 	///
 	/// This prevents DoS attacks via oversized transactions before they enter the pool.
 	/// The limit matches geth's `txMaxSize` and reth's `DEFAULT_MAX_TX_INPUT_BYTES`.
-	///
-	/// Reference:
-	/// - geth: <https://github.com/ethereum/go-ethereum/blob/master/core/txpool/validation.go> (`ValidateTransaction`)
-	/// - reth: <https://github.com/paradigmxyz/reth/blob/main/crates/transaction-pool/src/validate/eth.rs#L342-L363>
 	pub fn validate_size(&self) -> Result<(), String> {
 		let size = self.encoded_length();
 
 		if size > DEFAULT_MAX_TX_INPUT_BYTES {
 			return Err(format!(
-				"oversized data: transaction size {} exceeds limit {}",
-				size, DEFAULT_MAX_TX_INPUT_BYTES
+				"oversized data: transaction size {size} exceeds limit {DEFAULT_MAX_TX_INPUT_BYTES}"
 			));
 		}
 		Ok(())
@@ -587,8 +582,7 @@ mod tests {
 		// Verify it's a reasonable size for a minimal transaction
 		assert!(
 			size < 200,
-			"Size {} should be reasonable for minimal tx",
-			size
+			"Size {size} should be reasonable for minimal tx"
 		);
 	}
 
@@ -622,9 +616,7 @@ mod tests {
 		// - Access list overhead
 		assert!(
 			typed_size > legacy_size,
-			"Typed tx {} should be larger than legacy {}",
-			typed_size,
-			legacy_size
+			"Typed tx {typed_size} should be larger than legacy {legacy_size}"
 		);
 	}
 
@@ -659,8 +651,7 @@ mod tests {
 		let diff = size_100 - size_10;
 		assert!(
 			diff > 2500 && diff < 4000,
-			"Size difference {} should be proportional to storage keys",
-			diff
+			"Size difference {diff} should be proportional to storage keys"
 		);
 	}
 

--- a/client/rpc-core/src/types/transaction_request.rs
+++ b/client/rpc-core/src/types/transaction_request.rs
@@ -585,7 +585,11 @@ mod tests {
 		);
 
 		// Verify it's a reasonable size for a minimal transaction
-		assert!(size < 200, "Size {} should be reasonable for minimal tx", size);
+		assert!(
+			size < 200,
+			"Size {} should be reasonable for minimal tx",
+			size
+		);
 	}
 
 	#[test]

--- a/client/rpc-core/src/types/transaction_request.rs
+++ b/client/rpc-core/src/types/transaction_request.rs
@@ -569,7 +569,9 @@ mod tests {
 		// A minimal EIP-1559 transaction should include signature overhead
 		// Default TransactionRequest converts to EIP-1559 (no gas_price, no access_list)
 		let request = TransactionRequest::default();
-		let size = request.encoded_length().unwrap();
+		let size = request
+			.encoded_length()
+			.expect("should encode valid EIP-1559 request");
 
 		// EIP-1559 message RLP: ~11 bytes for minimal fields (all zeros/empty)
 		// + 1 byte type prefix + 67 bytes signature overhead = ~79 bytes minimum
@@ -602,14 +604,18 @@ mod tests {
 			}]),
 			..Default::default()
 		};
-		let typed_size = request.encoded_length().unwrap();
+		let typed_size = request
+			.encoded_length()
+			.expect("should encode valid EIP-1559 request");
 
 		// Legacy transaction
 		let legacy_request = TransactionRequest {
 			gas_price: Some(U256::from(1000)),
 			..Default::default()
 		};
-		let legacy_size = legacy_request.encoded_length().unwrap();
+		let legacy_size = legacy_request
+			.encoded_length()
+			.expect("should encode valid legacy request");
 
 		// Typed transaction should be larger due to:
 		// - Type byte (+1)
@@ -645,8 +651,12 @@ mod tests {
 			..Default::default()
 		};
 
-		let size_10 = request_10.encoded_length().unwrap();
-		let size_100 = request_100.encoded_length().unwrap();
+		let size_10 = request_10
+			.encoded_length()
+			.expect("should encode valid EIP-1559 request with 10 keys");
+		let size_100 = request_100
+			.encoded_length()
+			.expect("should encode valid EIP-1559 request with 100 keys");
 
 		// Size should scale roughly linearly with storage keys
 		// 90 additional keys * ~34 bytes each ≈ 3060 bytes difference

--- a/client/rpc-core/src/types/transaction_request.rs
+++ b/client/rpc-core/src/types/transaction_request.rs
@@ -184,58 +184,23 @@ impl TransactionRequest {
 
 	/// Calculates the RLP-encoded size of the signed transaction for DoS protection.
 	///
-	/// This mirrors geth's `tx.Size()` and reth's `transaction.encoded_length()` which use
-	/// actual RLP encoding to determine transaction size. We convert the request to its
-	/// transaction message type and use the `encoded_len()` method from the ethereum crate.
+	/// This converts the request to a `TransactionMessage` using default values for any
+	/// missing fields, then delegates to `TransactionMessage::encoded_length()`.
+	///
+	/// **Note:** For `eth_sendTransaction`, prefer calling `TransactionMessage::validate_size()`
+	/// on the fully-populated message (after nonce, gas, fees, chain ID are filled in)
+	/// to get an accurate size measurement.
 	///
 	/// Returns an error if the transaction request cannot be converted to a valid message type.
 	pub fn encoded_length(&self) -> Result<usize, String> {
-		// Convert to transaction message and use the ethereum crate's encoded_len()
 		let message: Option<TransactionMessage> = self.clone().into();
 
 		match message {
-			Some(TransactionMessage::Legacy(msg)) => {
-				// Legacy: RLP([nonce, gasPrice, gasLimit, to, value, data, v, r, s])
-				// v is variable (27/28 or chainId*2+35/36), r and s are 32 bytes each
-				Ok(msg.encoded_len() + Self::SIGNATURE_RLP_OVERHEAD)
-			}
-			Some(TransactionMessage::EIP2930(msg)) => {
-				// EIP-2930: 0x01 || RLP([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList, yParity, r, s])
-				Ok(1 + msg.encoded_len() + Self::SIGNATURE_RLP_OVERHEAD)
-			}
-			Some(TransactionMessage::EIP1559(msg)) => {
-				// EIP-1559: 0x02 || RLP([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data, accessList, yParity, r, s])
-				Ok(1 + msg.encoded_len() + Self::SIGNATURE_RLP_OVERHEAD)
-			}
-			Some(TransactionMessage::EIP7702(msg)) => {
-				// EIP-7702: 0x04 || RLP([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data, accessList, authorizationList, yParity, r, s])
-				Ok(1 + msg.encoded_len() + Self::SIGNATURE_RLP_OVERHEAD)
-			}
+			Some(msg) => Ok(msg.encoded_length()),
 			None => Err(
 				"invalid transaction parameters: unable to determine transaction type".to_string(),
 			),
 		}
-	}
-
-	/// RLP overhead for signature fields (yParity + r + s)
-	/// - yParity: 1 byte (0x00 or 0x01 encoded as single byte)
-	/// - r: typically 33 bytes (0x80 + 32 bytes, or less if leading zeros)
-	/// - s: typically 33 bytes (0x80 + 32 bytes, or less if leading zeros)
-	const SIGNATURE_RLP_OVERHEAD: usize = 1 + 33 + 33;
-
-	/// Validates that the estimated signed transaction size is within limits.
-	///
-	/// This prevents DoS attacks via oversized transactions before they enter the pool.
-	/// The limit matches geth's `txMaxSize` and reth's `DEFAULT_MAX_TX_INPUT_BYTES`.
-	pub fn validate_size(&self) -> Result<(), String> {
-		let size = self.encoded_length()?;
-
-		if size > DEFAULT_MAX_TX_INPUT_BYTES {
-			return Err(format!(
-				"oversized data: transaction size {size} exceeds limit {DEFAULT_MAX_TX_INPUT_BYTES}"
-			));
-		}
-		Ok(())
 	}
 }
 
@@ -299,6 +264,57 @@ pub enum TransactionMessage {
 	EIP2930(EIP2930TransactionMessage),
 	EIP1559(EIP1559TransactionMessage),
 	EIP7702(EIP7702TransactionMessage),
+}
+
+impl TransactionMessage {
+	/// RLP overhead for signature fields (yParity + r + s)
+	/// - yParity: 1 byte (0x00 or 0x01 encoded as single byte)
+	/// - r: typically 33 bytes (0x80 + 32 bytes, or less if leading zeros)
+	/// - s: typically 33 bytes (0x80 + 32 bytes, or less if leading zeros)
+	const SIGNATURE_RLP_OVERHEAD: usize = 1 + 33 + 33;
+
+	/// Calculates the RLP-encoded size of the signed transaction for DoS protection.
+	///
+	/// This mirrors geth's `tx.Size()` and reth's `transaction.encoded_length()` which use
+	/// actual RLP encoding to determine transaction size. We use the `encoded_len()` method
+	/// from the ethereum crate on the fully-populated message.
+	pub fn encoded_length(&self) -> usize {
+		match self {
+			// Legacy: RLP([nonce, gasPrice, gasLimit, to, value, data, v, r, s])
+			TransactionMessage::Legacy(msg) => msg.encoded_len() + Self::SIGNATURE_RLP_OVERHEAD,
+			// EIP-2930: 0x01 || RLP([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList, yParity, r, s])
+			TransactionMessage::EIP2930(msg) => {
+				1 + msg.encoded_len() + Self::SIGNATURE_RLP_OVERHEAD
+			}
+			// EIP-1559: 0x02 || RLP([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data, accessList, yParity, r, s])
+			TransactionMessage::EIP1559(msg) => {
+				1 + msg.encoded_len() + Self::SIGNATURE_RLP_OVERHEAD
+			}
+			// EIP-7702: 0x04 || RLP([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data, accessList, authorizationList, yParity, r, s])
+			TransactionMessage::EIP7702(msg) => {
+				1 + msg.encoded_len() + Self::SIGNATURE_RLP_OVERHEAD
+			}
+		}
+	}
+
+	/// Validates that the estimated signed transaction size is within limits.
+	///
+	/// This prevents DoS attacks via oversized transactions before they enter the pool.
+	/// The limit matches geth's `txMaxSize` and reth's `DEFAULT_MAX_TX_INPUT_BYTES`.
+	///
+	/// This should be called on the fully-populated message (after nonce, gas limit,
+	/// gas price, chain ID, etc. have been filled in) to ensure the final transaction
+	/// size is accurately measured.
+	pub fn validate_size(&self) -> Result<(), String> {
+		let size = self.encoded_length();
+
+		if size > DEFAULT_MAX_TX_INPUT_BYTES {
+			return Err(format!(
+				"oversized data: transaction size {size} exceeds limit {DEFAULT_MAX_TX_INPUT_BYTES}"
+			));
+		}
+		Ok(())
+	}
 }
 
 impl From<TransactionRequest> for Option<TransactionMessage> {
@@ -511,7 +527,7 @@ mod tests {
 	}
 
 	#[test]
-	fn test_request_size_validation_large_access_list() {
+	fn test_message_size_validation_large_access_list() {
 		use ethereum::AccessListItem;
 		use ethereum_types::{H160, H256};
 
@@ -527,11 +543,12 @@ mod tests {
 			access_list: Some(access_list),
 			..Default::default()
 		};
-		assert!(request.validate_size().is_err());
+		let message: Option<TransactionMessage> = request.into();
+		assert!(message.unwrap().validate_size().is_err());
 	}
 
 	#[test]
-	fn test_request_size_validation_valid() {
+	fn test_message_size_validation_valid() {
 		use ethereum::AccessListItem;
 		use ethereum_types::{H160, H256};
 
@@ -543,7 +560,8 @@ mod tests {
 			}]),
 			..Default::default()
 		};
-		assert!(request.validate_size().is_ok());
+		let message: Option<TransactionMessage> = request.into();
+		assert!(message.unwrap().validate_size().is_ok());
 	}
 
 	#[test]
@@ -557,10 +575,10 @@ mod tests {
 		// + 1 byte type prefix + 67 bytes signature overhead = ~79 bytes minimum
 		// The signature overhead (67 bytes) is the key verification
 		assert!(
-			size >= TransactionRequest::SIGNATURE_RLP_OVERHEAD,
+			size >= TransactionMessage::SIGNATURE_RLP_OVERHEAD,
 			"Size {} should be at least signature overhead {}",
 			size,
-			TransactionRequest::SIGNATURE_RLP_OVERHEAD
+			TransactionMessage::SIGNATURE_RLP_OVERHEAD
 		);
 
 		// Verify it's a reasonable size for a minimal transaction
@@ -657,6 +675,8 @@ mod tests {
 		};
 
 		assert!(request.encoded_length().is_err());
-		assert!(request.validate_size().is_err());
+		// Invalid parameters also fail conversion, so validate_size is unreachable
+		let message: Option<TransactionMessage> = request.into();
+		assert!(message.is_none());
 	}
 }

--- a/client/rpc/src/eth/submit.rs
+++ b/client/rpc/src/eth/submit.rs
@@ -49,9 +49,9 @@ where
 	CIDP: CreateInherentDataProviders<B, ()> + Send + 'static,
 {
 	pub async fn send_transaction(&self, request: TransactionRequest) -> RpcResult<H256> {
-		request.validate_size().map_err(|msg| {
-			crate::err(jsonrpsee::types::error::INVALID_PARAMS_CODE, &msg, None)
-		})?;
+		request
+			.validate_size()
+			.map_err(|msg| crate::err(jsonrpsee::types::error::INVALID_PARAMS_CODE, &msg, None))?;
 
 		let from = match request.from {
 			Some(from) => from,

--- a/client/rpc/src/eth/submit.rs
+++ b/client/rpc/src/eth/submit.rs
@@ -166,16 +166,12 @@ where
 
 		// Validate transaction size to prevent DoS attacks.
 		// This matches geth/reth pool validation which rejects transactions > 128 KB.
-		// Reference:
-		// - geth: https://github.com/ethereum/go-ethereum/blob/master/core/txpool/validation.go
-		// - reth: https://github.com/paradigmxyz/reth/blob/main/crates/transaction-pool/src/validate/eth.rs#L342-L363
 		if bytes.len() > DEFAULT_MAX_TX_INPUT_BYTES {
 			return Err(crate::err(
 				jsonrpsee::types::error::INVALID_PARAMS_CODE,
-				&format!(
-					"oversized data: transaction size {} exceeds limit {}",
-					bytes.len(),
-					DEFAULT_MAX_TX_INPUT_BYTES
+				format!(
+					"oversized data: transaction size {} exceeds limit {DEFAULT_MAX_TX_INPUT_BYTES}",
+					bytes.len()
 				),
 				None,
 			));

--- a/client/rpc/src/eth/submit.rs
+++ b/client/rpc/src/eth/submit.rs
@@ -49,10 +49,6 @@ where
 	CIDP: CreateInherentDataProviders<B, ()> + Send + 'static,
 {
 	pub async fn send_transaction(&self, request: TransactionRequest) -> RpcResult<H256> {
-		request
-			.validate_size()
-			.map_err(|msg| crate::err(jsonrpsee::types::error::INVALID_PARAMS_CODE, &msg, None))?;
-
 		let from = match request.from {
 			Some(from) => from,
 			None => {
@@ -131,6 +127,12 @@ where
 			}
 			_ => return Err(internal_err("invalid transaction parameters")),
 		};
+
+		// Validate size on the fully-populated message (after nonce, gas, fees, chain ID
+		// have been filled in) to accurately enforce the 128 KiB limit.
+		message
+			.validate_size()
+			.map_err(|msg| crate::err(jsonrpsee::types::error::INVALID_PARAMS_CODE, &msg, None))?;
 
 		let mut transaction = None;
 		for signer in &self.signers {


### PR DESCRIPTION
## Summary

  - Add transaction size validation to `eth_sendTransaction` and `eth_sendRawTransaction` RPC endpoints
  - Reject transactions exceeding 128 KiB (matching geth/reth `txMaxSize` limit)
  - Prevents DoS attacks via oversized transactions with large access lists

## Changes

  - Add `encoded_length()` and `validate_size()` methods to `TransactionRequest`
  - Add `TX_SLOT_BYTE_SIZE` (32 KiB) and `DEFAULT_MAX_TX_INPUT_BYTES` (128 KiB) constants
  - Validate size early in `send_transaction` before signing
  - Validate raw transaction bytes in `send_raw_transaction` before decoding

## References

  - reth: https://github.com/paradigmxyz/reth/blob/main/crates/transaction-pool/src/validate/constants.rs#L11

## Note

Depends on: https://github.com/rust-ethereum/ethereum/pull/76

Uses a temporary patch for the ethereum crate to access `encoded_len()`. This should be removed once the changes are released.