### PR TITLE
Meter EIP-7702 delegation writes in StorageMeter

### DIFF
--- a/frame/ethereum/src/mock.rs
+++ b/frame/ethereum/src/mock.rs
@@ -89,7 +89,7 @@ impl FindAuthor<H160> for FindAuthorTruncated {
 
 parameter_types! {
 	pub const TransactionByteFee: u64 = 1;
-	pub const GasLimitStorageGrowthRatio: u64 = 0;
+	pub const GasLimitStorageGrowthRatio: u64 = 366;
 	pub TransactionGasLimit: Option<U256> = Some(fp_evm::MAX_TRANSACTION_GAS_LIMIT);
 	pub static AllowUnprotectedTxs: bool = false;
 	// Alice is allowed to create contracts via CREATE and CALL(CREATE)

--- a/frame/ethereum/src/tests/eip1559.rs
+++ b/frame/ethereum/src/tests/eip1559.rs
@@ -28,7 +28,7 @@ fn eip1559_erc20_creation_unsigned_transaction() -> EIP1559UnsignedTransaction {
 		nonce: U256::zero(),
 		max_priority_fee_per_gas: U256::from(1),
 		max_fee_per_gas: U256::from(1),
-		gas_limit: U256::from(0x100000),
+		gas_limit: U256::from(0x300000),
 		action: ethereum::TransactionAction::Create,
 		value: U256::zero(),
 		input: hex::decode(ERC20_CONTRACT_BYTECODE.trim_end()).unwrap(),

--- a/frame/ethereum/src/tests/eip2930.rs
+++ b/frame/ethereum/src/tests/eip2930.rs
@@ -30,7 +30,7 @@ fn eip2930_erc20_creation_unsigned_transaction() -> EIP2930UnsignedTransaction {
 	EIP2930UnsignedTransaction {
 		nonce: U256::zero(),
 		gas_price: U256::from(1),
-		gas_limit: U256::from(0x100000),
+		gas_limit: U256::from(0x300000),
 		action: ethereum::TransactionAction::Create,
 		value: U256::zero(),
 		input: hex::decode(ERC20_CONTRACT_BYTECODE.trim_end()).unwrap(),

--- a/frame/ethereum/src/tests/eip7702.rs
+++ b/frame/ethereum/src/tests/eip7702.rs
@@ -21,6 +21,7 @@ use std::panic;
 
 use super::*;
 use ethereum::{AuthorizationListItem, TransactionAction};
+use evm::{ExitError, ExitReason};
 use pallet_evm::{config_preludes::ChainId, AddressMapping};
 use sp_core::{H160, H256, U256};
 
@@ -830,12 +831,8 @@ fn eip7702_delegation_storage_meter_safety_check() {
 		let delegation_target =
 			H160::from_str("0x1000000000000000000000000000000000000001").unwrap();
 
-		let authorization = create_authorization_tuple(
-			ChainId::get(),
-			delegation_target,
-			0,
-			&bob.private_key,
-		);
+		let authorization =
+			create_authorization_tuple(ChainId::get(), delegation_target, 0, &bob.private_key);
 
 		// Enough gas for EVM execution (25_000 auth + 21_000 base), but the derived
 		// storage limit (49_000 / 366 = 133 bytes) cannot fit one delegation (135 bytes).
@@ -859,15 +856,20 @@ fn eip7702_delegation_storage_meter_safety_check() {
 			panic!("Expected Call info");
 		};
 
-		assert!(
-			call_info.exit_reason.is_error(),
-			"Transaction should be rejected when delegation storage exceeds the StorageMeter limit, got {:?}",
+		assert_eq!(
+			call_info.exit_reason,
+			ExitReason::Error(ExitError::OutOfGas),
+			"StorageMeter limit exceeded should surface as OutOfGas, not {:?}",
 			call_info.exit_reason
 		);
 
 		assert!(
 			pallet_evm::AccountCodes::<Test>::get(bob.address).is_empty(),
-			"Delegation should not persist after StorageMeter OOG"
+			"Delegation code should not persist after StorageMeter OOG"
+		);
+		assert!(
+			!pallet_evm::AccountCodesMetadata::<Test>::contains_key(bob.address),
+			"Delegation metadata should not persist after StorageMeter OOG"
 		);
 	});
 }

--- a/frame/ethereum/src/tests/eip7702.rs
+++ b/frame/ethereum/src/tests/eip7702.rs
@@ -813,3 +813,61 @@ fn authorization_with_zero_address_delegation() {
 
 	});
 }
+
+/// Verifies that EIP-7702 delegation writes are accounted for by the StorageMeter.
+///
+/// With `GasLimitStorageGrowthRatio = 366` and `gas_limit = 49_000`:
+///   - `storage_limit = 49_000 / 366 = 133` bytes
+///   - One delegation writes 135 bytes, which exceeds the limit
+///   - EVM execution gas (21_000 base + 25_000 auth) still fits within 49_000
+#[test]
+fn eip7702_delegation_storage_meter_safety_check() {
+	let (pairs, mut ext) = new_test_ext_with_initial_balance(3, 10_000_000_000_000);
+	let alice = &pairs[0];
+	let bob = &pairs[1];
+
+	ext.execute_with(|| {
+		let delegation_target =
+			H160::from_str("0x1000000000000000000000000000000000000001").unwrap();
+
+		let authorization = create_authorization_tuple(
+			ChainId::get(),
+			delegation_target,
+			0,
+			&bob.private_key,
+		);
+
+		// Enough gas for EVM execution (25_000 auth + 21_000 base), but the derived
+		// storage limit (49_000 / 366 = 133 bytes) cannot fit one delegation (135 bytes).
+		let gas_limit = U256::from(49_000);
+
+		let transaction = eip7702_transaction_unsigned(
+			U256::zero(),
+			gas_limit,
+			TransactionAction::Call(bob.address),
+			U256::zero(),
+			vec![],
+			vec![authorization],
+		)
+		.sign(&alice.private_key, Some(ChainId::get()));
+
+		let result = Ethereum::execute(alice.address, &transaction, None, None);
+		assert_ok!(&result);
+
+		let (_, _, info) = result.unwrap();
+		let CallOrCreateInfo::Call(call_info) = info else {
+			panic!("Expected Call info");
+		};
+
+		assert!(
+			call_info.exit_reason.is_error(),
+			"Transaction should be rejected when delegation storage exceeds the StorageMeter limit, got {:?}",
+			call_info.exit_reason
+		);
+
+		assert!(
+			pallet_evm::AccountCodes::<Test>::get(bob.address).is_empty(),
+			"Delegation should not persist after StorageMeter OOG"
+		);
+	});
+}

--- a/frame/ethereum/src/tests/legacy.rs
+++ b/frame/ethereum/src/tests/legacy.rs
@@ -31,7 +31,7 @@ fn legacy_erc20_creation_unsigned_transaction() -> LegacyUnsignedTransaction {
 	LegacyUnsignedTransaction {
 		nonce: U256::zero(),
 		gas_price: U256::from(1),
-		gas_limit: U256::from(0x100000),
+		gas_limit: U256::from(0x300000),
 		action: ethereum::TransactionAction::Create,
 		value: U256::zero(),
 		input: hex::decode(ERC20_CONTRACT_BYTECODE.trim_end()).unwrap(),

--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -1359,9 +1359,25 @@ where
 			delegation.address()
 		);
 
-		let meta = crate::CodeMetadata::from_code(&delegation.to_bytes());
+		let code = delegation.to_bytes();
+		let code_len = code.len() as u64;
+
+		if let Some(weight_info) = self.weight_info.as_mut() {
+			weight_info.try_record_proof_size_or_fail(WRITE_PROOF_SIZE)?;
+		}
+
+		if let Some(storage_meter) = self.storage_meter.as_mut() {
+			let storage_growth = ACCOUNT_CODES_KEY_SIZE
+				.saturating_add(ACCOUNT_CODES_METADATA_PROOF_SIZE)
+				.saturating_add(code_len);
+			storage_meter
+				.record(storage_growth)
+				.map_err(|_| ExitError::OutOfGas)?;
+		}
+
+		let meta = crate::CodeMetadata::from_code(&code);
 		<AccountCodesMetadata<T>>::insert(authority, meta);
-		<AccountCodes<T>>::insert(authority, delegation.to_bytes());
+		<AccountCodes<T>>::insert(authority, code);
 		Ok(())
 	}
 


### PR DESCRIPTION
# Meter EIP-7702 delegation writes in StorageMeter

## Summary

- Wire `set_delegation` into Frontier's per-transaction `StorageMeter` and PoV proof-size accounting, matching the pattern already used for contract deployment via `ExternalOperation::Write`.
- EIP-7702 authorization processing calls `set_delegation` directly and previously wrote to `AccountCodes` / `AccountCodesMetadata` without recording storage growth. On chains with `GasLimitStorageGrowthRatio > 0`, this bypassed a hard safety limit: transactions could succeed that should have reverted with `OutOfGas` via `set_storage_oog()`.
- Enable storage metering in the `pallet-ethereum` test mock (`GasLimitStorageGrowthRatio = 366`) and add a regression test that proves delegation writes are now enforced by the meter.

## Problem

Contract deployment records storage growth before writing code:

```
ExternalOperation::Write(len)
  → storage_meter.record(ACCOUNT_CODES_KEY_SIZE + ACCOUNT_CODES_METADATA_PROOF_SIZE + len)
  → set_code(...)
```

EIP-7702 delegation followed a different path:

```
initialize_with_authorization_list(...)
  → set_delegation(...)   // direct AccountCodes insert, no metering
```

Each delegation writes ~135 bytes on-chain (36-byte key + 76-byte metadata + 23-byte delegation designator). With a `gas_limit` of 3.5M and ratio `366`, the StorageMeter allows ~9,562 bytes of growth per transaction — enough for ~71 delegations. Without metering, all 255 authorizations in a single transaction could succeed.

## Solution

In `frame/evm/src/runner/stack.rs`, `set_delegation` now records PoV proof size and storage growth before persisting the delegation code, using the same formula as `record_external_operation` for `ExternalOperation::Write`:

```rust
WRITE_PROOF_SIZE
ACCOUNT_CODES_KEY_SIZE + ACCOUNT_CODES_METADATA_PROOF_SIZE + code_len
```

If the per-transaction storage limit is exceeded, `storage_meter.record()` calls `set_storage_oog()` and returns `OutOfGas`, which propagates through `initialize_with_authorization_list` and fails the transaction.

## Test changes

- **`eip7702_delegation_storage_meter_safety_check`** — submits an EIP-7702 transaction with `gas_limit = 49_000` (storage limit = 133 bytes) and one delegation (135 bytes). Asserts the transaction is rejected and no delegation code is written.
- **`pallet-ethereum` mock** — `GasLimitStorageGrowthRatio` changed from `0` to `366` to match more realistic configuration. Previously, storage metering was disabled for all EIP-7702 tests, hiding this gap.
- **ERC20 deployment helpers** (legacy / EIP-1559 / EIP-2930) — `gas_limit` increased from `0x100000` to `0x300000` so large contract deployments remain within the storage budget when metering is enabled.

## Files changed

| File | Change |
|------|--------|
| `frame/evm/src/runner/stack.rs` | Meter storage growth and PoV proof size in `set_delegation` |
| `frame/ethereum/src/mock.rs` | Enable `GasLimitStorageGrowthRatio = 366` in test runtime |
| `frame/ethereum/src/tests/eip7702.rs` | Add `eip7702_delegation_storage_meter_safety_check` |
| `frame/ethereum/src/tests/legacy.rs` | Bump ERC20 deploy `gas_limit` for storage metering |
| `frame/ethereum/src/tests/eip1559.rs` | Bump ERC20 deploy `gas_limit` for storage metering |
| `frame/ethereum/src/tests/eip2930.rs` | Bump ERC20 deploy `gas_limit` for storage metering |

## Tests

- `cargo test -p pallet-ethereum eip7702_delegation_storage_meter_safety_check`
- `cargo test -p pallet-ethereum eip7702`
- `cargo test -p pallet-ethereum`
- `cargo test -p pallet-evm storage`
