### PR TITLE
Index transaction hashes when digest and storage block hashes disagree

### DIFF
--- a/client/db/src/sql/mod.rs
+++ b/client/db/src/sql/mod.rs
@@ -285,11 +285,21 @@ where
 								Some(block) => {
 									let got_eth_block_hash = block.header.hash();
 									if got_eth_block_hash != expect_eth_block_hash {
-										return Err(Error::Protocol(format!(
+										log::warn!(
+											target: "frontier-sql",
 											"Ethereum block hash mismatch: \
 											frontier consensus digest ({expect_eth_block_hash:?}), \
-											db state ({got_eth_block_hash:?})"
-										)));
+											db state ({got_eth_block_hash:?}); \
+											indexing db state tx hashes under digest block hash."
+										);
+										Hashes {
+											block_hash: expect_eth_block_hash,
+											transaction_hashes: block
+												.transactions
+												.iter()
+												.map(|tx| tx.hash())
+												.collect(),
+										}
 									} else {
 										Hashes::from_block(block)
 									}

--- a/client/mapping-sync/src/kv/canonical_reconciler.rs
+++ b/client/mapping-sync/src/kv/canonical_reconciler.rs
@@ -318,7 +318,6 @@ fn reconcile_range_internal<Block: BlockT, C: HeaderBackend<Block>>(
 						number,
 						fc_db::kv::NumberMappingWrite::Skip,
 					)?;
-					updated = updated.saturating_add(1);
 				} else if !ethereum_block.transactions.is_empty() {
 					// BLOCK_MAPPING exists but TRANSACTION_MAPPING may be incomplete
 					// (block was initially synced with pruned state via write_hashes

--- a/client/mapping-sync/src/kv/canonical_reconciler.rs
+++ b/client/mapping-sync/src/kv/canonical_reconciler.rs
@@ -45,6 +45,7 @@ pub struct ReconcileWindow {
 pub struct ReconcileStats {
 	pub scanned: u64,
 	pub updated: u64,
+	pub digest_mismatch_fallbacks: u64,
 	pub first_unresolved: Option<u64>,
 	pub highest_reconciled: Option<u64>,
 	pub next_cursor: u64,
@@ -230,6 +231,7 @@ fn reconcile_range_internal<Block: BlockT, C: HeaderBackend<Block>>(
 		return Ok(ReconcileStats {
 			scanned: 0,
 			updated: 0,
+			digest_mismatch_fallbacks: 0,
 			first_unresolved: None,
 			highest_reconciled: None,
 			next_cursor: sync_from_number,
@@ -239,6 +241,7 @@ fn reconcile_range_internal<Block: BlockT, C: HeaderBackend<Block>>(
 	}
 
 	let mut updated = 0u64;
+	let mut digest_mismatch_fallbacks = 0u64;
 	let mut first_unresolved = None;
 	let mut highest_reconciled: Option<u64> = None;
 	let mut scanned = 0u64;
@@ -276,7 +279,7 @@ fn reconcile_range_internal<Block: BlockT, C: HeaderBackend<Block>>(
 								.transactions
 								.iter()
 								.map(|tx| tx.hash())
-								.collect(),
+								.collect::<Vec<_>>(),
 						)
 					}
 					_ => (
@@ -285,7 +288,7 @@ fn reconcile_range_internal<Block: BlockT, C: HeaderBackend<Block>>(
 							.transactions
 							.iter()
 							.map(|tx| tx.hash())
-							.collect(),
+							.collect::<Vec<_>>(),
 					),
 				};
 
@@ -315,6 +318,7 @@ fn reconcile_range_internal<Block: BlockT, C: HeaderBackend<Block>>(
 						number,
 						fc_db::kv::NumberMappingWrite::Skip,
 					)?;
+					updated = updated.saturating_add(1);
 				} else if !ethereum_block.transactions.is_empty() {
 					// BLOCK_MAPPING exists but TRANSACTION_MAPPING may be incomplete
 					// (block was initially synced with pruned state via write_hashes
@@ -461,6 +465,7 @@ fn reconcile_range_internal<Block: BlockT, C: HeaderBackend<Block>>(
 	let stats = ReconcileStats {
 		scanned,
 		updated,
+		digest_mismatch_fallbacks,
 		first_unresolved,
 		highest_reconciled,
 		next_cursor,

--- a/client/mapping-sync/src/kv/canonical_reconciler.rs
+++ b/client/mapping-sync/src/kv/canonical_reconciler.rs
@@ -255,7 +255,39 @@ fn reconcile_range_internal<Block: BlockT, C: HeaderBackend<Block>>(
 
 		match storage_override.current_block(canonical_hash) {
 			Some(ethereum_block) => {
-				let canonical_eth_hash = ethereum_block.header.hash();
+				let reconstructed_eth_hash = ethereum_block.header.hash();
+				let digest_eth_hash = client
+					.header(canonical_hash)
+					.map_err(|e| format!("{e:?}"))?
+					.and_then(|h| eth_hash_from_digest::<Block>(&h));
+				let (canonical_eth_hash, transaction_hashes) = match digest_eth_hash {
+					Some(digest_eth_hash) if digest_eth_hash != reconstructed_eth_hash => {
+						log::warn!(
+							target: "reconcile",
+							"Ethereum block hash mismatch while reconciling #{number}: \
+							frontier consensus digest ({digest_eth_hash:?}), \
+							db state ({reconstructed_eth_hash:?}); \
+							writing digest block mapping with db state tx hashes."
+						);
+						digest_mismatch_fallbacks = digest_mismatch_fallbacks.saturating_add(1);
+						(
+							digest_eth_hash,
+							ethereum_block
+								.transactions
+								.iter()
+								.map(|tx| tx.hash())
+								.collect(),
+						)
+					}
+					_ => (
+						reconstructed_eth_hash,
+						ethereum_block
+							.transactions
+							.iter()
+							.map(|tx| tx.hash())
+							.collect(),
+					),
+				};
 
 				let should_update = frontier_backend.mapping().block_hash_by_number(number)?
 					!= Some(canonical_eth_hash);
@@ -276,11 +308,7 @@ fn reconcile_range_internal<Block: BlockT, C: HeaderBackend<Block>>(
 					let commitment = fc_db::kv::MappingCommitment::<Block> {
 						block_hash: canonical_hash,
 						ethereum_block_hash: canonical_eth_hash,
-						ethereum_transaction_hashes: ethereum_block
-							.transactions
-							.iter()
-							.map(|tx| tx.hash())
-							.collect(),
+						ethereum_transaction_hashes: transaction_hashes.clone(),
 					};
 					frontier_backend.mapping().write_hashes(
 						commitment,
@@ -312,11 +340,7 @@ fn reconcile_range_internal<Block: BlockT, C: HeaderBackend<Block>>(
 						let commitment = fc_db::kv::MappingCommitment::<Block> {
 							block_hash: canonical_hash,
 							ethereum_block_hash: canonical_eth_hash,
-							ethereum_transaction_hashes: ethereum_block
-								.transactions
-								.iter()
-								.map(|tx| tx.hash())
-								.collect(),
+							ethereum_transaction_hashes: transaction_hashes,
 						};
 						frontier_backend.mapping().write_hashes(
 							commitment,

--- a/client/mapping-sync/src/kv/mod.rs
+++ b/client/mapping-sync/src/kv/mod.rs
@@ -127,11 +127,27 @@ pub fn sync_block<Block: BlockT, C: HeaderBackend<Block>>(
 							Some(block) => {
 								let got_eth_block_hash = block.header.hash();
 								if got_eth_block_hash != expect_eth_block_hash {
-									Err(format!(
+									log::warn!(
+										target: "mapping-sync",
 										"Ethereum block hash mismatch: \
 										frontier consensus digest ({expect_eth_block_hash:?}), \
-										db state ({got_eth_block_hash:?})"
-									))
+										db state ({got_eth_block_hash:?}); \
+										writing digest block mapping with db state tx hashes."
+									);
+									let mapping_commitment = fc_db::kv::MappingCommitment::<Block> {
+										block_hash: substrate_block_hash,
+										ethereum_block_hash: expect_eth_block_hash,
+										ethereum_transaction_hashes: block
+											.transactions
+											.iter()
+											.map(|tx| tx.hash())
+											.collect(),
+									};
+									backend.mapping().write_hashes(
+										mapping_commitment,
+										block_number,
+										number_mapping_write,
+									)
 								} else {
 									let mapping_commitment = gen_from_block(block);
 									backend.mapping().write_hashes(
@@ -843,6 +859,206 @@ mod tests {
 		fn is_eip1559(&self, _at: <OpaqueBlock as BlockT>::Hash) -> bool {
 			false
 		}
+	}
+
+	#[test]
+	fn sync_block_writes_digest_mapping_on_runtime_hash_mismatch() {
+		let tmp = tempdir().expect("create temp dir");
+		let (client, _) = TestClientBuilder::new()
+			.build_with_native_executor::<substrate_test_runtime_client::runtime::RuntimeApi, _>(
+			None,
+		);
+		let client = Arc::new(client);
+
+		let frontier_backend = fc_db::kv::Backend::<OpaqueBlock, _>::new(
+			client.clone(),
+			&fc_db::kv::DatabaseSettings {
+				#[cfg(feature = "rocksdb")]
+				source: sc_client_db::DatabaseSource::RocksDb {
+					path: tmp.path().to_path_buf(),
+					cache_size: 0,
+				},
+				#[cfg(not(feature = "rocksdb"))]
+				source: sc_client_db::DatabaseSource::ParityDb {
+					path: tmp.path().to_path_buf(),
+				},
+			},
+		)
+		.expect("frontier backend");
+
+		let digest_block = make_ethereum_block(1);
+		let digest_eth_hash = digest_block.header.hash();
+		let reconstructed_block = make_ethereum_block_with_txs(2, 1);
+		let reconstructed_eth_hash = reconstructed_block.header.hash();
+		let reconstructed_tx_hash = reconstructed_block.transactions[0].hash();
+
+		let chain = client.chain_info();
+		let mut builder = BlockBuilderBuilder::new(client.as_ref())
+			.on_parent_block(chain.best_hash)
+			.with_parent_block_number(chain.best_number)
+			.build()
+			.expect("build block");
+		builder
+			.push_deposit_log_digest_item(ethereum_digest_item_for(&digest_block))
+			.expect("push ethereum digest");
+		let block = builder.build().expect("build block").block;
+		let header = block.header.clone();
+		let substrate_hash = header.hash();
+		futures::executor::block_on(client.import_as_final(BlockOrigin::Own, block))
+			.expect("import block");
+
+		let storage_override = SelectiveStorageOverride {
+			blocks: HashMap::from([(substrate_hash, reconstructed_block)]),
+		};
+
+		sync_block(
+			client.as_ref(),
+			Arc::new(storage_override),
+			&frontier_backend,
+			&header,
+		)
+		.expect("sync block");
+
+		assert_eq!(
+			frontier_backend.mapping().block_hash_by_number(1),
+			Ok(Some(digest_eth_hash)),
+			"number mapping must use the digest hash"
+		);
+		assert!(
+			frontier_backend
+				.mapping()
+				.block_hash(&digest_eth_hash)
+				.expect("read digest block mapping")
+				.as_ref()
+				.is_some_and(|hashes| hashes.contains(&substrate_hash)),
+			"digest block mapping must contain the substrate hash"
+		);
+		assert_eq!(
+			frontier_backend
+				.mapping()
+				.block_hash(&reconstructed_eth_hash),
+			Ok(None),
+			"reconstructed hash must not be written when it disagrees with the digest"
+		);
+		let tx_metadata = frontier_backend
+			.mapping()
+			.transaction_metadata(&reconstructed_tx_hash)
+			.expect("read transaction mapping");
+		assert!(
+			tx_metadata.iter().any(|metadata| metadata.substrate_block_hash == substrate_hash
+				&& metadata.ethereum_block_hash == digest_eth_hash
+				&& metadata.ethereum_index == 0),
+			"mismatched reconstructed block transactions must be indexed under the digest hash; got {tx_metadata:?}"
+		);
+	}
+
+	#[test]
+	fn reconciler_repairs_missing_mapping_with_digest_on_runtime_hash_mismatch() {
+		let tmp = tempdir().expect("create temp dir");
+		let (client, _) = TestClientBuilder::new()
+			.build_with_native_executor::<substrate_test_runtime_client::runtime::RuntimeApi, _>(
+			None,
+		);
+		let client = Arc::new(client);
+
+		let frontier_backend = fc_db::kv::Backend::<OpaqueBlock, _>::new(
+			client.clone(),
+			&fc_db::kv::DatabaseSettings {
+				#[cfg(feature = "rocksdb")]
+				source: sc_client_db::DatabaseSource::RocksDb {
+					path: tmp.path().to_path_buf(),
+					cache_size: 0,
+				},
+				#[cfg(not(feature = "rocksdb"))]
+				source: sc_client_db::DatabaseSource::ParityDb {
+					path: tmp.path().to_path_buf(),
+				},
+			},
+		)
+		.expect("frontier backend");
+
+		let digest_block = make_ethereum_block(1);
+		let digest_eth_hash = digest_block.header.hash();
+		let reconstructed_block = make_ethereum_block_with_txs(2, 1);
+		let reconstructed_eth_hash = reconstructed_block.header.hash();
+		let reconstructed_tx_hash = reconstructed_block.transactions[0].hash();
+
+		let chain = client.chain_info();
+		let mut builder = BlockBuilderBuilder::new(client.as_ref())
+			.on_parent_block(chain.best_hash)
+			.with_parent_block_number(chain.best_number)
+			.build()
+			.expect("build block");
+		builder
+			.push_deposit_log_digest_item(ethereum_digest_item_for(&digest_block))
+			.expect("push ethereum digest");
+		let block = builder.build().expect("build block").block;
+		futures::executor::block_on(client.import_as_final(BlockOrigin::Own, block))
+			.expect("import block");
+
+		let substrate_hash = client
+			.hash(1)
+			.expect("query canonical hash")
+			.expect("canonical hash");
+
+		frontier_backend
+			.mapping()
+			.write_none(substrate_hash)
+			.expect("write synced marker without mappings");
+
+		let storage_override = SelectiveStorageOverride {
+			blocks: HashMap::from([(substrate_hash, reconstructed_block)]),
+		};
+
+		let stats = canonical_reconciler::reconcile_from_cursor_batch(
+			client.as_ref(),
+			&storage_override,
+			&frontier_backend,
+			1,
+			1,
+		)
+		.expect("reconcile")
+		.expect("stats");
+
+		assert_eq!(
+			stats.updated, 2,
+			"number and block mapping updates should be reported"
+		);
+		assert_eq!(stats.number_mapping_updates, 1);
+		assert_eq!(stats.block_hash_mapping_updates, 1);
+		assert_eq!(stats.transaction_mapping_updates, 0);
+		assert_eq!(stats.digest_mismatch_fallbacks, 1);
+		assert_eq!(
+			frontier_backend.mapping().block_hash_by_number(1),
+			Ok(Some(digest_eth_hash)),
+			"number mapping must use the digest hash"
+		);
+		assert!(
+			frontier_backend
+				.mapping()
+				.block_hash(&digest_eth_hash)
+				.expect("read digest block mapping")
+				.as_ref()
+				.is_some_and(|hashes| hashes.contains(&substrate_hash)),
+			"digest block mapping must contain the substrate hash"
+		);
+		assert_eq!(
+			frontier_backend
+				.mapping()
+				.block_hash(&reconstructed_eth_hash),
+			Ok(None),
+			"reconstructed hash must not be written when it disagrees with the digest"
+		);
+		let tx_metadata = frontier_backend
+			.mapping()
+			.transaction_metadata(&reconstructed_tx_hash)
+			.expect("read transaction mapping");
+		assert!(
+			tx_metadata.iter().any(|metadata| metadata.substrate_block_hash == substrate_hash
+				&& metadata.ethereum_block_hash == digest_eth_hash
+				&& metadata.ethereum_index == 0),
+			"mismatched reconstructed block transactions must be indexed under the digest hash; got {tx_metadata:?}"
+		);
 	}
 
 	#[test]

--- a/client/mapping-sync/src/kv/mod.rs
+++ b/client/mapping-sync/src/kv/mod.rs
@@ -686,7 +686,9 @@ mod tests {
 
 	use sp_runtime::generic::DigestItem;
 
-	use super::{canonical_reconciler, repair_canonical_number_mappings_batch, sync_one_block};
+	use super::{
+		canonical_reconciler, repair_canonical_number_mappings_batch, sync_block, sync_one_block,
+	};
 	use crate::{
 		EthereumBlockNotification, EthereumBlockNotificationSinks, ReorgInfo, SyncStrategy,
 	};
@@ -1024,9 +1026,6 @@ mod tests {
 			stats.updated, 2,
 			"number and block mapping updates should be reported"
 		);
-		assert_eq!(stats.number_mapping_updates, 1);
-		assert_eq!(stats.block_hash_mapping_updates, 1);
-		assert_eq!(stats.transaction_mapping_updates, 0);
 		assert_eq!(stats.digest_mismatch_fallbacks, 1);
 		assert_eq!(
 			frontier_backend.mapping().block_hash_by_number(1),
@@ -1147,6 +1146,7 @@ mod tests {
 			Some(canonical_reconciler::ReconcileStats {
 				scanned: 1,
 				updated: 0,
+				digest_mismatch_fallbacks: 0,
 				first_unresolved: Some(1),
 				highest_reconciled: None,
 				next_cursor: 1,

--- a/client/mapping-sync/src/kv/mod.rs
+++ b/client/mapping-sync/src/kv/mod.rs
@@ -1022,10 +1022,7 @@ mod tests {
 		.expect("reconcile")
 		.expect("stats");
 
-		assert_eq!(
-			stats.updated, 2,
-			"number and block mapping updates should be reported"
-		);
+		assert_eq!(stats.updated, 1, "number mapping update should be reported");
 		assert_eq!(stats.digest_mismatch_fallbacks, 1);
 		assert_eq!(
 			frontier_backend.mapping().block_hash_by_number(1),


### PR DESCRIPTION

## Goal

Keep Frontier mapping repair useful when the Ethereum block hash from the Frontier digest disagrees with the hash reconstructed from `Ethereum::CurrentBlock`.

Before this change, mismatch handling wrote the digest Ethereum block hash but dropped transaction hashes. That repaired block hash lookups, but left affected blocks with empty transaction mappings even when the node still had enough state to decode the Ethereum block transactions.

## What changed

- KV mapping sync now preserves transaction hashes from decoded storage when the reconstructed block hash disagrees with the digest hash.
- Canonical mapping reconciliation applies the same behavior during repair.
- SQL indexing now logs the mismatch and indexes decoded transaction hashes under the digest Ethereum block hash instead of failing the block.
- Tests were updated to assert mismatched reconstructed block transactions are indexed under the digest hash, while the reconstructed block hash itself is not written.

## Notes for reviewers

The digest hash remains authoritative for the Ethereum block mapping. The storage-decoded block is used only as the source of transaction content when state is available.

This does not solve the original cause of the hash mismatch, but it prevents repair/indexing from producing blocks that are discoverable by hash while missing their transaction metadata.
