### PR TITLE
[block_count] Saturate `U256` to `u64::MAX`

### DIFF
--- a/client/rpc-core/src/types/block_count.rs
+++ b/client/rpc-core/src/types/block_count.rs
@@ -69,7 +69,7 @@ impl From<BlockCount> for u64 {
 	fn from(block_count: BlockCount) -> u64 {
 		match block_count {
 			BlockCount::Num(n) => n,
-			BlockCount::U256(n) => n.as_u64(),
+			BlockCount::U256(n) => n.min(U256::from(u64::MAX)).low_u64(),
 		}
 	}
 }
@@ -129,5 +129,13 @@ mod tests {
 		let bn_hex: BlockCount = serde_json::from_str(r#""0x45""#).unwrap();
 		assert_eq!(match_block_number(bn_dec).unwrap(), U256::from(42));
 		assert_eq!(match_block_number(bn_hex).unwrap(), U256::from("0x45"));
+	}
+
+	#[test]
+	fn block_count_to_u64_saturates_instead_of_panicking() {
+		let max_u256_hex =
+			r#""0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff""#;
+		let bc: BlockCount = serde_json::from_str(max_u256_hex).unwrap();
+		assert_eq!(u64::from(bc), u64::MAX);
 	}
 }

--- a/client/rpc-core/src/types/block_count.rs
+++ b/client/rpc-core/src/types/block_count.rs
@@ -24,6 +24,8 @@ use serde::{
 	Deserialize, Deserializer, Serialize, Serializer,
 };
 
+const U64_MAX_U256: U256 = U256([u64::MAX, 0, 0, 0]);
+
 /// Represents An RPC Api block count param, which can take the form of a number, an hex string, or a 32-bytes array
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum BlockCount {
@@ -69,7 +71,7 @@ impl From<BlockCount> for u64 {
 	fn from(block_count: BlockCount) -> u64 {
 		match block_count {
 			BlockCount::Num(n) => n,
-			BlockCount::U256(n) => n.min(U256::from(u64::MAX)).low_u64(),
+			BlockCount::U256(n) => n.min(U64_MAX_U256).low_u64(),
 		}
 	}
 }
@@ -137,5 +139,14 @@ mod tests {
 			r#""0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff""#;
 		let bc: BlockCount = serde_json::from_str(max_u256_hex).unwrap();
 		assert_eq!(u64::from(bc), u64::MAX);
+	}
+
+	#[test]
+	fn block_count_to_u64_saturation_boundary() {
+		let at_max: BlockCount = serde_json::from_str(r#""0xffffffffffffffff""#).unwrap();
+		assert_eq!(u64::from(at_max), u64::MAX);
+
+		let above_max: BlockCount = serde_json::from_str(r#""0x10000000000000000""#).unwrap();
+		assert_eq!(u64::from(above_max), u64::MAX);
 	}
 }

--- a/client/rpc-core/src/types/block_count.rs
+++ b/client/rpc-core/src/types/block_count.rs
@@ -67,6 +67,10 @@ impl From<BlockCount> for U256 {
 	}
 }
 
+/// Converts `BlockCount` to `u64`.
+///
+/// For `BlockCount::U256` values greater than `u64::MAX`, the result saturates to `u64::MAX`
+/// instead of panicking or truncating.
 impl From<BlockCount> for u64 {
 	fn from(block_count: BlockCount) -> u64 {
 		match block_count {


### PR DESCRIPTION
Do not panic If RPC `BlockCount` is a hex `U256` larger than `u64::MAX`, saturates it to `u64::MAX` instead.