### PR TITLE
feat: reorged-out logs: re-emitted lost logs with `removed=true`, and winning-chain logs with `removed=false`

### DIFF
--- a/client/rpc-core/src/types/filter.rs
+++ b/client/rpc-core/src/types/filter.rs
@@ -315,6 +315,7 @@ pub enum FilterType {
 #[derive(Clone, Debug)]
 pub struct FilterPoolItem {
 	pub last_poll: BlockNumberOrHash,
+	pub last_log_journal_seq: Option<u64>,
 	pub filter_type: FilterType,
 	pub at_block: u64,
 	pub pending_transaction_hashes: HashSet<H256>,

--- a/client/rpc-core/src/types/filter.rs
+++ b/client/rpc-core/src/types/filter.rs
@@ -140,7 +140,7 @@ impl Filter {
 
 /// Helper for Filter matching.
 /// Supports conditional indexed parameters and wildcards.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct FilteredParams {
 	pub filter: Filter,
 }

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -26,7 +26,7 @@ scale-codec = { workspace = true }
 schnellru = "0.2.4"
 serde = { workspace = true, optional = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["sync", "time"] }
 
 # Substrate
 prometheus-endpoint = { workspace = true }

--- a/client/rpc/src/eth/filter.rs
+++ b/client/rpc/src/eth/filter.rs
@@ -226,8 +226,13 @@ where
 		// anonymous types) we collect all necessary data in this enum then have
 		// a single async block.
 		enum FuturePath {
-			Block { last: u64, next: u64 },
-			PendingTransaction { new_hashes: Vec<H256> },
+			Block {
+				last: u64,
+				next: u64,
+			},
+			PendingTransaction {
+				new_hashes: Vec<H256>,
+			},
 			Log {
 				filter: Filter,
 				cursor: u64,
@@ -304,10 +309,7 @@ where
 					// For each event since last poll, get a vector of ethereum logs.
 					FilterType::Log(filter) => {
 						let cursor = pool_item.last_log_journal_seq.unwrap_or(0);
-						let last_poll_block = pool_item
-							.last_poll
-							.to_min_block_num()
-							.unwrap_or(0);
+						let last_poll_block = pool_item.last_poll.to_min_block_num().unwrap_or(0);
 						FuturePath::Log {
 							filter: filter.clone(),
 							cursor,

--- a/client/rpc/src/eth/filter.rs
+++ b/client/rpc/src/eth/filter.rs
@@ -180,8 +180,7 @@ where
 				key,
 				FilterPoolItem {
 					last_poll: BlockNumberOrHash::Num(best_number),
-					last_log_journal_seq: matches!(filter_type, FilterType::Log(_))
-						.then(|| self.logs_journal.cursor()),
+					last_log_journal_seq: matches!(filter_type, FilterType::Log(_)).then_some(0),
 					filter_type,
 					at_block: best_number,
 					pending_transaction_hashes,
@@ -229,7 +228,11 @@ where
 		enum FuturePath {
 			Block { last: u64, next: u64 },
 			PendingTransaction { new_hashes: Vec<H256> },
-			Log { filter: Filter, cursor: u64 },
+			Log {
+				filter: Filter,
+				cursor: u64,
+				last_poll_block: u64,
+			},
 			Error(jsonrpsee::types::ErrorObjectOwned),
 		}
 
@@ -300,12 +303,15 @@ where
 					}
 					// For each event since last poll, get a vector of ethereum logs.
 					FilterType::Log(filter) => {
-						let cursor = pool_item
-							.last_log_journal_seq
-							.unwrap_or_else(|| self.logs_journal.cursor());
+						let cursor = pool_item.last_log_journal_seq.unwrap_or(0);
+						let last_poll_block = pool_item
+							.last_poll
+							.to_min_block_num()
+							.unwrap_or(0);
 						FuturePath::Log {
 							filter: filter.clone(),
 							cursor,
+							last_poll_block,
 						}
 					}
 				}
@@ -338,7 +344,20 @@ where
 				Ok(FilterChanges::Hashes(ethereum_hashes))
 			}
 			FuturePath::PendingTransaction { new_hashes } => Ok(FilterChanges::Hashes(new_hashes)),
-			FuturePath::Log { filter, cursor } => {
+			FuturePath::Log {
+				filter,
+				cursor,
+				last_poll_block,
+			} => {
+				let latest_indexed = self.latest_indexed_block_number().await?;
+				let latest_u64: u64 = latest_indexed.unique_saturated_into();
+				if latest_u64.saturating_sub(last_poll_block) > self.max_block_range.into() {
+					return Err(internal_err(format!(
+						"block range is too wide (maximum {})",
+						self.max_block_range
+					)));
+				}
+
 				let params = FilteredParams::new(filter);
 				let (entries, next_cursor) = match self.logs_journal.snapshot_since(cursor) {
 					Ok(snapshot) => snapshot,
@@ -359,16 +378,16 @@ where
 					}
 				}
 
-				if logs.len() as u32 > self.max_past_logs {
+				if logs.len() as u32 > max_past_logs {
 					return Err(internal_err(format!(
-						"query returned more than {} results",
-						self.max_past_logs
+						"query returned more than {max_past_logs} results",
 					)));
 				}
 
 				if let Ok(locked) = &mut self.filter_pool.lock() {
 					if let Some(pool_item) = locked.get_mut(&key) {
 						pool_item.last_log_journal_seq = Some(next_cursor);
+						pool_item.last_poll = BlockNumberOrHash::Num(latest_u64);
 					}
 				}
 

--- a/client/rpc/src/eth/filter.rs
+++ b/client/rpc/src/eth/filter.rs
@@ -40,7 +40,10 @@ use sp_runtime::{
 use fc_rpc_core::{types::*, EthFilterApiServer};
 use fp_rpc::{EthereumRuntimeRPCApi, TransactionStatus};
 
-use crate::{cache::EthBlockDataCacheTask, frontier_backend_client, internal_err};
+use crate::{
+	cache::EthBlockDataCacheTask, frontier_backend_client, internal_err, LogsJournal,
+	LogsJournalError,
+};
 
 pub struct EthFilter<B: BlockT, C, BE, P> {
 	client: Arc<C>,
@@ -51,6 +54,7 @@ pub struct EthFilter<B: BlockT, C, BE, P> {
 	max_past_logs: u32,
 	max_block_range: u32,
 	block_data_cache: Arc<EthBlockDataCacheTask<B>>,
+	logs_journal: Arc<LogsJournal>,
 	_marker: PhantomData<BE>,
 }
 
@@ -64,6 +68,7 @@ impl<B: BlockT, C, BE, P: TransactionPool> EthFilter<B, C, BE, P> {
 		max_past_logs: u32,
 		max_block_range: u32,
 		block_data_cache: Arc<EthBlockDataCacheTask<B>>,
+		logs_journal: Arc<LogsJournal>,
 	) -> Self {
 		Self {
 			client,
@@ -74,6 +79,7 @@ impl<B: BlockT, C, BE, P: TransactionPool> EthFilter<B, C, BE, P> {
 			max_past_logs,
 			max_block_range,
 			block_data_cache,
+			logs_journal,
 			_marker: PhantomData,
 		}
 	}
@@ -174,6 +180,8 @@ where
 				key,
 				FilterPoolItem {
 					last_poll: BlockNumberOrHash::Num(best_number),
+					last_log_journal_seq: matches!(filter_type, FilterType::Log(_))
+						.then(|| self.logs_journal.cursor()),
 					filter_type,
 					at_block: best_number,
 					pending_transaction_hashes,
@@ -218,19 +226,10 @@ where
 		// To avoid issues with multiple async blocks (having different
 		// anonymous types) we collect all necessary data in this enum then have
 		// a single async block.
-		enum FuturePath<B: BlockT> {
-			Block {
-				last: u64,
-				next: u64,
-			},
-			PendingTransaction {
-				new_hashes: Vec<H256>,
-			},
-			Log {
-				filter: Filter,
-				from_number: NumberFor<B>,
-				current_number: NumberFor<B>,
-			},
+		enum FuturePath {
+			Block { last: u64, next: u64 },
+			PendingTransaction { new_hashes: Vec<H256> },
+			Log { filter: Filter, cursor: u64 },
 			Error(jsonrpsee::types::ErrorObjectOwned),
 		}
 
@@ -238,9 +237,6 @@ where
 		let info = self.client.info();
 		let best_hash = info.best_hash;
 		let best_number = UniqueSaturatedInto::<u64>::unique_saturated_into(info.best_number);
-		// Get latest indexed block number before acquiring the lock to avoid
-		// holding the lock across an await point.
-		let latest_indexed_number = self.latest_indexed_block_number().await?;
 		let pool = self.filter_pool.clone();
 		// Try to lock.
 		let path = if let Ok(locked) = &mut pool.lock() {
@@ -256,13 +252,14 @@ where
 							key,
 							FilterPoolItem {
 								last_poll: BlockNumberOrHash::Num(next),
+								last_log_journal_seq: None,
 								filter_type: pool_item.filter_type.clone(),
 								at_block: pool_item.at_block,
 								pending_transaction_hashes: HashSet::new(),
 							},
 						);
 
-						FuturePath::<B>::Block { last, next }
+						FuturePath::Block { last, next }
 					}
 					FilterType::PendingTransaction => {
 						let previous_hashes = pool_item.pending_transaction_hashes;
@@ -287,6 +284,7 @@ where
 							key,
 							FilterPoolItem {
 								last_poll: BlockNumberOrHash::Num(best_number + 1),
+								last_log_journal_seq: None,
 								filter_type: pool_item.filter_type.clone(),
 								at_block: pool_item.at_block,
 								pending_transaction_hashes: current_hashes.clone(),
@@ -302,62 +300,12 @@ where
 					}
 					// For each event since last poll, get a vector of ethereum logs.
 					FilterType::Log(filter) => {
-						// Either the filter-specific `to` block or latest indexed block.
-						// Use latest indexed block to ensure consistency with other RPCs.
-						let mut current_number = filter
-							.to_block
-							.and_then(|v| v.to_min_block_num())
-							.map(|s| s.unique_saturated_into())
-							.unwrap_or(latest_indexed_number);
-
-						if current_number > latest_indexed_number {
-							current_number = latest_indexed_number;
-						}
-
-						// The from clause is the max(last_poll, filter_from).
-						let last_poll = pool_item
-							.last_poll
-							.to_min_block_num()
-							.unwrap()
-							.unique_saturated_into();
-
-						let filter_from = filter
-							.from_block
-							.and_then(|v| v.to_min_block_num())
-							.map(|s| s.unique_saturated_into())
-							.unwrap_or(last_poll);
-
-						let from_number = std::cmp::max(last_poll, filter_from);
-						let block_range = current_number.saturating_sub(from_number);
-
-						// Validate block range before advancing last_poll. If we reject after
-						// updating last_poll, the cursor would skip logs on the next poll.
-						if block_range > self.max_block_range.into() {
-							FuturePath::Error(internal_err(format!(
-								"block range is too wide (maximum {})",
-								self.max_block_range
-							)))
-						} else {
-							// Update filter `last_poll` based on the same capped head we query.
-							// This avoids skipping blocks when best_number is ahead of indexed data.
-							let next_last_poll =
-								UniqueSaturatedInto::<u64>::unique_saturated_into(current_number)
-									.saturating_add(1);
-							locked.insert(
-								key,
-								FilterPoolItem {
-									last_poll: BlockNumberOrHash::Num(next_last_poll),
-									filter_type: pool_item.filter_type.clone(),
-									at_block: pool_item.at_block,
-									pending_transaction_hashes: HashSet::new(),
-								},
-							);
-							// Build the response.
-							FuturePath::Log {
-								filter: filter.clone(),
-								from_number,
-								current_number,
-							}
+						let cursor = pool_item
+							.last_log_journal_seq
+							.unwrap_or_else(|| self.logs_journal.cursor());
+						FuturePath::Log {
+							filter: filter.clone(),
+							cursor,
 						}
 					}
 				}
@@ -369,7 +317,6 @@ where
 		};
 
 		let client = Arc::clone(&self.client);
-		let backend = Arc::clone(&self.backend);
 		let block_data_cache = Arc::clone(&self.block_data_cache);
 		let max_past_logs = self.max_past_logs;
 
@@ -391,33 +338,39 @@ where
 				Ok(FilterChanges::Hashes(ethereum_hashes))
 			}
 			FuturePath::PendingTransaction { new_hashes } => Ok(FilterChanges::Hashes(new_hashes)),
-			FuturePath::Log {
-				filter,
-				from_number,
-				current_number,
-			} => {
-				let logs = if backend.is_indexed() {
-					filter_range_logs_indexed(
-						client.as_ref(),
-						backend.log_indexer(),
-						&block_data_cache,
-						max_past_logs,
-						&filter,
-						from_number,
-						current_number,
-					)
-					.await?
-				} else {
-					filter_range_logs(
-						client.as_ref(),
-						&block_data_cache,
-						max_past_logs,
-						&filter,
-						from_number,
-						current_number,
-					)
-					.await?
+			FuturePath::Log { filter, cursor } => {
+				let params = FilteredParams::new(filter);
+				let (entries, next_cursor) = match self.logs_journal.snapshot_since(cursor) {
+					Ok(snapshot) => snapshot,
+					Err(err) => {
+						if let Ok(locked) = &mut self.filter_pool.lock() {
+							let _ = locked.remove(&key);
+						}
+						return Err(logs_journal_error(err));
+					}
 				};
+
+				let mut logs = Vec::new();
+				for entry in entries {
+					for log in entry.logs.iter() {
+						if log_matches_filter(&params, log, true) {
+							logs.push(log.clone());
+						}
+					}
+				}
+
+				if logs.len() as u32 > self.max_past_logs {
+					return Err(internal_err(format!(
+						"query returned more than {} results",
+						self.max_past_logs
+					)));
+				}
+
+				if let Ok(locked) = &mut self.filter_pool.lock() {
+					if let Some(pool_item) = locked.get_mut(&key) {
+						pool_item.last_log_journal_seq = Some(next_cursor);
+					}
+				}
 
 				Ok(FilterChanges::Logs(logs))
 			}
@@ -803,10 +756,41 @@ where
 	Ok(logs)
 }
 
+pub(crate) fn log_matches_filter(
+	params: &FilteredParams,
+	log: &Log,
+	include_block_range: bool,
+) -> bool {
+	let block_hash_match = log
+		.block_hash
+		.is_none_or(|block_hash| params.filter_block_hash(block_hash));
+	let topics_match = params.filter.topics().is_empty() || params.filter_topics(&log.topics);
+	let address_match = params
+		.filter
+		.address
+		.as_ref()
+		.is_none_or(|_| params.filter_address(&log.address));
+	let block_range_match = !include_block_range
+		|| log
+			.block_number
+			.is_some_and(|block_number| params.filter_block_range(block_number.low_u64()));
+
+	block_hash_match && topics_match && address_match && block_range_match
+}
+
 pub(crate) fn filter_block_logs(
 	filter: &Filter,
 	block: EthereumBlock,
 	transaction_statuses: Vec<TransactionStatus>,
+) -> Vec<Log> {
+	filter_block_logs_with_removed(filter, block, transaction_statuses, false)
+}
+
+pub(crate) fn filter_block_logs_with_removed(
+	filter: &Filter,
+	block: EthereumBlock,
+	transaction_statuses: Vec<TransactionStatus>,
+	removed: bool,
 ) -> Vec<Log> {
 	let params = FilteredParams::new(filter.clone());
 	let mut block_log_index: u32 = 0;
@@ -827,21 +811,16 @@ pub(crate) fn filter_block_logs(
 				transaction_index: None,
 				log_index: None,
 				transaction_log_index: None,
-				removed: false,
+				removed,
 			};
 
-			let topics_match = filter.topics().is_empty() || params.filter_topics(&log.topics);
-			let address_match = filter
-				.address
-				.as_ref()
-				.is_none_or(|_| params.filter_address(&log.address));
-			if topics_match && address_match {
-				log.block_hash = Some(block_hash);
-				log.block_number = Some(block.header.number);
-				log.transaction_hash = Some(transaction_hash);
-				log.transaction_index = Some(U256::from(status.transaction_index));
-				log.log_index = Some(U256::from(block_log_index));
-				log.transaction_log_index = Some(U256::from(transaction_log_index));
+			log.block_hash = Some(block_hash);
+			log.block_number = Some(block.header.number);
+			log.transaction_hash = Some(transaction_hash);
+			log.transaction_index = Some(U256::from(status.transaction_index));
+			log.log_index = Some(U256::from(block_log_index));
+			log.transaction_log_index = Some(U256::from(transaction_log_index));
+			if log_matches_filter(&params, &log, false) {
 				logs.push(log);
 			}
 			transaction_log_index += 1;
@@ -849,4 +828,19 @@ pub(crate) fn filter_block_logs(
 		}
 	}
 	logs
+}
+
+fn logs_journal_error(err: LogsJournalError) -> jsonrpsee::types::ErrorObjectOwned {
+	match err {
+		LogsJournalError::CursorTooOld {
+			cursor,
+			earliest_available,
+			next_cursor,
+		} => internal_err(format!(
+			"log filter fell behind the retained reorg journal (cursor={cursor}, earliest={earliest_available}, next={next_cursor}); recreate the filter"
+		)),
+		LogsJournalError::IncompleteEntry { seq } => internal_err(format!(
+			"log filter encountered an incomplete reorg journal entry at sequence {seq}; recreate the filter"
+		)),
+	}
 }

--- a/client/rpc/src/eth/filter.rs
+++ b/client/rpc/src/eth/filter.rs
@@ -176,11 +176,13 @@ where
 
 			// Assume `max_stored_filters` is always < U256::max.
 			let key = last_key.checked_add(U256::one()).unwrap();
+			let last_log_journal_seq =
+				matches!(&filter_type, FilterType::Log(_)).then(|| self.logs_journal.cursor());
 			locked.insert(
 				key,
 				FilterPoolItem {
 					last_poll: BlockNumberOrHash::Num(best_number),
-					last_log_journal_seq: matches!(filter_type, FilterType::Log(_)).then_some(0),
+					last_log_journal_seq,
 					filter_type,
 					at_block: best_number,
 					pending_transaction_hashes,

--- a/client/rpc/src/eth_pubsub.rs
+++ b/client/rpc/src/eth_pubsub.rs
@@ -50,6 +50,8 @@ use fc_rpc_core::{
 use fc_storage::StorageOverride;
 use fp_rpc::EthereumRuntimeRPCApi;
 
+use crate::{eth::filter::log_matches_filter, LogsJournal};
+
 #[derive(Clone, Debug)]
 pub struct EthereumSubIdProvider;
 impl IdProvider for EthereumSubIdProvider {
@@ -68,6 +70,7 @@ pub struct EthPubSub<B: BlockT, P, C, BE> {
 	storage_override: Arc<dyn StorageOverride<B>>,
 	starting_block: u64,
 	pubsub_notification_sinks: Arc<EthereumBlockNotificationSinks<EthereumBlockNotification<B>>>,
+	logs_journal: Arc<LogsJournal>,
 	_marker: PhantomData<BE>,
 }
 
@@ -81,6 +84,7 @@ impl<B: BlockT, P, C, BE> Clone for EthPubSub<B, P, C, BE> {
 			storage_override: self.storage_override.clone(),
 			starting_block: self.starting_block,
 			pubsub_notification_sinks: self.pubsub_notification_sinks.clone(),
+			logs_journal: self.logs_journal.clone(),
 			_marker: PhantomData::<BE>,
 		}
 	}
@@ -103,6 +107,7 @@ where
 		pubsub_notification_sinks: Arc<
 			EthereumBlockNotificationSinks<EthereumBlockNotification<B>>,
 		>,
+		logs_journal: Arc<LogsJournal>,
 	) -> Self {
 		// Capture the best block as seen on initialization. Used for syncing subscriptions.
 		let best_number = client.info().best_number;
@@ -115,6 +120,7 @@ where
 			storage_override,
 			starting_block,
 			pubsub_notification_sinks,
+			logs_journal,
 			_marker: PhantomData,
 		}
 	}
@@ -156,36 +162,6 @@ where
 			.current_block(notification.hash)
 			.map(PubSubResult::header);
 		futures::stream::iter(maybe_header).boxed()
-	}
-
-	fn notify_logs(
-		&self,
-		notification: EthereumBlockNotification<B>,
-		params: &FilteredParams,
-	) -> future::Ready<Option<impl Iterator<Item = PubSubResult>>> {
-		let res = if notification.is_new_best {
-			let substrate_hash = notification.hash;
-
-			let block = self.storage_override.current_block(substrate_hash);
-			let statuses = self
-				.storage_override
-				.current_transaction_statuses(substrate_hash);
-
-			match (block, statuses) {
-				(Some(block), Some(statuses)) => Some((block, statuses)),
-				_ => None,
-			}
-		} else {
-			None
-		};
-
-		future::ready(res.map(|(block, statuses)| {
-			let logs = crate::eth::filter::filter_block_logs(&params.filter, block, statuses);
-
-			logs.clone()
-				.into_iter()
-				.map(|log| PubSubResult::Log(Box::new(log.clone())))
-		}))
 	}
 
 	fn pending_transactions(&self, hash: &TxHash<P>) -> future::Ready<Option<PubSubResult>> {
@@ -277,80 +253,124 @@ where
 			sc_utils::mpsc::tracing_unbounded("pubsub_notification_stream", 100_000);
 		self.pubsub_notification_sinks.lock().push(inner_sink);
 
-		let fut = async move {
-			match kind {
-				Kind::NewHeads => {
-					// Per Ethereum spec, when a reorg occurs, we must emit all headers
-					// for the new canonical chain. The reorg_info field in the notification
-					// contains the enacted blocks when a reorg occurred.
-					let flat_stream = block_notification_stream.flat_map(move |notification| {
-						pubsub.new_heads_from_notification(notification)
-					});
+		let fut =
+			async move {
+				match kind {
+					Kind::NewHeads => {
+						// Per Ethereum spec, when a reorg occurs, we must emit all headers
+						// for the new canonical chain. The reorg_info field in the notification
+						// contains the enacted blocks when a reorg occurred.
+						let flat_stream = block_notification_stream.flat_map(move |notification| {
+							pubsub.new_heads_from_notification(notification)
+						});
 
-					PendingSubscription::from(pending)
-						.pipe_from_stream(flat_stream, BoundedVecDeque::new(16))
-						.await
-				}
-				Kind::Logs => {
-					let stream = block_notification_stream
-						.filter_map(move |notification| {
-							pubsub.notify_logs(notification, &filtered_params)
-						})
-						.flat_map(futures::stream::iter);
-					PendingSubscription::from(pending)
-						.pipe_from_stream(stream, BoundedVecDeque::new(16))
-						.await
-				}
-				Kind::NewPendingTransactions => {
-					let pool = pubsub.pool.clone();
-					let stream = pool
-						.import_notification_stream()
-						.filter_map(move |hash| pubsub.pending_transactions(&hash));
-					PendingSubscription::from(pending)
-						.pipe_from_stream(stream, BoundedVecDeque::new(16))
-						.await;
-				}
-				Kind::Syncing => {
-					let Ok(sink) = pending.accept().await else {
-						return;
-					};
-					// On connection subscriber expects a value.
-					// Because import notifications are only emitted when the node is synced or
-					// in case of reorg, the first event is emitted right away.
-					let syncing_status = pubsub.syncing_status().await;
-					let subscription = Subscription::from(sink);
-					if subscription
-						.send(&PubSubResult::SyncingStatus(syncing_status))
-						.await
-						.is_err()
-					{
-						return;
+						PendingSubscription::from(pending)
+							.pipe_from_stream(flat_stream, BoundedVecDeque::new(16))
+							.await
 					}
+					Kind::Logs => {
+						let filter = filtered_params.filter.clone();
+						let stream =
+							futures::stream::unfold(
+								pubsub.logs_journal.subscribe(),
+								move |mut receiver| {
+									let filter = filter.clone();
+									async move {
+										loop {
+											match receiver.recv().await {
+										Ok(entry) => {
+											if !entry.complete {
+												debug!(
+													target: "eth-pubsub",
+													"Closing logs subscription after incomplete journal entry {}",
+													entry.seq,
+												);
+												return None;
+											}
 
-					// When the node is not under a major syncing (i.e. from genesis), react
-					// normally to import notifications.
-					//
-					// Only send new notifications down the pipe when the syncing status changed.
-					let mut stream = pubsub.client.import_notification_stream();
-					let mut last_syncing_status = pubsub.sync.is_major_syncing();
-					while (stream.next().await).is_some() {
-						let syncing_status = pubsub.sync.is_major_syncing();
-						if syncing_status != last_syncing_status {
-							let syncing_status = pubsub.syncing_status().await;
-							if subscription
-								.send(&PubSubResult::SyncingStatus(syncing_status))
-								.await
-								.is_err()
-							{
-								break;
-							}
+											let params = FilteredParams::new(filter.clone());
+											let logs = entry
+												.logs
+												.iter()
+												.filter(|log| log_matches_filter(&params, log, false))
+												.cloned()
+												.map(|log| PubSubResult::Log(Box::new(log)))
+												.collect::<Vec<_>>();
+											if logs.is_empty() {
+												continue;
+											}
+											return Some((logs, receiver));
+										}
+										Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+											debug!(
+												target: "eth-pubsub",
+												"Closing lagging logs subscription after missing {skipped} journal entries",
+											);
+											return None;
+										}
+										Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+											return None;
+										}
+									}
+										}
+									}
+								},
+							)
+							.flat_map(futures::stream::iter);
+						PendingSubscription::from(pending)
+							.pipe_from_stream(stream, BoundedVecDeque::new(16))
+							.await
+					}
+					Kind::NewPendingTransactions => {
+						let pool = pubsub.pool.clone();
+						let stream = pool
+							.import_notification_stream()
+							.filter_map(move |hash| pubsub.pending_transactions(&hash));
+						PendingSubscription::from(pending)
+							.pipe_from_stream(stream, BoundedVecDeque::new(16))
+							.await;
+					}
+					Kind::Syncing => {
+						let Ok(sink) = pending.accept().await else {
+							return;
+						};
+						// On connection subscriber expects a value.
+						// Because import notifications are only emitted when the node is synced or
+						// in case of reorg, the first event is emitted right away.
+						let syncing_status = pubsub.syncing_status().await;
+						let subscription = Subscription::from(sink);
+						if subscription
+							.send(&PubSubResult::SyncingStatus(syncing_status))
+							.await
+							.is_err()
+						{
+							return;
 						}
-						last_syncing_status = syncing_status;
+
+						// When the node is not under a major syncing (i.e. from genesis), react
+						// normally to import notifications.
+						//
+						// Only send new notifications down the pipe when the syncing status changed.
+						let mut stream = pubsub.client.import_notification_stream();
+						let mut last_syncing_status = pubsub.sync.is_major_syncing();
+						while (stream.next().await).is_some() {
+							let syncing_status = pubsub.sync.is_major_syncing();
+							if syncing_status != last_syncing_status {
+								let syncing_status = pubsub.syncing_status().await;
+								if subscription
+									.send(&PubSubResult::SyncingStatus(syncing_status))
+									.await
+									.is_err()
+								{
+									break;
+								}
+							}
+							last_syncing_status = syncing_status;
+						}
 					}
 				}
 			}
-		}
-		.boxed();
+			.boxed();
 
 		self.executor
 			.spawn("frontier-rpc-subscription", Some("rpc"), fut);

--- a/client/rpc/src/eth_pubsub.rs
+++ b/client/rpc/src/eth_pubsub.rs
@@ -318,7 +318,7 @@ where
 							)
 							.flat_map(futures::stream::iter);
 						PendingSubscription::from(pending)
-							.pipe_from_stream(stream, BoundedVecDeque::new(16))
+							.pipe_from_stream(Box::pin(stream), BoundedVecDeque::new(16))
 							.await
 					}
 					Kind::NewPendingTransactions => {

--- a/client/rpc/src/eth_pubsub.rs
+++ b/client/rpc/src/eth_pubsub.rs
@@ -16,7 +16,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use std::{marker::PhantomData, sync::Arc};
+use std::{
+	marker::PhantomData,
+	sync::{
+		atomic::{AtomicBool, Ordering},
+		Arc,
+	},
+};
 
 use ethereum::TransactionV3 as EthereumTransaction;
 use futures::{future, stream::BoxStream, FutureExt as _, StreamExt as _};
@@ -50,7 +56,10 @@ use fc_rpc_core::{
 use fc_storage::StorageOverride;
 use fp_rpc::EthereumRuntimeRPCApi;
 
-use crate::{eth::filter::log_matches_filter, LogsJournal};
+use crate::{
+	eth::filter::log_matches_filter, logs_journal::build_journal_payload_for_subscription,
+	LogsJournal,
+};
 
 #[derive(Clone, Debug)]
 pub struct EthereumSubIdProvider;
@@ -164,6 +173,44 @@ where
 		futures::stream::iter(maybe_header).boxed()
 	}
 
+	/// Turn a best-chain notification into pub-sub log results, using the same log set as
+	/// [`LogsJournal`]. When the payload is incomplete (reorg in progress), `subscription_ended`
+	/// is set so the outer stream stops (matches closing the prior broadcast-based subscription).
+	fn notify_logs(
+		&self,
+		notification: EthereumBlockNotification<B>,
+		params: &FilteredParams,
+		subscription_ended: &Arc<AtomicBool>,
+	) -> Option<Vec<PubSubResult>> {
+		if !notification.is_new_best {
+			return None;
+		}
+
+		let (complete, logs) =
+			build_journal_payload_for_subscription(self.storage_override.as_ref(), notification);
+
+		if !complete {
+			debug!(
+				target: "eth-pubsub",
+				"Closing logs subscription after incomplete journal-equivalent payload",
+			);
+			subscription_ended.store(true, Ordering::SeqCst);
+			return Some(Vec::new());
+		}
+
+		let results = logs
+			.into_iter()
+			.filter(|log| log_matches_filter(params, log, false))
+			.map(|log| PubSubResult::Log(Box::new(log)))
+			.collect::<Vec<_>>();
+
+		if results.is_empty() {
+			None
+		} else {
+			Some(results)
+		}
+	}
+
 	fn pending_transactions(&self, hash: &TxHash<P>) -> future::Ready<Option<PubSubResult>> {
 		let res = if let Some(xt) = self.pool.ready_transaction(hash) {
 			let best_block = self.client.info().best_hash;
@@ -253,124 +300,93 @@ where
 			sc_utils::mpsc::tracing_unbounded("pubsub_notification_stream", 100_000);
 		self.pubsub_notification_sinks.lock().push(inner_sink);
 
-		let fut =
-			async move {
-				match kind {
-					Kind::NewHeads => {
-						// Per Ethereum spec, when a reorg occurs, we must emit all headers
-						// for the new canonical chain. The reorg_info field in the notification
-						// contains the enacted blocks when a reorg occurred.
-						let flat_stream = block_notification_stream.flat_map(move |notification| {
-							pubsub.new_heads_from_notification(notification)
-						});
+		let fut = async move {
+			match kind {
+				Kind::NewHeads => {
+					// Per Ethereum spec, when a reorg occurs, we must emit all headers
+					// for the new canonical chain. The reorg_info field in the notification
+					// contains the enacted blocks when a reorg occurred.
+					let flat_stream = block_notification_stream.flat_map(move |notification| {
+						pubsub.new_heads_from_notification(notification)
+					});
 
-						PendingSubscription::from(pending)
-							.pipe_from_stream(flat_stream, BoundedVecDeque::new(16))
-							.await
+					PendingSubscription::from(pending)
+						.pipe_from_stream(flat_stream, BoundedVecDeque::new(16))
+						.await
+				}
+				Kind::Logs => {
+					let subscription_ended = Arc::new(AtomicBool::new(false));
+					let logs_params = filtered_params.clone();
+					let stream = block_notification_stream
+						.take_while({
+							let subscription_ended = subscription_ended.clone();
+							move |_| future::ready(!subscription_ended.load(Ordering::SeqCst))
+						})
+						.filter_map(move |notification| {
+							let pubsub = pubsub.clone();
+							let subscription_ended = subscription_ended.clone();
+							let logs_params = logs_params.clone();
+							future::ready(pubsub.notify_logs(
+								notification,
+								&logs_params,
+								&subscription_ended,
+							))
+						})
+						.flat_map(futures::stream::iter);
+					PendingSubscription::from(pending)
+						.pipe_from_stream(stream, BoundedVecDeque::new(16))
+						.await
+				}
+				Kind::NewPendingTransactions => {
+					let pool = pubsub.pool.clone();
+					let stream = pool
+						.import_notification_stream()
+						.filter_map(move |hash| pubsub.pending_transactions(&hash));
+					PendingSubscription::from(pending)
+						.pipe_from_stream(stream, BoundedVecDeque::new(16))
+						.await;
+				}
+				Kind::Syncing => {
+					let Ok(sink) = pending.accept().await else {
+						return;
+					};
+					// On connection subscriber expects a value.
+					// Because import notifications are only emitted when the node is synced or
+					// in case of reorg, the first event is emitted right away.
+					let syncing_status = pubsub.syncing_status().await;
+					let subscription = Subscription::from(sink);
+					if subscription
+						.send(&PubSubResult::SyncingStatus(syncing_status))
+						.await
+						.is_err()
+					{
+						return;
 					}
-					Kind::Logs => {
-						let filter = filtered_params.filter.clone();
-						let stream =
-							futures::stream::unfold(
-								pubsub.logs_journal.subscribe(),
-								move |mut receiver| {
-									let filter = filter.clone();
-									async move {
-										loop {
-											match receiver.recv().await {
-										Ok(entry) => {
-											if !entry.complete {
-												debug!(
-													target: "eth-pubsub",
-													"Closing logs subscription after incomplete journal entry {}",
-													entry.seq,
-												);
-												return None;
-											}
 
-											let params = FilteredParams::new(filter.clone());
-											let logs = entry
-												.logs
-												.iter()
-												.filter(|log| log_matches_filter(&params, log, false))
-												.cloned()
-												.map(|log| PubSubResult::Log(Box::new(log)))
-												.collect::<Vec<_>>();
-											if logs.is_empty() {
-												continue;
-											}
-											return Some((logs, receiver));
-										}
-										Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
-											debug!(
-												target: "eth-pubsub",
-												"Closing lagging logs subscription after missing {skipped} journal entries",
-											);
-											return None;
-										}
-										Err(tokio::sync::broadcast::error::RecvError::Closed) => {
-											return None;
-										}
-									}
-										}
-									}
-								},
-							)
-							.flat_map(futures::stream::iter);
-						PendingSubscription::from(pending)
-							.pipe_from_stream(Box::pin(stream), BoundedVecDeque::new(16))
-							.await
-					}
-					Kind::NewPendingTransactions => {
-						let pool = pubsub.pool.clone();
-						let stream = pool
-							.import_notification_stream()
-							.filter_map(move |hash| pubsub.pending_transactions(&hash));
-						PendingSubscription::from(pending)
-							.pipe_from_stream(stream, BoundedVecDeque::new(16))
-							.await;
-					}
-					Kind::Syncing => {
-						let Ok(sink) = pending.accept().await else {
-							return;
-						};
-						// On connection subscriber expects a value.
-						// Because import notifications are only emitted when the node is synced or
-						// in case of reorg, the first event is emitted right away.
-						let syncing_status = pubsub.syncing_status().await;
-						let subscription = Subscription::from(sink);
-						if subscription
-							.send(&PubSubResult::SyncingStatus(syncing_status))
-							.await
-							.is_err()
-						{
-							return;
-						}
-
-						// When the node is not under a major syncing (i.e. from genesis), react
-						// normally to import notifications.
-						//
-						// Only send new notifications down the pipe when the syncing status changed.
-						let mut stream = pubsub.client.import_notification_stream();
-						let mut last_syncing_status = pubsub.sync.is_major_syncing();
-						while (stream.next().await).is_some() {
-							let syncing_status = pubsub.sync.is_major_syncing();
-							if syncing_status != last_syncing_status {
-								let syncing_status = pubsub.syncing_status().await;
-								if subscription
-									.send(&PubSubResult::SyncingStatus(syncing_status))
-									.await
-									.is_err()
-								{
-									break;
-								}
+					// When the node is not under a major syncing (i.e. from genesis), react
+					// normally to import notifications.
+					//
+					// Only send new notifications down the pipe when the syncing status changed.
+					let mut stream = pubsub.client.import_notification_stream();
+					let mut last_syncing_status = pubsub.sync.is_major_syncing();
+					while (stream.next().await).is_some() {
+						let syncing_status = pubsub.sync.is_major_syncing();
+						if syncing_status != last_syncing_status {
+							let syncing_status = pubsub.syncing_status().await;
+							if subscription
+								.send(&PubSubResult::SyncingStatus(syncing_status))
+								.await
+								.is_err()
+							{
+								break;
 							}
-							last_syncing_status = syncing_status;
 						}
+						last_syncing_status = syncing_status;
 					}
 				}
 			}
-			.boxed();
+		}
+		.boxed();
 
 		self.executor
 			.spawn("frontier-rpc-subscription", Some("rpc"), fut);

--- a/client/rpc/src/eth_pubsub.rs
+++ b/client/rpc/src/eth_pubsub.rs
@@ -16,18 +16,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use std::{
-	marker::PhantomData,
-	sync::{
-		atomic::{AtomicBool, Ordering},
-		Arc,
-	},
-};
+use std::{marker::PhantomData, sync::Arc};
 
 use ethereum::TransactionV3 as EthereumTransaction;
 use futures::{future, stream::BoxStream, FutureExt as _, StreamExt as _};
 use jsonrpsee::{core::traits::IdProvider, server::PendingSubscriptionSink};
 use log::debug;
+use tokio::sync::broadcast::error::RecvError;
 // Substrate
 use sc_client_api::{
 	backend::{Backend, StorageProvider},
@@ -56,10 +51,7 @@ use fc_rpc_core::{
 use fc_storage::StorageOverride;
 use fp_rpc::EthereumRuntimeRPCApi;
 
-use crate::{
-	eth::filter::log_matches_filter, logs_journal::build_journal_payload_for_subscription,
-	LogsJournal,
-};
+use crate::{eth::filter::log_matches_filter, LogsJournal};
 
 #[derive(Clone, Debug)]
 pub struct EthereumSubIdProvider;
@@ -173,44 +165,6 @@ where
 		futures::stream::iter(maybe_header).boxed()
 	}
 
-	/// Turn a best-chain notification into pub-sub log results, using the same log set as
-	/// [`LogsJournal`]. When the payload is incomplete (reorg in progress), `subscription_ended`
-	/// is set so the outer stream stops (matches closing the prior broadcast-based subscription).
-	fn notify_logs(
-		&self,
-		notification: EthereumBlockNotification<B>,
-		params: &FilteredParams,
-		subscription_ended: &Arc<AtomicBool>,
-	) -> Option<Vec<PubSubResult>> {
-		if !notification.is_new_best {
-			return None;
-		}
-
-		let (complete, logs) =
-			build_journal_payload_for_subscription(self.storage_override.as_ref(), notification);
-
-		if !complete {
-			debug!(
-				target: "eth-pubsub",
-				"Closing logs subscription after incomplete journal-equivalent payload",
-			);
-			subscription_ended.store(true, Ordering::SeqCst);
-			return Some(Vec::new());
-		}
-
-		let results = logs
-			.into_iter()
-			.filter(|log| log_matches_filter(params, log, false))
-			.map(|log| PubSubResult::Log(Box::new(log)))
-			.collect::<Vec<_>>();
-
-		if results.is_empty() {
-			None
-		} else {
-			Some(results)
-		}
-	}
-
 	fn pending_transactions(&self, hash: &TxHash<P>) -> future::Ready<Option<PubSubResult>> {
 		let res = if let Some(xt) = self.pool.ready_transaction(hash) {
 			let best_block = self.client.info().best_hash;
@@ -295,14 +249,13 @@ where
 		};
 
 		let pubsub = self.clone();
-		// Everytime a new subscription is created, a new mpsc channel is added to the sink pool.
-		let (inner_sink, block_notification_stream) =
-			sc_utils::mpsc::tracing_unbounded("pubsub_notification_stream", 100_000);
-		self.pubsub_notification_sinks.lock().push(inner_sink);
 
 		let fut = async move {
 			match kind {
 				Kind::NewHeads => {
+					let (inner_sink, block_notification_stream) =
+						sc_utils::mpsc::tracing_unbounded("pubsub_notification_stream", 100_000);
+					pubsub.pubsub_notification_sinks.lock().push(inner_sink);
 					// Per Ethereum spec, when a reorg occurs, we must emit all headers
 					// for the new canonical chain. The reorg_info field in the notification
 					// contains the enacted blocks when a reorg occurred.
@@ -315,26 +268,48 @@ where
 						.await
 				}
 				Kind::Logs => {
-					let subscription_ended = Arc::new(AtomicBool::new(false));
 					let logs_params = filtered_params.clone();
-					let stream = block_notification_stream
-						.take_while({
-							let subscription_ended = subscription_ended.clone();
-							move |_| future::ready(!subscription_ended.load(Ordering::SeqCst))
-						})
-						.filter_map(move |notification| {
-							let pubsub = pubsub.clone();
-							let subscription_ended = subscription_ended.clone();
-							let logs_params = logs_params.clone();
-							future::ready(pubsub.notify_logs(
-								notification,
-								&logs_params,
-								&subscription_ended,
-							))
-						})
-						.flat_map(futures::stream::iter);
+					let journal_rx = pubsub.logs_journal.subscribe();
+					let stream = futures::stream::unfold(journal_rx, move |mut rx| {
+						let logs_params = logs_params.clone();
+						async move {
+							loop {
+								let entry = match rx.recv().await {
+									Ok(e) => e,
+									Err(RecvError::Lagged(n)) => {
+										debug!(
+											target: "eth-pubsub",
+											"Closing logs subscription; lagged behind logs journal by {n} entries"
+										);
+										return None;
+									}
+									Err(RecvError::Closed) => return None,
+								};
+
+								if !entry.complete {
+									debug!(
+										target: "eth-pubsub",
+										"Closing logs subscription after incomplete journal entry",
+									);
+									return None;
+								}
+
+								let results: Vec<PubSubResult> = entry
+									.logs
+									.iter()
+									.filter(|log| log_matches_filter(&logs_params, log, false))
+									.map(|log| PubSubResult::Log(Box::new(log.clone())))
+									.collect();
+
+								if !results.is_empty() {
+									return Some((results, rx));
+								}
+							}
+						}
+					})
+					.flat_map(futures::stream::iter);
 					PendingSubscription::from(pending)
-						.pipe_from_stream(stream, BoundedVecDeque::new(16))
+						.pipe_from_stream(Box::pin(stream), BoundedVecDeque::new(16))
 						.await
 				}
 				Kind::NewPendingTransactions => {

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -30,6 +30,7 @@ mod cache;
 mod debug;
 mod eth;
 mod eth_pubsub;
+mod logs_journal;
 mod net;
 mod signer;
 #[cfg(feature = "txpool")]
@@ -43,6 +44,7 @@ pub use self::{
 	debug::Debug,
 	eth::{format, pending, EstimateGasAdapter, Eth, EthConfig, EthFilter},
 	eth_pubsub::{EthPubSub, EthereumSubIdProvider},
+	logs_journal::{LogsJournal, LogsJournalEntry, LogsJournalError},
 	net::Net,
 	signer::{EthDevSigner, EthSigner},
 	web3::Web3,

--- a/client/rpc/src/logs_journal.rs
+++ b/client/rpc/src/logs_journal.rs
@@ -197,15 +197,6 @@ impl LogsJournal {
 	}
 }
 
-/// Same payload as pushed to the journal; used by `eth_subscribe("logs")` so pub-sub matches
-/// `eth_getFilterChanges` / the retained journal without reading the broadcast channel.
-pub(crate) fn build_journal_payload_for_subscription<B: BlockT>(
-	storage_override: &dyn StorageOverride<B>,
-	notification: EthereumBlockNotification<B>,
-) -> (bool, Vec<Log>) {
-	build_journal_payload(storage_override, notification)
-}
-
 fn build_journal_payload<B: BlockT>(
 	storage_override: &dyn StorageOverride<B>,
 	notification: EthereumBlockNotification<B>,

--- a/client/rpc/src/logs_journal.rs
+++ b/client/rpc/src/logs_journal.rs
@@ -6,6 +6,7 @@
 use std::{
 	collections::VecDeque,
 	sync::{Arc, Mutex},
+	time::Duration,
 };
 
 use futures::{FutureExt as _, StreamExt as _};
@@ -21,6 +22,12 @@ use fc_storage::StorageOverride;
 use crate::eth::filter::filter_block_logs_with_removed;
 
 const DEFAULT_LOGS_JOURNAL_CAPACITY: usize = 256;
+
+/// When the per-connection notification stream ends (sender dropped — e.g. sink pool refresh or
+/// RPC restart), we register a new sink and continue. A short pause avoids tight spinning if sinks
+/// churn rapidly; we intentionally **do not** cap retries so the journal keeps tracking the best
+/// chain for the lifetime of the process.
+const LOGS_JOURNAL_RECONNECT_BACKOFF: Duration = Duration::from_millis(50);
 
 #[derive(Clone, Debug)]
 pub struct LogsJournalEntry {
@@ -147,6 +154,8 @@ impl LogsJournal {
 					};
 					let _ = worker_tx.send(entry);
 				}
+
+				tokio::time::sleep(LOGS_JOURNAL_RECONNECT_BACKOFF).await;
 			}
 		}
 		.boxed();

--- a/client/rpc/src/logs_journal.rs
+++ b/client/rpc/src/logs_journal.rs
@@ -266,6 +266,89 @@ fn append_block_logs<B: BlockT>(
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use std::collections::HashMap;
+
+	use ethereum::{BlockV3, PartialHeader};
+	use ethereum_types::{Bloom, H160, H256, H64, U256};
+	use fp_rpc::TransactionStatus;
+	use sp_runtime::{
+		generic::{Block, Header},
+		traits::BlakeTwo256,
+		Permill,
+	};
+
+	type OpaqueBlock = Block<Header<u64, BlakeTwo256>, sp_runtime::OpaqueExtrinsic>;
+
+	#[derive(Default)]
+	struct MockStorageOverride {
+		blocks: HashMap<H256, BlockV3>,
+		statuses: HashMap<H256, Vec<TransactionStatus>>,
+	}
+
+	impl StorageOverride<OpaqueBlock> for MockStorageOverride {
+		fn account_code_at(&self, _at: H256, _address: H160) -> Option<Vec<u8>> {
+			None
+		}
+
+		fn account_storage_at(&self, _at: H256, _address: H160, _index: U256) -> Option<H256> {
+			None
+		}
+
+		fn current_block(&self, at: H256) -> Option<BlockV3> {
+			self.blocks.get(&at).cloned()
+		}
+
+		fn current_receipts(&self, _at: H256) -> Option<Vec<ethereum::ReceiptV4>> {
+			None
+		}
+
+		fn current_transaction_statuses(&self, at: H256) -> Option<Vec<TransactionStatus>> {
+			self.statuses.get(&at).cloned()
+		}
+
+		fn elasticity(&self, _at: H256) -> Option<Permill> {
+			None
+		}
+
+		fn is_eip1559(&self, _at: H256) -> bool {
+			false
+		}
+	}
+
+	fn make_ethereum_block(seed: u64) -> ethereum::BlockV3 {
+		let partial_header = PartialHeader {
+			parent_hash: H256::from_low_u64_be(seed),
+			beneficiary: H160::from_low_u64_be(seed),
+			state_root: H256::from_low_u64_be(seed.saturating_add(1)),
+			receipts_root: H256::from_low_u64_be(seed.saturating_add(2)),
+			logs_bloom: Bloom::default(),
+			difficulty: U256::from(seed),
+			number: U256::from(seed),
+			gas_limit: U256::from(seed.saturating_add(100)),
+			gas_used: U256::from(seed.saturating_add(50)),
+			timestamp: seed,
+			extra_data: Vec::new(),
+			mix_hash: H256::from_low_u64_be(seed.saturating_add(3)),
+			nonce: H64::from_low_u64_be(seed),
+		};
+		ethereum::Block::new(partial_header, vec![], vec![])
+	}
+
+	fn make_status(topic: H256, tx_index: u32) -> TransactionStatus {
+		TransactionStatus {
+			transaction_hash: H256::from_low_u64_be(topic.to_low_u64_be()),
+			transaction_index: tx_index,
+			from: H160::repeat_byte(0x11),
+			to: Some(H160::repeat_byte(0x22)),
+			contract_address: None,
+			logs: vec![ethereum::Log {
+				address: H160::repeat_byte(0x33),
+				topics: vec![topic],
+				data: vec![0x01, 0x02],
+			}],
+			logs_bloom: Bloom::default(),
+		}
+	}
 
 	#[test]
 	fn snapshot_since_returns_cursor_too_old_after_eviction() {
@@ -307,5 +390,99 @@ mod tests {
 
 		let err = journal.snapshot_since(0).unwrap_err();
 		assert!(matches!(err, LogsJournalError::IncompleteEntry { seq: 1 }));
+	}
+
+	#[test]
+	fn build_payload_without_reorg_marks_logs_as_not_removed() {
+		let hash = H256::repeat_byte(0xAA);
+		let mut storage = MockStorageOverride::default();
+		storage.blocks.insert(hash, make_ethereum_block(10));
+		storage
+			.statuses
+			.insert(hash, vec![make_status(H256::repeat_byte(0xA1), 0)]);
+
+		let notification = EthereumBlockNotification::<OpaqueBlock> {
+			is_new_best: true,
+			hash,
+			reorg_info: None,
+		};
+		let (complete, logs) = build_journal_payload(&storage, notification);
+
+		assert!(complete);
+		assert_eq!(logs.len(), 1);
+		assert!(!logs[0].removed);
+		assert_eq!(logs[0].topics, vec![H256::repeat_byte(0xA1)]);
+	}
+
+	#[test]
+	fn build_payload_with_reorg_orders_retracted_then_enacted_then_new_best() {
+		let retracted = H256::repeat_byte(0x10);
+		let enacted = H256::repeat_byte(0x20);
+		let new_best = H256::repeat_byte(0x30);
+
+		let mut storage = MockStorageOverride::default();
+		storage.blocks.insert(retracted, make_ethereum_block(1));
+		storage.blocks.insert(enacted, make_ethereum_block(2));
+		storage.blocks.insert(new_best, make_ethereum_block(3));
+		storage
+			.statuses
+			.insert(retracted, vec![make_status(H256::repeat_byte(0xA1), 0)]);
+		storage
+			.statuses
+			.insert(enacted, vec![make_status(H256::repeat_byte(0xB2), 0)]);
+		storage
+			.statuses
+			.insert(new_best, vec![make_status(H256::repeat_byte(0xC3), 0)]);
+
+		let notification = EthereumBlockNotification::<OpaqueBlock> {
+			is_new_best: true,
+			hash: new_best,
+			reorg_info: Some(Arc::new(fc_mapping_sync::ReorgInfo::<OpaqueBlock> {
+				common_ancestor: H256::repeat_byte(0x01),
+				retracted: vec![retracted],
+				enacted: vec![enacted],
+				new_best,
+			})),
+		};
+		let (complete, logs) = build_journal_payload(&storage, notification);
+
+		assert!(complete);
+		assert_eq!(logs.len(), 3);
+		assert_eq!(logs[0].topics, vec![H256::repeat_byte(0xA1)]);
+		assert_eq!(logs[1].topics, vec![H256::repeat_byte(0xB2)]);
+		assert_eq!(logs[2].topics, vec![H256::repeat_byte(0xC3)]);
+		assert!(logs[0].removed);
+		assert!(!logs[1].removed);
+		assert!(!logs[2].removed);
+	}
+
+	#[test]
+	fn build_payload_returns_incomplete_when_reorg_data_is_missing() {
+		let retracted = H256::repeat_byte(0x10);
+		let enacted = H256::repeat_byte(0x20);
+		let new_best = H256::repeat_byte(0x30);
+
+		let mut storage = MockStorageOverride::default();
+		storage.blocks.insert(retracted, make_ethereum_block(1));
+		storage.blocks.insert(enacted, make_ethereum_block(2));
+		storage
+			.statuses
+			.insert(retracted, vec![make_status(H256::repeat_byte(0xA1), 0)]);
+		// Missing statuses for enacted hash forces an incomplete payload.
+
+		let notification = EthereumBlockNotification::<OpaqueBlock> {
+			is_new_best: true,
+			hash: new_best,
+			reorg_info: Some(Arc::new(fc_mapping_sync::ReorgInfo::<OpaqueBlock> {
+				common_ancestor: H256::repeat_byte(0x01),
+				retracted: vec![retracted],
+				enacted: vec![enacted],
+				new_best,
+			})),
+		};
+		let (complete, logs) = build_journal_payload(&storage, notification);
+
+		assert!(!complete);
+		assert!(logs.is_empty());
 	}
 }

--- a/client/rpc/src/logs_journal.rs
+++ b/client/rpc/src/logs_journal.rs
@@ -127,13 +127,11 @@ impl LogsJournal {
 		let worker_tx = tx.clone();
 		let worker_fut = async move {
 			loop {
-				let mut had_stream = false;
 				let (inner_sink, mut notifications) =
 					sc_utils::mpsc::tracing_unbounded("logs_journal_notification_stream", 100_000);
 				pubsub_notification_sinks.lock().push(inner_sink);
 
 				while let Some(notification) = notifications.next().await {
-					had_stream = true;
 					if !notification.is_new_best {
 						continue;
 					}
@@ -147,11 +145,17 @@ impl LogsJournal {
 					let _ = worker_tx.send(entry);
 				}
 
-				if had_stream {
-					let entry = {
-						let mut state = worker_state.lock().expect("logs journal mutex poisoned");
-						state.push(false, Vec::new())
-					};
+				// Stream ended: fail closed for consumers only if we had a complete tail (continuity
+				// may be broken). Skip if the journal is still empty (no notifications yet) or the
+				// tail is already incomplete (do not stack duplicate gap markers).
+				let maybe_gap = {
+					let mut state = worker_state.lock().expect("logs journal mutex poisoned");
+					match state.entries.back() {
+						Some(last) if last.complete => Some(state.push(false, Vec::new())),
+						_ => None,
+					}
+				};
+				if let Some(entry) = maybe_gap {
 					let _ = worker_tx.send(entry);
 				}
 

--- a/client/rpc/src/logs_journal.rs
+++ b/client/rpc/src/logs_journal.rs
@@ -1,0 +1,299 @@
+// This file is part of Frontier.
+//
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+use std::{
+	collections::VecDeque,
+	sync::{Arc, Mutex},
+};
+
+use futures::StreamExt as _;
+use tokio::sync::broadcast;
+// Substrate
+use sc_rpc::SubscriptionTaskExecutor;
+use sp_runtime::traits::Block as BlockT;
+// Frontier
+use fc_mapping_sync::{EthereumBlockNotification, EthereumBlockNotificationSinks};
+use fc_rpc_core::types::{Filter, Log};
+use fc_storage::StorageOverride;
+
+use crate::eth::filter::filter_block_logs_with_removed;
+
+const DEFAULT_LOGS_JOURNAL_CAPACITY: usize = 256;
+
+#[derive(Clone, Debug)]
+pub struct LogsJournalEntry {
+	pub seq: u64,
+	pub complete: bool,
+	pub logs: Vec<Log>,
+}
+
+#[derive(Clone, Debug)]
+pub enum LogsJournalError {
+	CursorTooOld {
+		cursor: u64,
+		earliest_available: u64,
+		next_cursor: u64,
+	},
+	IncompleteEntry {
+		seq: u64,
+	},
+}
+
+#[derive(Default)]
+struct LogsJournalState {
+	entries: VecDeque<Arc<LogsJournalEntry>>,
+	next_seq: u64,
+	max_entries: usize,
+}
+
+impl LogsJournalState {
+	fn with_capacity(max_entries: usize) -> Self {
+		Self {
+			entries: VecDeque::new(),
+			next_seq: 0,
+			max_entries: max_entries.max(1),
+		}
+	}
+
+	fn cursor(&self) -> u64 {
+		self.next_seq
+	}
+
+	fn earliest_available(&self) -> u64 {
+		self.entries
+			.front()
+			.map(|entry| entry.seq)
+			.unwrap_or(self.next_seq)
+	}
+
+	fn push(&mut self, complete: bool, logs: Vec<Log>) -> Arc<LogsJournalEntry> {
+		let entry = Arc::new(LogsJournalEntry {
+			seq: self.next_seq,
+			complete,
+			logs,
+		});
+		self.next_seq = self.next_seq.saturating_add(1);
+		self.entries.push_back(entry.clone());
+		while self.entries.len() > self.max_entries {
+			self.entries.pop_front();
+		}
+		entry
+	}
+}
+
+#[derive(Clone)]
+pub struct LogsJournal {
+	state: Arc<Mutex<LogsJournalState>>,
+	tx: broadcast::Sender<Arc<LogsJournalEntry>>,
+}
+
+impl LogsJournal {
+	pub fn new<B: BlockT + 'static>(
+		executor: SubscriptionTaskExecutor,
+		storage_override: Arc<dyn StorageOverride<B>>,
+		pubsub_notification_sinks: Arc<
+			EthereumBlockNotificationSinks<EthereumBlockNotification<B>>,
+		>,
+	) -> Self {
+		Self::with_capacity(
+			executor,
+			storage_override,
+			pubsub_notification_sinks,
+			DEFAULT_LOGS_JOURNAL_CAPACITY,
+		)
+	}
+
+	pub fn with_capacity<B: BlockT + 'static>(
+		executor: SubscriptionTaskExecutor,
+		storage_override: Arc<dyn StorageOverride<B>>,
+		pubsub_notification_sinks: Arc<
+			EthereumBlockNotificationSinks<EthereumBlockNotification<B>>,
+		>,
+		max_entries: usize,
+	) -> Self {
+		let state = Arc::new(Mutex::new(LogsJournalState::with_capacity(max_entries)));
+		let (tx, _) = broadcast::channel(max_entries.max(1));
+
+		let worker_state = state.clone();
+		let worker_tx = tx.clone();
+		executor.spawn("frontier-rpc-logs-journal", Some("rpc"), async move {
+			let mut had_stream = false;
+			loop {
+				let (inner_sink, mut notifications) =
+					sc_utils::mpsc::tracing_unbounded("logs_journal_notification_stream", 100_000);
+				pubsub_notification_sinks.lock().push(inner_sink);
+
+				while let Some(notification) = notifications.next().await {
+					had_stream = true;
+					if !notification.is_new_best {
+						continue;
+					}
+
+					let (complete, logs) =
+						build_journal_payload(storage_override.as_ref(), notification);
+					let entry = {
+						let mut state = worker_state.lock().expect("logs journal mutex poisoned");
+						state.push(complete, logs)
+					};
+					let _ = worker_tx.send(entry);
+				}
+
+				if had_stream {
+					let entry = {
+						let mut state = worker_state.lock().expect("logs journal mutex poisoned");
+						state.push(false, Vec::new())
+					};
+					let _ = worker_tx.send(entry);
+				}
+			}
+		});
+
+		Self { state, tx }
+	}
+
+	pub fn cursor(&self) -> u64 {
+		self.state
+			.lock()
+			.expect("logs journal mutex poisoned")
+			.cursor()
+	}
+
+	pub fn subscribe(&self) -> broadcast::Receiver<Arc<LogsJournalEntry>> {
+		self.tx.subscribe()
+	}
+
+	pub fn snapshot_since(
+		&self,
+		cursor: u64,
+	) -> Result<(Vec<Arc<LogsJournalEntry>>, u64), LogsJournalError> {
+		let state = self.state.lock().expect("logs journal mutex poisoned");
+		let earliest_available = state.earliest_available();
+		let next_cursor = state.cursor();
+
+		if cursor < earliest_available {
+			return Err(LogsJournalError::CursorTooOld {
+				cursor,
+				earliest_available,
+				next_cursor,
+			});
+		}
+
+		let entries = state
+			.entries
+			.iter()
+			.filter(|entry| entry.seq >= cursor)
+			.cloned()
+			.collect::<Vec<_>>();
+		if let Some(entry) = entries.iter().find(|entry| !entry.complete) {
+			return Err(LogsJournalError::IncompleteEntry { seq: entry.seq });
+		}
+
+		Ok((entries, next_cursor))
+	}
+}
+
+fn build_journal_payload<B: BlockT>(
+	storage_override: &dyn StorageOverride<B>,
+	notification: EthereumBlockNotification<B>,
+) -> (bool, Vec<Log>) {
+	let mut logs = Vec::new();
+	let empty_filter = Filter::default();
+
+	if let Some(reorg_info) = notification.reorg_info {
+		for hash in reorg_info.retracted {
+			if !append_block_logs(storage_override, &empty_filter, hash, true, &mut logs) {
+				return (false, Vec::new());
+			}
+		}
+		for hash in reorg_info
+			.enacted
+			.into_iter()
+			.chain(std::iter::once(reorg_info.new_best))
+		{
+			if !append_block_logs(storage_override, &empty_filter, hash, false, &mut logs) {
+				return (false, Vec::new());
+			}
+		}
+		return (true, logs);
+	}
+
+	if append_block_logs(
+		storage_override,
+		&empty_filter,
+		notification.hash,
+		false,
+		&mut logs,
+	) {
+		(true, logs)
+	} else {
+		(false, Vec::new())
+	}
+}
+
+fn append_block_logs<B: BlockT>(
+	storage_override: &dyn StorageOverride<B>,
+	filter: &Filter,
+	block_hash: B::Hash,
+	removed: bool,
+	out: &mut Vec<Log>,
+) -> bool {
+	let Some(block) = storage_override.current_block(block_hash) else {
+		return false;
+	};
+	let Some(statuses) = storage_override.current_transaction_statuses(block_hash) else {
+		return false;
+	};
+	out.extend(filter_block_logs_with_removed(
+		filter, block, statuses, removed,
+	));
+	true
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn snapshot_since_returns_cursor_too_old_after_eviction() {
+		let journal = LogsJournal {
+			state: Arc::new(Mutex::new(LogsJournalState::with_capacity(2))),
+			tx: broadcast::channel(2).0,
+		};
+
+		{
+			let mut state = journal.state.lock().unwrap();
+			state.push(true, Vec::new());
+			state.push(true, Vec::new());
+			state.push(true, Vec::new());
+		}
+
+		let err = journal.snapshot_since(0).unwrap_err();
+		assert!(matches!(
+			err,
+			LogsJournalError::CursorTooOld {
+				cursor: 0,
+				earliest_available: 1,
+				next_cursor: 3,
+			}
+		));
+	}
+
+	#[test]
+	fn snapshot_since_fails_closed_on_incomplete_entry() {
+		let journal = LogsJournal {
+			state: Arc::new(Mutex::new(LogsJournalState::with_capacity(4))),
+			tx: broadcast::channel(4).0,
+		};
+
+		{
+			let mut state = journal.state.lock().unwrap();
+			state.push(true, Vec::new());
+			state.push(false, Vec::new());
+		}
+
+		let err = journal.snapshot_since(0).unwrap_err();
+		assert!(matches!(err, LogsJournalError::IncompleteEntry { seq: 1 }));
+	}
+}

--- a/client/rpc/src/logs_journal.rs
+++ b/client/rpc/src/logs_journal.rs
@@ -118,37 +118,45 @@ impl LogsJournal {
 
 		let worker_state = state.clone();
 		let worker_tx = tx.clone();
-		executor.spawn("frontier-rpc-logs-journal", Some("rpc"), async move {
-			let mut had_stream = false;
-			loop {
-				let (inner_sink, mut notifications) =
-					sc_utils::mpsc::tracing_unbounded("logs_journal_notification_stream", 100_000);
-				pubsub_notification_sinks.lock().push(inner_sink);
+		executor.spawn(
+			"frontier-rpc-logs-journal",
+			Some("rpc"),
+			Box::pin(async move {
+				let mut had_stream = false;
+				loop {
+					let (inner_sink, mut notifications) = sc_utils::mpsc::tracing_unbounded(
+						"logs_journal_notification_stream",
+						100_000,
+					);
+					pubsub_notification_sinks.lock().push(inner_sink);
 
-				while let Some(notification) = notifications.next().await {
-					had_stream = true;
-					if !notification.is_new_best {
-						continue;
+					while let Some(notification) = notifications.next().await {
+						had_stream = true;
+						if !notification.is_new_best {
+							continue;
+						}
+
+						let (complete, logs) =
+							build_journal_payload(storage_override.as_ref(), notification);
+						let entry = {
+							let mut state =
+								worker_state.lock().expect("logs journal mutex poisoned");
+							state.push(complete, logs)
+						};
+						let _ = worker_tx.send(entry);
 					}
 
-					let (complete, logs) =
-						build_journal_payload(storage_override.as_ref(), notification);
-					let entry = {
-						let mut state = worker_state.lock().expect("logs journal mutex poisoned");
-						state.push(complete, logs)
-					};
-					let _ = worker_tx.send(entry);
+					if had_stream {
+						let entry = {
+							let mut state =
+								worker_state.lock().expect("logs journal mutex poisoned");
+							state.push(false, Vec::new())
+						};
+						let _ = worker_tx.send(entry);
+					}
 				}
-
-				if had_stream {
-					let entry = {
-						let mut state = worker_state.lock().expect("logs journal mutex poisoned");
-						state.push(false, Vec::new())
-					};
-					let _ = worker_tx.send(entry);
-				}
-			}
-		});
+			}),
+		);
 
 		Self { state, tx }
 	}
@@ -201,18 +209,18 @@ fn build_journal_payload<B: BlockT>(
 	let mut logs = Vec::new();
 	let empty_filter = Filter::default();
 
-	if let Some(reorg_info) = notification.reorg_info {
-		for hash in reorg_info.retracted {
-			if !append_block_logs(storage_override, &empty_filter, hash, true, &mut logs) {
+	if let Some(reorg_info) = notification.reorg_info.as_deref() {
+		for hash in &reorg_info.retracted {
+			if !append_block_logs(storage_override, &empty_filter, *hash, true, &mut logs) {
 				return (false, Vec::new());
 			}
 		}
 		for hash in reorg_info
 			.enacted
-			.into_iter()
-			.chain(std::iter::once(reorg_info.new_best))
+			.iter()
+			.chain(std::iter::once(&reorg_info.new_best))
 		{
-			if !append_block_logs(storage_override, &empty_filter, hash, false, &mut logs) {
+			if !append_block_logs(storage_override, &empty_filter, *hash, false, &mut logs) {
 				return (false, Vec::new());
 			}
 		}

--- a/client/rpc/src/logs_journal.rs
+++ b/client/rpc/src/logs_journal.rs
@@ -119,8 +119,8 @@ impl LogsJournal {
 		let worker_state = state.clone();
 		let worker_tx = tx.clone();
 		let worker_fut = async move {
-			let mut had_stream = false;
 			loop {
+				let mut had_stream = false;
 				let (inner_sink, mut notifications) =
 					sc_utils::mpsc::tracing_unbounded("logs_journal_notification_stream", 100_000);
 				pubsub_notification_sinks.lock().push(inner_sink);
@@ -252,9 +252,17 @@ fn append_block_logs<B: BlockT>(
 	out: &mut Vec<Log>,
 ) -> bool {
 	let Some(block) = storage_override.current_block(block_hash) else {
+		log::debug!(
+			target: "rpc",
+			"Missing block data for {block_hash:?}, marking journal entry incomplete"
+		);
 		return false;
 	};
 	let Some(statuses) = storage_override.current_transaction_statuses(block_hash) else {
+		log::debug!(
+			target: "rpc",
+			"Missing transaction statuses for {block_hash:?}, marking journal entry incomplete"
+		);
 		return false;
 	};
 	out.extend(filter_block_logs_with_removed(

--- a/client/rpc/src/logs_journal.rs
+++ b/client/rpc/src/logs_journal.rs
@@ -288,6 +288,7 @@ mod tests {
 		traits::BlakeTwo256,
 		Permill,
 	};
+	use tokio::sync::broadcast::error::RecvError;
 
 	type OpaqueBlock = Block<Header<u64, BlakeTwo256>, sp_runtime::OpaqueExtrinsic>;
 
@@ -402,6 +403,34 @@ mod tests {
 
 		let err = journal.snapshot_since(0).unwrap_err();
 		assert!(matches!(err, LogsJournalError::IncompleteEntry { seq: 1 }));
+	}
+
+	/// `eth_subscribe("logs")` reads the same `broadcast` channel as the journal worker (`LogsJournal::new`).
+	/// If the subscriber stops calling `recv` while the chain advances, `RecvError::Lagged` ends the stream
+	/// (see `eth_pubsub.rs` Kind::Logs).
+	#[test]
+	fn journal_broadcast_matches_channel_capacity_for_ws_lag() {
+		let cap = 4usize;
+		let (tx, mut rx) = broadcast::channel(cap.max(1));
+		let dummy = Arc::new(LogsJournalEntry {
+			seq: 0,
+			complete: true,
+			logs: Vec::new(),
+		});
+		futures::executor::block_on(async move {
+			for _ in 0..cap {
+				let _ = tx.send(dummy.clone());
+				assert!(rx.recv().await.is_ok());
+			}
+			for _ in 0..cap.saturating_add(2) {
+				let _ = tx.send(dummy.clone());
+			}
+			let next = rx.recv().await;
+			assert!(
+				matches!(next, Err(RecvError::Lagged(_))),
+				"expected Lagged when subscriber falls behind the journal broadcast buffer: {next:?}"
+			);
+		});
 	}
 
 	#[test]

--- a/client/rpc/src/logs_journal.rs
+++ b/client/rpc/src/logs_journal.rs
@@ -8,7 +8,7 @@ use std::{
 	sync::{Arc, Mutex},
 };
 
-use futures::StreamExt as _;
+use futures::{FutureExt as _, StreamExt as _};
 use tokio::sync::broadcast;
 // Substrate
 use sc_rpc::SubscriptionTaskExecutor;
@@ -118,45 +118,40 @@ impl LogsJournal {
 
 		let worker_state = state.clone();
 		let worker_tx = tx.clone();
-		executor.spawn(
-			"frontier-rpc-logs-journal",
-			Some("rpc"),
-			Box::pin(async move {
-				let mut had_stream = false;
-				loop {
-					let (inner_sink, mut notifications) = sc_utils::mpsc::tracing_unbounded(
-						"logs_journal_notification_stream",
-						100_000,
-					);
-					pubsub_notification_sinks.lock().push(inner_sink);
+		let worker_fut = async move {
+			let mut had_stream = false;
+			loop {
+				let (inner_sink, mut notifications) =
+					sc_utils::mpsc::tracing_unbounded("logs_journal_notification_stream", 100_000);
+				pubsub_notification_sinks.lock().push(inner_sink);
 
-					while let Some(notification) = notifications.next().await {
-						had_stream = true;
-						if !notification.is_new_best {
-							continue;
-						}
-
-						let (complete, logs) =
-							build_journal_payload(storage_override.as_ref(), notification);
-						let entry = {
-							let mut state =
-								worker_state.lock().expect("logs journal mutex poisoned");
-							state.push(complete, logs)
-						};
-						let _ = worker_tx.send(entry);
+				while let Some(notification) = notifications.next().await {
+					had_stream = true;
+					if !notification.is_new_best {
+						continue;
 					}
 
-					if had_stream {
-						let entry = {
-							let mut state =
-								worker_state.lock().expect("logs journal mutex poisoned");
-							state.push(false, Vec::new())
-						};
-						let _ = worker_tx.send(entry);
-					}
+					let (complete, logs) =
+						build_journal_payload(storage_override.as_ref(), notification);
+					let entry = {
+						let mut state = worker_state.lock().expect("logs journal mutex poisoned");
+						state.push(complete, logs)
+					};
+					let _ = worker_tx.send(entry);
 				}
-			}),
-		);
+
+				if had_stream {
+					let entry = {
+						let mut state = worker_state.lock().expect("logs journal mutex poisoned");
+						state.push(false, Vec::new())
+					};
+					let _ = worker_tx.send(entry);
+				}
+			}
+		}
+		.boxed();
+
+		executor.spawn("frontier-rpc-logs-journal", Some("rpc"), worker_fut);
 
 		Self { state, tx }
 	}
@@ -200,6 +195,15 @@ impl LogsJournal {
 
 		Ok((entries, next_cursor))
 	}
+}
+
+/// Same payload as pushed to the journal; used by `eth_subscribe("logs")` so pub-sub matches
+/// `eth_getFilterChanges` / the retained journal without reading the broadcast channel.
+pub(crate) fn build_journal_payload_for_subscription<B: BlockT>(
+	storage_override: &dyn StorageOverride<B>,
+	notification: EthereumBlockNotification<B>,
+) -> (bool, Vec<Log>) {
+	build_journal_payload(storage_override, notification)
 }
 
 fn build_journal_payload<B: BlockT>(

--- a/template/node/src/rpc/eth.rs
+++ b/template/node/src/rpc/eth.rs
@@ -95,8 +95,8 @@ where
 {
 	use fc_rpc::{
 		pending::AuraConsensusDataProvider, Debug, DebugApiServer, Eth, EthApiServer, EthDevSigner,
-		EthFilter, EthFilterApiServer, EthPubSub, EthPubSubApiServer, EthSigner, Net, NetApiServer,
-		Web3, Web3ApiServer,
+		EthFilter, EthFilterApiServer, EthPubSub, EthPubSubApiServer, EthSigner, LogsJournal, Net,
+		NetApiServer, Web3, Web3ApiServer,
 	};
 	#[cfg(feature = "txpool")]
 	use fc_rpc::{TxPool, TxPoolApiServer};
@@ -127,6 +127,12 @@ where
 	if enable_dev_signer {
 		signers.push(Box::new(EthDevSigner::new()) as Box<dyn EthSigner>);
 	}
+
+	let logs_journal = Arc::new(LogsJournal::new(
+		subscription_task_executor.clone(),
+		storage_override.clone(),
+		pubsub_notification_sinks.clone(),
+	));
 
 	io.merge(
 		Eth::<B, C, P, CT, BE, CIDP, EC>::new(
@@ -162,6 +168,7 @@ where
 				max_past_logs,
 				max_block_range,
 				block_data_cache.clone(),
+				logs_journal.clone(),
 			)
 			.into_rpc(),
 		)?;
@@ -175,6 +182,7 @@ where
 			subscription_task_executor,
 			storage_override.clone(),
 			pubsub_notification_sinks,
+			logs_journal,
 		)
 		.into_rpc(),
 	)?;

--- a/ts-tests/tests/test-filter-api.ts
+++ b/ts-tests/tests/test-filter-api.ts
@@ -126,20 +126,28 @@ describeWithFrontier("Frontier RPC (EthFilterApi)", (context) => {
 
 		expect(receipt.logs.length).to.be.eq(1);
 
-		// Create a filter for the created contract.
+		// Topic-only filter: `eth_getFilterChanges` starts at the journal cursor (no replay of
+		// retained history).
 		let createFilter = await customRequest(context.web3, "eth_newFilter", [
 			{
 				fromBlock: "0x0",
 				toBlock: "latest",
-				address: receipt.contractAddress,
 				topics: receipt.logs[0].topics,
 			},
 		]);
 		let poll = await customRequest(context.web3, "eth_getFilterChanges", [createFilter.result]);
+		expect(poll.result.length).to.be.eq(0);
 
+		// A new canonical transition after the filter exists produces filter changes.
+		let tx2 = await sendTransaction(context);
+		await createAndFinalizeBlock(context.web3);
+		let receipt2 = await context.web3.eth.getTransactionReceipt(tx2.transactionHash);
+		expect(receipt2.logs.length).to.be.eq(1);
+
+		poll = await customRequest(context.web3, "eth_getFilterChanges", [createFilter.result]);
 		expect(poll.result.length).to.be.eq(1);
-		expect(poll.result[0].address.toLowerCase()).to.be.eq(receipt.contractAddress.toLowerCase());
-		expect(poll.result[0].topics).to.be.deep.eq(receipt.logs[0].topics);
+		expect(poll.result[0].address.toLowerCase()).to.be.eq(receipt2.contractAddress.toLowerCase());
+		expect(poll.result[0].topics).to.be.deep.eq(receipt2.logs[0].topics);
 
 		// A subsequent request must be empty.
 		poll = await customRequest(context.web3, "eth_getFilterChanges", [createFilter.result]);

--- a/ts-tests/tests/test-log-reorg-compliance.ts
+++ b/ts-tests/tests/test-log-reorg-compliance.ts
@@ -2,7 +2,14 @@ import { expect } from "chai";
 import { step } from "mocha-steps";
 
 import { GENESIS_ACCOUNT, GENESIS_ACCOUNT_PRIVATE_KEY } from "./config";
-import { customRequest, describeWithFrontierWs, waitForBlock, waitForReceipt } from "./util";
+import {
+	createAndFinalizeBlock,
+	createAndFinalizeBlockNowait,
+	customRequest,
+	describeWithFrontierWs,
+	waitForBlock,
+	waitForReceipt,
+} from "./util";
 
 const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 const LOG_EMITTING_CONSTRUCTOR =
@@ -27,15 +34,6 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 
 	async function sleep(ms: number) {
 		await new Promise<void>((resolve) => setTimeout(resolve, ms));
-	}
-
-	async function createBlock(finalize: boolean = true, parentHash: string | null = null): Promise<string> {
-		const response = await customRequest(context.web3, "engine_createBlock", [true, finalize, parentHash]);
-		if (!response.result?.hash) {
-			throw new Error(`Unexpected result: ${JSON.stringify(response)}`);
-		}
-		await waitForBlock(context.web3, "latest", 15000);
-		return response.result.hash as string;
 	}
 
 	async function sendLogTransaction() {
@@ -124,9 +122,9 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 			});
 		});
 
-		const anchor = await createBlock(false);
+		const anchor = await createAndFinalizeBlock(context.web3, false);
 		const tx = await sendLogTransaction();
-		await createBlock(false, anchor);
+		await createAndFinalizeBlock(context.web3, false, anchor);
 
 		const receipt = await waitForReceipt(context.web3, tx.transactionHash);
 		const firstEvent = await waitForMatchingEvent(
@@ -137,8 +135,8 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 		);
 		expect(firstEvent.blockHash).to.equal(receipt.blockHash);
 
-		const b1 = await createBlock(false, anchor);
-		await createBlock(false, b1);
+		const b1 = await createAndFinalizeBlock(context.web3, false, anchor);
+		await createAndFinalizeBlock(context.web3, false, b1);
 
 		const removedEvent = await waitForMatchingEvent(
 			events,
@@ -155,9 +153,9 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 		this.timeout(60000);
 
 		const filterId = (await customRequest(context.web3, "eth_newFilter", [{}])).result as string;
-		const anchor = await createBlock(false);
+		const anchor = await createAndFinalizeBlock(context.web3, false);
 		const tx = await sendLogTransaction();
-		await createBlock(false, anchor);
+		await createAndFinalizeBlock(context.web3, false, anchor);
 
 		const receipt = await waitForReceipt(context.web3, tx.transactionHash);
 		const firstEvent = await waitForFilterChange(
@@ -168,8 +166,8 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 		);
 		expect(firstEvent.blockHash).to.equal(receipt.blockHash);
 
-		const b1 = await createBlock(false, anchor);
-		await createBlock(false, b1);
+		const b1 = await createAndFinalizeBlock(context.web3, false, anchor);
+		await createAndFinalizeBlock(context.web3, false, b1);
 
 		const removedEvent = await waitForFilterChange(
 			filterId,
@@ -195,10 +193,10 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 		});
 
 		// Canonical chain: A1 -> A2 (includes deploy tx + log)
-		const a1Hash = await createBlock(false);
+		const a1Hash = await createAndFinalizeBlock(context.web3, false);
 		const signedTx = await deployErc20ContractTx();
 		const txHash = signedTx.transactionHash as string;
-		await createBlock(false);
+		await createAndFinalizeBlock(context.web3, false);
 
 		const receipt = await waitForReceipt(context.web3, txHash, 20000);
 		const blockWithDeploy = await context.web3.eth.getBlock(receipt.blockNumber, false);
@@ -208,8 +206,8 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 		await new Promise((r) => setTimeout(r, 1500));
 
 		// Longer fork from A1: A1 -> B2 -> B3 (retracts the block that contained the deploy)
-		const b2Hash = await createBlock(false, a1Hash);
-		await createBlock(false, b2Hash);
+		const b2Hash = await createAndFinalizeBlock(context.web3, false, a1Hash);
+		await createAndFinalizeBlock(context.web3, false, b2Hash);
 
 		const pollDeadline = Date.now() + 60000;
 		while (Date.now() < pollDeadline) {

--- a/ts-tests/tests/test-log-reorg-compliance.ts
+++ b/ts-tests/tests/test-log-reorg-compliance.ts
@@ -152,7 +152,7 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 				e.transactionHash?.toLowerCase() === (winningTx.transactionHash as string).toLowerCase() &&
 				e.removed !== true
 		);
-		expect(canonicalAfterReorg.removed === true, "winning-branch log must not be a tombstone").to.equal(false);
+		expect(canonicalAfterReorg.removed, "winning-branch log must not be a tombstone").to.not.equal(true);
 
 		subscription.unsubscribe();
 	}).timeout(60000);
@@ -196,6 +196,7 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 				e.removed !== true
 		);
 		expect(canonicalAfterReorg.removed === true, "winning-branch log must not be a tombstone").to.equal(false);
+		await customRequest(context.web3, "eth_uninstallFilter", [filterId]);
 	}).timeout(60000);
 
 	step("logs subscription should emit removed=true after a longer fork (ERC20 deploy)", async function () {
@@ -220,7 +221,12 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 		expect(blockWithDeploy).to.not.be.null;
 		const retractedEthBlockHash = blockWithDeploy!.hash as string;
 
-		await sleep(1500);
+		// Wait for the canonical log event before triggering reorg
+		await waitForMatchingEvent(
+			logEvents,
+			(e) => e.transactionHash?.toLowerCase() === txHash.toLowerCase() && e.removed !== true,
+			10000
+		);
 
 		// Longer fork from A1: A1 -> B2 -> B3 (retracts the block that contained the deploy)
 		const b2Hash = await createAndFinalizeBlock(context.web3, false, a1Hash, true);

--- a/ts-tests/tests/test-log-reorg-compliance.ts
+++ b/ts-tests/tests/test-log-reorg-compliance.ts
@@ -29,6 +29,23 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 		await new Promise<void>((resolve) => setTimeout(resolve, ms));
 	}
 
+	async function waitForSubscriptionConnection(subscription: any) {
+		return new Promise<void>((resolve, reject) => {
+			const timer = setTimeout(
+				() => reject(new Error("Timed out waiting for logs subscription connection")),
+				10000
+			);
+			subscription.on("connected", function () {
+				clearTimeout(timer);
+				resolve();
+			});
+			subscription.on("error", function (error: any) {
+				clearTimeout(timer);
+				reject(error);
+			});
+		});
+	}
+
 	async function sendLogTransaction() {
 		const tx = await context.web3.eth.accounts.signTransaction(
 			{
@@ -100,20 +117,7 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 		};
 		subscription.on("data", recordLog);
 		subscription.on("changed", recordLog);
-		await new Promise<void>((resolve, reject) => {
-			const timer = setTimeout(
-				() => reject(new Error("Timed out waiting for logs subscription connection")),
-				10000
-			);
-			subscription.on("connected", function () {
-				clearTimeout(timer);
-				resolve();
-			});
-			subscription.on("error", function (error: any) {
-				clearTimeout(timer);
-				reject(error);
-			});
-		});
+		await waitForSubscriptionConnection(subscription);
 
 		const anchor = await createAndFinalizeBlock(context.web3, false);
 		const tx = await sendLogTransaction();
@@ -203,9 +207,7 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 		};
 		subscription.on("data", recordLog);
 		subscription.on("changed", recordLog);
-		await new Promise<void>((resolve) => {
-			subscription.on("connected", () => resolve());
-		});
+		await waitForSubscriptionConnection(subscription);
 
 		// Canonical chain: A1 -> A2 (includes deploy tx + log)
 		const a1Hash = await createAndFinalizeBlock(context.web3, false);
@@ -218,7 +220,7 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 		expect(blockWithDeploy).to.not.be.null;
 		const retractedEthBlockHash = blockWithDeploy!.hash as string;
 
-		await new Promise((r) => setTimeout(r, 1500));
+		await sleep(1500);
 
 		// Longer fork from A1: A1 -> B2 -> B3 (retracts the block that contained the deploy)
 		const b2Hash = await createAndFinalizeBlock(context.web3, false, a1Hash);
@@ -229,7 +231,7 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 			if (logEvents.some((e) => e.removed === true)) {
 				break;
 			}
-			await new Promise((r) => setTimeout(r, 300));
+			await sleep(300);
 		}
 
 		const postForkTx = await sendLogTransaction();

--- a/ts-tests/tests/test-log-reorg-compliance.ts
+++ b/ts-tests/tests/test-log-reorg-compliance.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { step } from "mocha-steps";
 
 import { GENESIS_ACCOUNT, GENESIS_ACCOUNT_PRIVATE_KEY } from "./config";
-import { customRequest, describeWithFrontierWs, waitForReceipt } from "./util";
+import { customRequest, describeWithFrontierWs, waitForBlock, waitForReceipt } from "./util";
 
 const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 const LOG_EMITTING_CONSTRUCTOR =
@@ -15,6 +15,13 @@ const LOG_EMITTING_CONSTRUCTOR =
 	"60206000a1" +
 	"60006000f3";
 
+const TEST_CONTRACT_BYTECODE =
+	"0x608060405234801561001057600080fd5b50610041337fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff61004660201b60201c565b610291565b600073ffffffffffffffffffffffffffffffffffffffff168273ffffffffffffffffffffffffffffffffffffffff1614156100e9576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252601f8152602001807f45524332303a206d696e7420746f20746865207a65726f20616464726573730081525060200191505060405180910390fd5b6101028160025461020960201b610c7c1790919060201c565b60028190555061015d816000808573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205461020960201b610c7c1790919060201c565b6000808473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020819055508173ffffffffffffffffffffffffffffffffffffffff16600073ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef836040518082815260200191505060405180910390a35050565b600080828401905083811015610287576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252601b8152602001807f536166654d6174683a206164646974696f6e206f766572666c6f77000000000081525060200191505060405180910390fd5b8091505092915050565b610e3a806102a06000396000f3fe608060405234801561001057600080fd5b50600436106100885760003560e01c806370a082311161005b57806370a08231146101fd578063a457c2d714610255578063a9059cbb146102bb578063dd62ed3e1461032157610088565b8063095ea7b31461008d57806318160ddd146100f357806323b872dd146101115780633950935114610197575b600080fd5b6100d9600480360360408110156100a357600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919080359060200190929190505050610399565b604051808215151515815260200191505060405180910390f35b6100fb6103b7565b6040518082815260200191505060405180910390f35b61017d6004803603606081101561012757600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff169060200190929190803573ffffffffffffffffffffffffffffffffffffffff169060200190929190803590602001909291905050506103c1565b604051808215151515815260200191505060405180910390f35b6101e3600480360360408110156101ad57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291908035906020019092919050505061049a565b604051808215151515815260200191505060405180910390f35b61023f6004803603602081101561021357600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919050505061054d565b6040518082815260200191505060405180910390f35b6102a16004803603604081101561026b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919080359060200190929190505050610595565b604051808215151515815260200191505060405180910390f35b610307600480360360408110156102d157600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919080359060200190929190505050610662565b604051808215151515815260200191505060405180910390f35b6103836004803603604081101561033757600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff169060200190929190803573ffffffffffffffffffffffffffffffffffffffff169060200190929190505050610680565b6040518082815260200191505060405180910390f35b60006103ad6103a6610707565b848461070f565b6001905092915050565b6000600254905090565b60006103ce848484610906565b61048f846103da610707565b61048a85604051806060016040528060288152602001610d7060289139600160008b73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000610440610707565b73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054610bbc9092919063ffffffff16565b61070f565b600190509392505050565b60006105436104a7610707565b8461053e85600160006104b8610707565b73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008973ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054610c7c90919063ffffffff16565b61070f565b6001905092915050565b60008060008373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020549050919050565b60006106586105a2610707565b8461065385604051806060016040528060258152602001610de160259139600160006105cc610707565b73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008a73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054610bbc9092919063ffffffff16565b61070f565b6001905092915050565b600061067661066f610707565b8484610906565b6001905092915050565b6000600160008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054905092915050565b600033905090565b600073ffffffffffffffffffffffffffffffffffffffff168373ffffffffffffffffffffffffffffffffffffffff161415610795576040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401808060200182810382526024815260200180610dbd6024913960400191505060405180910390fd5b600073ffffffffffffffffffffffffffffffffffffffff168273ffffffffffffffffffffffffffffffffffffffff16141561081b576040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401808060200182810382526022815260200180610d286022913960400191505060405180910390fd5b80600160008573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020819055508173ffffffffffffffffffffffffffffffffffffffff168373ffffffffffffffffffffffffffffffffffffffff167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925836040518082815260200191505060405180910390a3505050565b600073ffffffffffffffffffffffffffffffffffffffff168373ffffffffffffffffffffffffffffffffffffffff16141561098c576040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401808060200182810382526025815260200180610d986025913960400191505060405180910390fd5b600073ffffffffffffffffffffffffffffffffffffffff168273ffffffffffffffffffffffffffffffffffffffff161415610a12576040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401808060200182810382526023815260200180610d056023913960400191505060405180910390fd5b610a7d81604051806060016040528060268152602001610d4a602691396000808773ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054610bbc9092919063ffffffff16565b6000808573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002081905550610b10816000808573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054610c7c90919063ffffffff16565b6000808473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020819055508173ffffffffffffffffffffffffffffffffffffffff168373ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef836040518082815260200191505060405180910390a3505050565b6000838311158290610c69576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825283818151815260200191508051906020019080838360005b83811015610c2e578082015181840152602081019050610c13565b50505050905090810190601f168015610c5b5780820380516001836020036101000a031916815260200191505b509250505060405180910390fd5b5060008385039050809150509392505050565b600080828401905083811015610cfa576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252601b8152602001807f536166654d6174683a206164646974696f6e206f766572666c6f77000000000081525060200191505060405180910390fd5b809150509291505056fe45524332303a207472616e7366657220746f20746865207a65726f206164647265737345524332303a20617070726f766520746f20746865207a65726f206164647265737345524332303a207472616e7366657220616d6f756e7420657863656564732062616c616e636545524332303a207472616e7366657220616d6f756e74206578636565647320616c6c6f77616e636545524332303a207472616e736665722066726f6d20746865207a65726f206164647265737345524332303a20617070726f76652066726f6d20746865207a65726f206164647265737345524332303a2064656372656173656420616c6c6f77616e63652062656c6f77207a65726fa265627a7a72315820c7a5ffabf642bda14700b2de42f8c57b36621af020441df825de45fd2b3e1c5c64736f6c63430005100032";
+
+/**
+ * Reorg log semantics: invalidated logs appear with removed: true (filters + pub/sub).
+ * Note: web3.js v1 emits log tombstones on subscription "changed", not "data".
+ */
 describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 	let subscription;
 
@@ -27,7 +34,7 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 		if (!response.result?.hash) {
 			throw new Error(`Unexpected result: ${JSON.stringify(response)}`);
 		}
-		await sleep(300);
+		await waitForBlock(context.web3, "latest", 15000);
 		return response.result.hash as string;
 	}
 
@@ -43,11 +50,28 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 			GENESIS_ACCOUNT_PRIVATE_KEY
 		);
 
-		await customRequest(context.web3, "eth_sendRawTransaction", [tx.rawTransaction]);
-		return tx;
+		const sendRes = await customRequest(context.web3, "eth_sendRawTransaction", [tx.rawTransaction]);
+		const txHash = (sendRes.result as string) || (tx.transactionHash as string);
+		return { ...tx, transactionHash: txHash };
 	}
 
-	async function waitForMatchingEvent(events: any[], predicate: (event: any) => boolean, timeoutMs = 15000) {
+	async function deployErc20ContractTx() {
+		const tx = await context.web3.eth.accounts.signTransaction(
+			{
+				from: GENESIS_ACCOUNT,
+				data: TEST_CONTRACT_BYTECODE,
+				value: "0x00",
+				gasPrice: "0x3B9ACA00",
+				gas: "0x1000000",
+			},
+			GENESIS_ACCOUNT_PRIVATE_KEY
+		);
+		const sendRes = await customRequest(context.web3, "eth_sendRawTransaction", [tx.rawTransaction]);
+		const txHash = (sendRes.result as string) || (tx.transactionHash as string);
+		return { ...tx, transactionHash: txHash };
+	}
+
+	async function waitForMatchingEvent(events: any[], predicate: (event: any) => boolean, timeoutMs = 60000) {
 		const start = Date.now();
 		while (Date.now() - start < timeoutMs) {
 			const match = events.find(predicate);
@@ -59,7 +83,7 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 		throw new Error("Timed out waiting for matching log event");
 	}
 
-	async function waitForFilterChange(filterId: string, predicate: (event: any) => boolean, timeoutMs = 15000) {
+	async function waitForFilterChange(filterId: string, predicate: (event: any) => boolean, timeoutMs = 60000) {
 		const start = Date.now();
 		while (Date.now() - start < timeoutMs) {
 			const response = await customRequest(context.web3, "eth_getFilterChanges", [filterId]);
@@ -77,6 +101,14 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 		this.timeout(60000);
 
 		subscription = context.web3.eth.subscribe("logs", {}, function (_error, _result) {});
+
+		const events: any[] = [];
+		// web3.js emits log tombstones (removed: true) on "changed", not "data" (see web3-eth subscribe logs subscriptionHandler).
+		const recordLog = (event: any) => {
+			events.push(event);
+		};
+		subscription.on("data", recordLog);
+		subscription.on("changed", recordLog);
 		await new Promise<void>((resolve, reject) => {
 			const timer = setTimeout(
 				() => reject(new Error("Timed out waiting for logs subscription connection")),
@@ -92,11 +124,6 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 			});
 		});
 
-		const events: any[] = [];
-		subscription.on("data", function (event: any) {
-			events.push(event);
-		});
-
 		const anchor = await createBlock(false);
 		const tx = await sendLogTransaction();
 		await createBlock(false, anchor);
@@ -104,7 +131,9 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 		const receipt = await waitForReceipt(context.web3, tx.transactionHash);
 		const firstEvent = await waitForMatchingEvent(
 			events,
-			(event) => event.transactionHash === tx.transactionHash && event.removed === false
+			(event) =>
+				event.transactionHash?.toLowerCase() === (tx.transactionHash as string).toLowerCase() &&
+				event.removed !== true
 		);
 		expect(firstEvent.blockHash).to.equal(receipt.blockHash);
 
@@ -113,7 +142,9 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 
 		const removedEvent = await waitForMatchingEvent(
 			events,
-			(event) => event.transactionHash === tx.transactionHash && event.removed === true
+			(event) =>
+				event.transactionHash?.toLowerCase() === (tx.transactionHash as string).toLowerCase() &&
+				event.removed === true
 		);
 		expect(removedEvent.blockHash).to.equal(receipt.blockHash);
 
@@ -131,7 +162,9 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 		const receipt = await waitForReceipt(context.web3, tx.transactionHash);
 		const firstEvent = await waitForFilterChange(
 			filterId,
-			(event) => event.transactionHash === tx.transactionHash && event.removed === false
+			(event) =>
+				event.transactionHash?.toLowerCase() === (tx.transactionHash as string).toLowerCase() &&
+				event.removed !== true
 		);
 		expect(firstEvent.blockHash).to.equal(receipt.blockHash);
 
@@ -140,9 +173,71 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 
 		const removedEvent = await waitForFilterChange(
 			filterId,
-			(event) => event.transactionHash === tx.transactionHash && event.removed === true
+			(event) =>
+				event.transactionHash?.toLowerCase() === (tx.transactionHash as string).toLowerCase() &&
+				event.removed === true
 		);
 		expect(removedEvent.blockHash).to.equal(receipt.blockHash);
 		expect(removedEvent.topics[0]).to.equal(TRANSFER_TOPIC);
 	}).timeout(60000);
+
+	step("logs subscription should emit removed=true after a longer fork (ERC20 deploy)", async function () {
+		subscription = context.web3.eth.subscribe("logs", {}, () => {});
+
+		const logEvents: any[] = [];
+		const recordLog = (d: any) => {
+			logEvents.push(d);
+		};
+		subscription.on("data", recordLog);
+		subscription.on("changed", recordLog);
+		await new Promise<void>((resolve) => {
+			subscription.on("connected", () => resolve());
+		});
+
+		// Canonical chain: A1 -> A2 (includes deploy tx + log)
+		const a1Hash = await createBlock(false);
+		const signedTx = await deployErc20ContractTx();
+		const txHash = signedTx.transactionHash as string;
+		await createBlock(false);
+
+		const receipt = await waitForReceipt(context.web3, txHash, 20000);
+		const blockWithDeploy = await context.web3.eth.getBlock(receipt.blockNumber, false);
+		expect(blockWithDeploy).to.not.be.null;
+		const retractedEthBlockHash = blockWithDeploy!.hash as string;
+
+		await new Promise((r) => setTimeout(r, 1500));
+
+		// Longer fork from A1: A1 -> B2 -> B3 (retracts the block that contained the deploy)
+		const b2Hash = await createBlock(false, a1Hash);
+		await createBlock(false, b2Hash);
+
+		const pollDeadline = Date.now() + 60000;
+		while (Date.now() < pollDeadline) {
+			if (logEvents.some((e) => e.removed === true)) {
+				break;
+			}
+			await new Promise((r) => setTimeout(r, 300));
+		}
+
+		subscription.unsubscribe();
+
+		const removedTrue = logEvents.filter((e) => e.removed === true);
+		const removedFalse = logEvents.filter((e) => e.removed === false);
+
+		expect(removedFalse.length, "should see at least one canonical log before/during test").to.be.at.least(1);
+
+		expect(
+			removedTrue.length,
+			`expected removed=true after reorg; events: ${JSON.stringify(
+				logEvents.map((e) => ({ removed: e.removed, blockHash: e.blockHash?.slice(0, 12) }))
+			)}`
+		).to.be.at.least(1);
+
+		const matchesRetractedBlock = removedTrue.some(
+			(e) => e.blockHash?.toLowerCase() === retractedEthBlockHash.toLowerCase()
+		);
+		expect(matchesRetractedBlock, "removed=true log should reference the retracted Ethereum block hash").to.equal(
+			true
+		);
+	}).timeout(120000);
 });

--- a/ts-tests/tests/test-log-reorg-compliance.ts
+++ b/ts-tests/tests/test-log-reorg-compliance.ts
@@ -2,14 +2,7 @@ import { expect } from "chai";
 import { step } from "mocha-steps";
 
 import { GENESIS_ACCOUNT, GENESIS_ACCOUNT_PRIVATE_KEY } from "./config";
-import {
-	createAndFinalizeBlock,
-	createAndFinalizeBlockNowait,
-	customRequest,
-	describeWithFrontierWs,
-	waitForBlock,
-	waitForReceipt,
-} from "./util";
+import { createAndFinalizeBlock, customRequest, describeWithFrontierWs, waitForReceipt } from "./util";
 
 const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 const LOG_EMITTING_CONSTRUCTOR =
@@ -146,6 +139,17 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 		);
 		expect(removedEvent.blockHash).to.equal(receipt.blockHash);
 
+		const winningTx = await sendLogTransaction();
+		await createAndFinalizeBlock(context.web3, false);
+		await waitForReceipt(context.web3, winningTx.transactionHash as string);
+		const canonicalAfterReorg = await waitForMatchingEvent(
+			events,
+			(e) =>
+				e.transactionHash?.toLowerCase() === (winningTx.transactionHash as string).toLowerCase() &&
+				e.removed !== true
+		);
+		expect(canonicalAfterReorg.removed === true, "winning-branch log must not be a tombstone").to.equal(false);
+
 		subscription.unsubscribe();
 	}).timeout(60000);
 
@@ -177,6 +181,17 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 		);
 		expect(removedEvent.blockHash).to.equal(receipt.blockHash);
 		expect(removedEvent.topics[0]).to.equal(TRANSFER_TOPIC);
+
+		const winningTx = await sendLogTransaction();
+		await createAndFinalizeBlock(context.web3, false);
+		await waitForReceipt(context.web3, winningTx.transactionHash as string);
+		const canonicalAfterReorg = await waitForFilterChange(
+			filterId,
+			(e) =>
+				e.transactionHash?.toLowerCase() === (winningTx.transactionHash as string).toLowerCase() &&
+				e.removed !== true
+		);
+		expect(canonicalAfterReorg.removed === true, "winning-branch log must not be a tombstone").to.equal(false);
 	}).timeout(60000);
 
 	step("logs subscription should emit removed=true after a longer fork (ERC20 deploy)", async function () {
@@ -216,6 +231,17 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 			}
 			await new Promise((r) => setTimeout(r, 300));
 		}
+
+		const postForkTx = await sendLogTransaction();
+		await createAndFinalizeBlock(context.web3, false);
+		await waitForReceipt(context.web3, postForkTx.transactionHash as string);
+		const canonicalOnWinningFork = await waitForMatchingEvent(
+			logEvents,
+			(e) =>
+				e.transactionHash?.toLowerCase() === (postForkTx.transactionHash as string).toLowerCase() &&
+				e.removed !== true
+		);
+		expect(canonicalOnWinningFork.removed === true, "winning-branch log must not be a tombstone").to.equal(false);
 
 		subscription.unsubscribe();
 

--- a/ts-tests/tests/test-log-reorg-compliance.ts
+++ b/ts-tests/tests/test-log-reorg-compliance.ts
@@ -246,9 +246,9 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 		subscription.unsubscribe();
 
 		const removedTrue = logEvents.filter((e) => e.removed === true);
-		const removedFalse = logEvents.filter((e) => e.removed === false);
+		const canonicalEvents = logEvents.filter((e) => e.removed !== true);
 
-		expect(removedFalse.length, "should see at least one canonical log before/during test").to.be.at.least(1);
+		expect(canonicalEvents.length, "should see at least one canonical log before/during test").to.be.at.least(1);
 
 		expect(
 			removedTrue.length,

--- a/ts-tests/tests/test-log-reorg-compliance.ts
+++ b/ts-tests/tests/test-log-reorg-compliance.ts
@@ -132,8 +132,8 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 		);
 		expect(firstEvent.blockHash).to.equal(receipt.blockHash);
 
-		const b1 = await createAndFinalizeBlock(context.web3, false, anchor);
-		await createAndFinalizeBlock(context.web3, false, b1);
+		const b1 = await createAndFinalizeBlock(context.web3, false, anchor, true);
+		await createAndFinalizeBlock(context.web3, false, b1, true);
 
 		const removedEvent = await waitForMatchingEvent(
 			events,
@@ -174,8 +174,8 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 		);
 		expect(firstEvent.blockHash).to.equal(receipt.blockHash);
 
-		const b1 = await createAndFinalizeBlock(context.web3, false, anchor);
-		await createAndFinalizeBlock(context.web3, false, b1);
+		const b1 = await createAndFinalizeBlock(context.web3, false, anchor, true);
+		await createAndFinalizeBlock(context.web3, false, b1, true);
 
 		const removedEvent = await waitForFilterChange(
 			filterId,
@@ -223,8 +223,8 @@ describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
 		await sleep(1500);
 
 		// Longer fork from A1: A1 -> B2 -> B3 (retracts the block that contained the deploy)
-		const b2Hash = await createAndFinalizeBlock(context.web3, false, a1Hash);
-		await createAndFinalizeBlock(context.web3, false, b2Hash);
+		const b2Hash = await createAndFinalizeBlock(context.web3, false, a1Hash, true);
+		await createAndFinalizeBlock(context.web3, false, b2Hash, true);
 
 		const pollDeadline = Date.now() + 60000;
 		while (Date.now() < pollDeadline) {

--- a/ts-tests/tests/test-log-reorg-compliance.ts
+++ b/ts-tests/tests/test-log-reorg-compliance.ts
@@ -1,0 +1,148 @@
+import { expect } from "chai";
+import { step } from "mocha-steps";
+
+import { GENESIS_ACCOUNT, GENESIS_ACCOUNT_PRIVATE_KEY } from "./config";
+import { customRequest, describeWithFrontierWs, waitForReceipt } from "./util";
+
+const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const LOG_EMITTING_CONSTRUCTOR =
+	"0x" +
+	"7f" +
+	"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" +
+	"600052" +
+	"7f" +
+	TRANSFER_TOPIC.slice(2) +
+	"60206000a1" +
+	"60006000f3";
+
+describeWithFrontierWs("Frontier RPC (Log Reorg Compliance)", (context) => {
+	let subscription;
+
+	async function sleep(ms: number) {
+		await new Promise<void>((resolve) => setTimeout(resolve, ms));
+	}
+
+	async function createBlock(finalize: boolean = true, parentHash: string | null = null): Promise<string> {
+		const response = await customRequest(context.web3, "engine_createBlock", [true, finalize, parentHash]);
+		if (!response.result?.hash) {
+			throw new Error(`Unexpected result: ${JSON.stringify(response)}`);
+		}
+		await sleep(300);
+		return response.result.hash as string;
+	}
+
+	async function sendLogTransaction() {
+		const tx = await context.web3.eth.accounts.signTransaction(
+			{
+				from: GENESIS_ACCOUNT,
+				data: LOG_EMITTING_CONSTRUCTOR,
+				value: "0x00",
+				gasPrice: "0x3B9ACA00",
+				gas: "0x1000000",
+			},
+			GENESIS_ACCOUNT_PRIVATE_KEY
+		);
+
+		await customRequest(context.web3, "eth_sendRawTransaction", [tx.rawTransaction]);
+		return tx;
+	}
+
+	async function waitForMatchingEvent(events: any[], predicate: (event: any) => boolean, timeoutMs = 15000) {
+		const start = Date.now();
+		while (Date.now() - start < timeoutMs) {
+			const match = events.find(predicate);
+			if (match) {
+				return match;
+			}
+			await sleep(100);
+		}
+		throw new Error("Timed out waiting for matching log event");
+	}
+
+	async function waitForFilterChange(filterId: string, predicate: (event: any) => boolean, timeoutMs = 15000) {
+		const start = Date.now();
+		while (Date.now() - start < timeoutMs) {
+			const response = await customRequest(context.web3, "eth_getFilterChanges", [filterId]);
+			const logs = (response.result || []) as any[];
+			const match = logs.find(predicate);
+			if (match) {
+				return match;
+			}
+			await sleep(100);
+		}
+		throw new Error("Timed out waiting for matching filter change");
+	}
+
+	step("logs subscription should emit removed=true when a logged tx is reorged out", async function () {
+		this.timeout(60000);
+
+		subscription = context.web3.eth.subscribe("logs", {}, function (_error, _result) {});
+		await new Promise<void>((resolve, reject) => {
+			const timer = setTimeout(
+				() => reject(new Error("Timed out waiting for logs subscription connection")),
+				10000
+			);
+			subscription.on("connected", function () {
+				clearTimeout(timer);
+				resolve();
+			});
+			subscription.on("error", function (error: any) {
+				clearTimeout(timer);
+				reject(error);
+			});
+		});
+
+		const events: any[] = [];
+		subscription.on("data", function (event: any) {
+			events.push(event);
+		});
+
+		const anchor = await createBlock(false);
+		const tx = await sendLogTransaction();
+		await createBlock(false, anchor);
+
+		const receipt = await waitForReceipt(context.web3, tx.transactionHash);
+		const firstEvent = await waitForMatchingEvent(
+			events,
+			(event) => event.transactionHash === tx.transactionHash && event.removed === false
+		);
+		expect(firstEvent.blockHash).to.equal(receipt.blockHash);
+
+		const b1 = await createBlock(false, anchor);
+		await createBlock(false, b1);
+
+		const removedEvent = await waitForMatchingEvent(
+			events,
+			(event) => event.transactionHash === tx.transactionHash && event.removed === true
+		);
+		expect(removedEvent.blockHash).to.equal(receipt.blockHash);
+
+		subscription.unsubscribe();
+	}).timeout(60000);
+
+	step("eth_getFilterChanges should emit removed=true when a logged tx is reorged out", async function () {
+		this.timeout(60000);
+
+		const filterId = (await customRequest(context.web3, "eth_newFilter", [{}])).result as string;
+		const anchor = await createBlock(false);
+		const tx = await sendLogTransaction();
+		await createBlock(false, anchor);
+
+		const receipt = await waitForReceipt(context.web3, tx.transactionHash);
+		const firstEvent = await waitForFilterChange(
+			filterId,
+			(event) => event.transactionHash === tx.transactionHash && event.removed === false
+		);
+		expect(firstEvent.blockHash).to.equal(receipt.blockHash);
+
+		const b1 = await createBlock(false, anchor);
+		await createBlock(false, b1);
+
+		const removedEvent = await waitForFilterChange(
+			filterId,
+			(event) => event.transactionHash === tx.transactionHash && event.removed === true
+		);
+		expect(removedEvent.blockHash).to.equal(receipt.blockHash);
+		expect(removedEvent.topics[0]).to.equal(TRANSFER_TOPIC);
+	}).timeout(60000);
+});

--- a/ts-tests/tests/test-receipt-consistency.ts
+++ b/ts-tests/tests/test-receipt-consistency.ts
@@ -35,6 +35,7 @@ describeWithFrontier("Frontier RPC (Receipt Consistency)", (context) => {
 	}
 
 	step("should return receipt immediately after block is visible", async function () {
+		const nonce = Number(await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT, "latest"));
 		const tx = await context.web3.eth.accounts.signTransaction(
 			{
 				from: GENESIS_ACCOUNT,
@@ -42,7 +43,7 @@ describeWithFrontier("Frontier RPC (Receipt Consistency)", (context) => {
 				value: "0x200",
 				gasPrice: "0x3B9ACA00",
 				gas: "0x100000",
-				nonce: 0,
+				nonce,
 			},
 			GENESIS_ACCOUNT_PRIVATE_KEY
 		);
@@ -63,8 +64,8 @@ describeWithFrontier("Frontier RPC (Receipt Consistency)", (context) => {
 		expect(block.transactions).to.be.an("array").with.lengthOf(1);
 		expect(block.transactions[0].hash).to.equal(txHash);
 
-		// If block is visible, receipt should also be available
-		const receipt = await context.web3.eth.getTransactionReceipt(txHash);
+		// Block can surface before mapping-sync exposes receipts; poll until consistent.
+		const receipt = await waitForReceipt(context.web3, txHash);
 
 		expect(receipt).to.not.be.null;
 		expect(receipt.transactionHash).to.equal(txHash);
@@ -76,6 +77,7 @@ describeWithFrontier("Frontier RPC (Receipt Consistency)", (context) => {
 	step("should return receipt for multiple transactions in same block", async function () {
 		const txCount = 3;
 		const txHashes: string[] = [];
+		const baseNonce = Number(await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT, "latest"));
 
 		for (let i = 0; i < txCount; i++) {
 			const tx = await context.web3.eth.accounts.signTransaction(
@@ -85,7 +87,7 @@ describeWithFrontier("Frontier RPC (Receipt Consistency)", (context) => {
 					value: "0x200",
 					gasPrice: "0x3B9ACA00",
 					gas: "0x100000",
-					nonce: i + 1, // nonce 0 was used in previous test
+					nonce: baseNonce + i,
 				},
 				GENESIS_ACCOUNT_PRIVATE_KEY
 			);
@@ -122,7 +124,7 @@ describeWithFrontier("Frontier RPC (Receipt Consistency)", (context) => {
 	});
 
 	step("should return receipt when queried by transaction hash from block", async function () {
-		const nonce = await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT, "latest");
+		const nonce = Number(await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT, "latest"));
 		const tx = await context.web3.eth.accounts.signTransaction(
 			{
 				from: GENESIS_ACCOUNT,

--- a/ts-tests/tests/test-receipt-consistency.ts
+++ b/ts-tests/tests/test-receipt-consistency.ts
@@ -122,6 +122,7 @@ describeWithFrontier("Frontier RPC (Receipt Consistency)", (context) => {
 	});
 
 	step("should return receipt when queried by transaction hash from block", async function () {
+		const nonce = await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT, "latest");
 		const tx = await context.web3.eth.accounts.signTransaction(
 			{
 				from: GENESIS_ACCOUNT,
@@ -129,7 +130,7 @@ describeWithFrontier("Frontier RPC (Receipt Consistency)", (context) => {
 				value: "0x200",
 				gasPrice: "0x3B9ACA00",
 				gas: "0x100000",
-				nonce: 4, // continuing from previous tests
+				nonce,
 			},
 			GENESIS_ACCOUNT_PRIVATE_KEY
 		);
@@ -150,9 +151,11 @@ describeWithFrontier("Frontier RPC (Receipt Consistency)", (context) => {
 
 		// Get tx hash from the block, then query its receipt
 		const txFromBlock = block.transactions[0];
-		const txHash = txFromBlock.hash;
+		const txHash = typeof txFromBlock === "string" ? txFromBlock : txFromBlock.hash;
+		expect(txHash).to.be.a("string").lengthOf(66);
 
-		const receipt = await context.web3.eth.getTransactionReceipt(txHash);
+		// Block can surface before mapping-sync exposes receipts; poll like ADR-003 implies.
+		const receipt = await waitForReceipt(context.web3, txHash);
 
 		expect(receipt).to.not.be.null;
 		expect(receipt.transactionHash).to.equal(txHash);

--- a/ts-tests/tests/util.ts
+++ b/ts-tests/tests/util.ts
@@ -135,10 +135,11 @@ export async function createAndFinalizeBlock(
 // Use this only for tests that explicitly handle waiting themselves.
 export async function createAndFinalizeBlockNowait(web3: Web3, parentHash: string | null = null): Promise<string> {
 	const response = await customRequest(web3, "engine_createBlock", [true, true, parentHash]);
-	if (!response.result?.hash) {
+	const blockHash = response?.result?.hash;
+	if (!blockHash || typeof blockHash !== "string") {
 		throw new Error(`Unexpected result: ${JSON.stringify(response)}`);
 	}
-	return response.result.hash;
+	return blockHash;
 }
 
 // Wait for a receipt to be available for a given transaction hash.

--- a/ts-tests/tests/util.ts
+++ b/ts-tests/tests/util.ts
@@ -65,14 +65,27 @@ export async function waitForBlock(
 	throw new Error(`Timeout waiting for block ${blockTag} to be indexed${errorSuffix}`);
 }
 
-// Create a block, optionally finalize it, and wait for it to be indexed by mapping-sync.
-// This ensures the block is visible via eth_getBlockByNumber before returning.
-// When finalize is false the block is still imported (best block); we wait for it to be
-// visible as "latest". The node exposes the best chain to eth RPC, so this works for both.
+/**
+ * Calls `engine_createBlock` and returns the new Substrate block hash.
+ *
+ * Always waits until `chain_getHeader(blockHash)` succeeds (import may lag the RPC response).
+ *
+ * When `isFork` is false (default), assumes the new block becomes **canonical** at its height:
+ * then waits for mapping-sync (`eth_getBlockByNumber` at that height) and for
+ * `eth_blockNumber >=` that height so `"latest"` and receipts stay consistent with the block
+ * you just built. Use this for extending the current best chain (`parentHash` null or tip).
+ *
+ * When `isFork` is true, skips Ethereum waits: `eth_getBlockByNumber` reflects the canonical
+ * chain, so a rival child at the same height would make number-based polling misleading or
+ * impossible. Substrate import is still guaranteed via `chain_getHeader` above.
+ *
+ * `finalize`: passed through to `engine_createBlock` (whether the block is finalized).
+ */
 export async function createAndFinalizeBlock(
 	web3: Web3,
 	finalize: boolean = true,
-	parentHash: string | null = null
+	parentHash: string | null = null,
+	isFork: boolean = false
 ): Promise<string> {
 	const response = await customRequest(web3, "engine_createBlock", [true, finalize, parentHash]);
 	if (!response?.result?.hash) {
@@ -103,32 +116,36 @@ export async function createAndFinalizeBlock(
 		const errSuffix = headerLastError ? ` (last error: ${headerLastError.message})` : "";
 		throw new Error(`chain_getHeader(${blockHash}) returned no header for created block${errSuffix}`);
 	}
-	const expectedNumber = parseInt(header.number, 16);
-	const expectedBlockTag = "0x" + expectedNumber.toString(16);
 
-	await waitForBlock(web3, expectedBlockTag, 10_000);
+	if (isFork) {
+		return blockHash;
+	} else {
+		const expectedNumber = parseInt(header.number, 16);
+		const expectedBlockTag = "0x" + expectedNumber.toString(16);
+		await waitForBlock(web3, expectedBlockTag, 10_000);
 
-	// Also wait for eth_blockNumber / "latest" to be at least the new block, so tests that
-	// assert on getBlockNumber() or use "latest" see the block we just created.
-	// Use >= so we don't timeout if the node advances past expectedNumber between polls.
-	// Retry on transient RPC errors instead of failing fast.
-	const rpcSyncTimeout = 10_000;
-	const rpcStart = Date.now();
-	let rpcLastError: Error | null = null;
-	while (Date.now() - rpcStart < rpcSyncTimeout) {
-		try {
-			const current = await customRequest(web3, "eth_blockNumber", []);
-			const n = current.result != null ? parseInt(current.result, 16) : -1;
-			if (n >= expectedNumber) {
-				return blockHash;
+		// Also wait for eth_blockNumber / "latest" to be at least the new block, so tests that
+		// assert on getBlockNumber() or use "latest" see the block we just created.
+		// Use >= so we don't timeout if the node advances past expectedNumber between polls.
+		// Retry on transient RPC errors instead of failing fast.
+		const rpcSyncTimeout = 10_000;
+		const rpcStart = Date.now();
+		let rpcLastError: Error | null = null;
+		while (Date.now() - rpcStart < rpcSyncTimeout) {
+			try {
+				const current = await customRequest(web3, "eth_blockNumber", []);
+				const n = current.result != null ? parseInt(current.result, 16) : -1;
+				if (n >= expectedNumber) {
+					return blockHash;
+				}
+			} catch (error) {
+				rpcLastError = error instanceof Error ? error : new Error(String(error));
 			}
-		} catch (error) {
-			rpcLastError = error instanceof Error ? error : new Error(String(error));
+			await new Promise<void>((r) => setTimeout(r, 50));
 		}
-		await new Promise<void>((r) => setTimeout(r, 50));
+		const rpcErrorSuffix = rpcLastError ? ` (last error: ${rpcLastError.message})` : "";
+		throw new Error(`eth_blockNumber did not reach ${expectedNumber} after ${rpcSyncTimeout}ms${rpcErrorSuffix}`);
 	}
-	const rpcErrorSuffix = rpcLastError ? ` (last error: ${rpcLastError.message})` : "";
-	throw new Error(`eth_blockNumber did not reach ${expectedNumber} after ${rpcSyncTimeout}ms${rpcErrorSuffix}`);
 }
 
 // Create a block and finalize it without waiting for indexing.

--- a/ts-tests/tests/util.ts
+++ b/ts-tests/tests/util.ts
@@ -69,8 +69,12 @@ export async function waitForBlock(
 // This ensures the block is visible via eth_getBlockByNumber before returning.
 // When finalize is false the block is still imported (best block); we wait for it to be
 // visible as "latest". The node exposes the best chain to eth RPC, so this works for both.
-export async function createAndFinalizeBlock(web3: Web3, finalize: boolean = true) {
-	const response = await customRequest(web3, "engine_createBlock", [true, finalize, null]);
+export async function createAndFinalizeBlock(
+	web3: Web3,
+	finalize: boolean = true,
+	parentHash: string | null = null
+): Promise<string> {
+	const response = await customRequest(web3, "engine_createBlock", [true, finalize, parentHash]);
 	if (!response?.result?.hash) {
 		throw new Error(`Unexpected result: ${JSON.stringify(response)}`);
 	}
@@ -116,7 +120,7 @@ export async function createAndFinalizeBlock(web3: Web3, finalize: boolean = tru
 			const current = await customRequest(web3, "eth_blockNumber", []);
 			const n = current.result != null ? parseInt(current.result, 16) : -1;
 			if (n >= expectedNumber) {
-				return;
+				return blockHash;
 			}
 		} catch (error) {
 			rpcLastError = error instanceof Error ? error : new Error(String(error));
@@ -129,11 +133,12 @@ export async function createAndFinalizeBlock(web3: Web3, finalize: boolean = tru
 
 // Create a block and finalize it without waiting for indexing.
 // Use this only for tests that explicitly handle waiting themselves.
-export async function createAndFinalizeBlockNowait(web3: Web3) {
-	const response = await customRequest(web3, "engine_createBlock", [true, true, null]);
-	if (!response.result) {
+export async function createAndFinalizeBlockNowait(web3: Web3, parentHash: string | null = null): Promise<string> {
+	const response = await customRequest(web3, "engine_createBlock", [true, true, parentHash]);
+	if (!response.result?.hash) {
 		throw new Error(`Unexpected result: ${JSON.stringify(response)}`);
 	}
+	return response.result.hash;
 }
 
 // Wait for a receipt to be available for a given transaction hash.


### PR DESCRIPTION
## :warning: Breaking changes :warning:

- `eth_subscribe("logs")` and `eth_getFilterChanges` for log filters now treat reorgs as first-class events instead of silently keeping stale logs.
- Reorged-out logs are intended to be re-emitted with `removed=true`, and winning-chain logs are intended to be emitted again with `removed=false`.
- Lagging consumers are intended to fail closed once they fall behind the retained in-memory reorg journal, instead of receiving a partial or misleading stream.
- Integrators should ensure their log consumers already handle:
  - duplicate logical events across forks
  - `removed=true` removals
  - filter recreation / subscription restart after falling behind retained reorg history

## Goal of the changes

Fix Frontier log reorg handling so websocket log subscriptions and polling log filters follow Ethereum-compatible semantics, while remaining safe under pruning and sustained reorg pressure.

Today the patch introduces a bounded in-memory log journal that captures canonical transition deltas at notification time, instead of trying to reconstruct removed logs later from storage that may already be pruned. The RPC layer then uses that journal for both live subscriptions and `eth_getFilterChanges`.

## What reviewers need to know

- A new shared log journal is introduced in the RPC layer and wired into both `EthFilter` and `EthPubSub`.
- Log filter state now tracks a journal cursor so polling can replay canonical log deltas rather than relying on block-number progress alone.
- The implementation is designed to fail closed under backpressure:
  - if a polling filter falls behind retained journal history, it is invalidated and the caller must recreate it
  - if a websocket subscriber lags or the journal continuity becomes incomplete, the subscription is closed instead of silently emitting an incorrect stream
- Log filtering was refactored so the same log-building path can emit both normal logs and `removed=true` logs.
- New TS coverage was added to exercise log reorg behavior for both websocket subscriptions and `eth_getFilterChanges`.

