### PR TITLE
fix(rpc): resolve explicit block hash params per EIP-1898

### DIFF
--- a/client/rpc-core/CHANGELOG.md
+++ b/client/rpc-core/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog for `fc-rpc-core`
 
 ## Unreleased
+- Accept a bare 32-byte block-hash string (e.g. `"0x<64 hex>"`) as the `eth` JSON-RPC block parameter, deserializing it to the `Hash` variant instead of overflowing `u64` parsing.
 - Add `FilteredParams::address_in_bloom()` and `FilteredParams::topics_in_bloom()` functions to check the possible existence of Filter addresses or topics in a block.
 - Removed `PendingTransaction` and `PendingTransactions` types.

--- a/client/rpc-core/src/types/block_number.rs
+++ b/client/rpc-core/src/types/block_number.rs
@@ -167,9 +167,24 @@ impl<'a> Visitor<'a> for BlockNumberOrHashVisitor {
 			"pending" => Ok(BlockNumberOrHash::Pending),
 			"safe" => Ok(BlockNumberOrHash::Safe),
 			"finalized" => Ok(BlockNumberOrHash::Finalized),
-			_ if value.starts_with("0x") => u64::from_str_radix(&value[2..], 16)
-				.map(BlockNumberOrHash::Num)
-				.map_err(|e| Error::custom(format!("Invalid block number: {e}"))),
+			_ if value.starts_with("0x") => {
+				let hex = &value[2..];
+				// A 64-hex-char (32-byte) value is a block hash, not a quantity. Geth and
+				// EIP-1898 tooling (e.g. op-deployer's forking layer) pass the block param as a
+				// bare hash string; accept it as a `Hash` instead of overflowing u64 parsing.
+				if hex.len() == 64 {
+					return hex
+						.parse::<H256>()
+						.map(|hash| BlockNumberOrHash::Hash {
+							hash,
+							require_canonical: false,
+						})
+						.map_err(|e| Error::custom(format!("Invalid block hash: {e}")));
+				}
+				u64::from_str_radix(hex, 16)
+					.map(BlockNumberOrHash::Num)
+					.map_err(|e| Error::custom(format!("Invalid block number: {e}")))
+			}
 			_ => value
 				.parse::<u64>()
 				.map(BlockNumberOrHash::Num)
@@ -231,5 +246,26 @@ mod tests {
 		assert_eq!(match_block_number(bn_tag_safe).unwrap(), 999);
 		assert_eq!(match_block_number(bn_tag_finalized).unwrap(), 999);
 		assert_eq!(match_block_number(bn_tag_pending).unwrap(), 1001);
+	}
+
+	#[test]
+	fn bare_block_hash_string_deserialize() {
+		// A 32-byte hex string passed as the block param (as op-deployer's forking layer does)
+		// must deserialize to the `Hash` variant, not overflow u64 parsing.
+		let raw = r#""0x608aef548e02aa13187172e750fd31bd05c39f6f253035a89d6c4882228f03ef""#;
+		let parsed: BlockNumberOrHash = serde_json::from_str(raw).unwrap();
+		match parsed {
+			BlockNumberOrHash::Hash {
+				hash,
+				require_canonical,
+			} => {
+				assert!(!require_canonical);
+				assert_eq!(
+					format!("{hash:#x}"),
+					"0x608aef548e02aa13187172e750fd31bd05c39f6f253035a89d6c4882228f03ef"
+				);
+			}
+			other => panic!("expected Hash variant, got {other:?}"),
+		}
 	}
 }

--- a/client/rpc/CHANGELOG.md
+++ b/client/rpc/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Return a JSON-RPC error (EIP-1898 `-32001` "Resource not found") when an explicit block hash given as a block parameter cannot be resolved, instead of silently returning a zero/default/empty result.
 * Fix `estimate_gas`: ensure that provided gas limit it never larger than current block's gas limit
 * `EthPubSubApi::new` takes an additional `overrides` parameter.
 * Fix `estimate_gas` inaccurate issue.

--- a/client/rpc/src/eth/execute.rs
+++ b/client/rpc/src/eth/execute.rs
@@ -122,7 +122,8 @@ where
 				(hash, self.client.runtime_api())
 			}
 			None => {
-				// Not mapped in the db, assume pending.
+				// `native_block_id` only returns `None` for the `pending` block
+				// parameter; an unknown explicit hash is surfaced as an error.
 				let (hash, api) = self.pending_runtime_api().await.map_err(|err| {
 					internal_err(format!("Create pending runtime api error: {err}"))
 				})?;
@@ -612,7 +613,8 @@ where
 				(hash, client.runtime_api())
 			}
 			None => {
-				// Not mapped in the db, assume pending.
+				// `native_block_id` only returns `None` for the `pending` block
+				// parameter; an unknown explicit hash is surfaced as an error.
 				let (hash, api) = self.pending_runtime_api().await.map_err(|err| {
 					internal_err(format!("Create pending runtime api error: {err}"))
 				})?;

--- a/client/rpc/src/eth/state.rs
+++ b/client/rpc/src/eth/state.rs
@@ -58,13 +58,15 @@ where
 				.account_basic(hash, address)
 				.map_err(|err| internal_err(format!("Fetch account balances failed: {err}")))?
 				.balance)
-		} else if let Ok(Some(id)) = frontier_backend_client::native_block_id::<B, C>(
-			self.client.as_ref(),
-			self.backend.as_ref(),
-			Some(number_or_hash),
-		)
-		.await
-		{
+		} else {
+			let id = frontier_backend_client::native_block_id::<B, C>(
+				self.client.as_ref(),
+				self.backend.as_ref(),
+				Some(number_or_hash),
+			)
+			.await?
+			.ok_or_else(|| internal_err("Block not found"))?;
+
 			let substrate_hash = self
 				.client
 				.expect_block_hash_from_id(&id)
@@ -76,8 +78,6 @@ where
 				.account_basic(substrate_hash, address)
 				.map_err(|err| internal_err(format!("Fetch account balances failed: {err:?}")))?
 				.balance)
-		} else {
-			Ok(U256::zero())
 		}
 	}
 
@@ -94,13 +94,15 @@ where
 				.await
 				.map_err(|err| internal_err(format!("Create pending runtime api error: {err}")))?;
 			Ok(api.storage_at(hash, address, index).unwrap_or_default())
-		} else if let Ok(Some(id)) = frontier_backend_client::native_block_id::<B, C>(
-			self.client.as_ref(),
-			self.backend.as_ref(),
-			Some(number_or_hash),
-		)
-		.await
-		{
+		} else {
+			let id = frontier_backend_client::native_block_id::<B, C>(
+				self.client.as_ref(),
+				self.backend.as_ref(),
+				Some(number_or_hash),
+			)
+			.await?
+			.ok_or_else(|| internal_err("Block not found"))?;
+
 			let substrate_hash = self
 				.client
 				.expect_block_hash_from_id(&id)
@@ -109,8 +111,6 @@ where
 				.storage_override
 				.account_storage_at(substrate_hash, address, index)
 				.unwrap_or_default())
-		} else {
-			Ok(H256::default())
 		}
 	}
 
@@ -182,13 +182,15 @@ where
 				.account_code_at(hash, address)
 				.unwrap_or_default()
 				.into())
-		} else if let Ok(Some(id)) = frontier_backend_client::native_block_id::<B, C>(
-			self.client.as_ref(),
-			self.backend.as_ref(),
-			Some(number_or_hash),
-		)
-		.await
-		{
+		} else {
+			let id = frontier_backend_client::native_block_id::<B, C>(
+				self.client.as_ref(),
+				self.backend.as_ref(),
+				Some(number_or_hash),
+			)
+			.await?
+			.ok_or_else(|| internal_err("Block not found"))?;
+
 			let substrate_hash = self
 				.client
 				.expect_block_hash_from_id(&id)
@@ -198,8 +200,6 @@ where
 				.account_code_at(substrate_hash, address)
 				.unwrap_or_default()
 				.into())
-		} else {
-			Ok(Bytes(vec![]))
 		}
 	}
 }

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -59,7 +59,7 @@ pub use fc_rpc_core::{
 pub use fc_storage::{overrides::*, StorageOverrideHandler};
 
 pub mod frontier_backend_client {
-	use super::internal_err;
+	use super::{err, internal_err, RESOURCE_NOT_FOUND_CODE};
 
 	use ethereum_types::{H160, H256, U256};
 	use jsonrpsee::core::RpcResult;
@@ -200,10 +200,19 @@ pub mod frontier_backend_client {
 	{
 		Ok(match number.unwrap_or(BlockNumberOrHash::Latest) {
 			BlockNumberOrHash::Hash { hash, .. } => {
-				if let Ok(Some(hash)) = load_hash::<B, C>(client, backend, hash).await {
-					Some(BlockId::Hash(hash))
-				} else {
-					None
+				match load_hash::<B, C>(client, backend, hash).await? {
+					Some(hash) => Some(BlockId::Hash(hash)),
+					// EIP-1898: an explicit block hash that cannot be resolved must
+					// raise a JSON-RPC error (recommended code -32001 "Resource not
+					// found") rather than falling through to a zero/default/empty
+					// result or being treated as pending.
+					None => {
+						return Err(err(
+							RESOURCE_NOT_FOUND_CODE,
+							format!("block hash not found: {hash:?}"),
+							None,
+						))
+					}
 				}
 			}
 			BlockNumberOrHash::Num(number) => Some(BlockId::Number(number.unique_saturated_into())),
@@ -306,6 +315,11 @@ pub fn err<T: ToString>(
 		}),
 	)
 }
+
+/// EIP-1898 "Resource not found" error code. Returned when an explicit block
+/// hash supplied as a block parameter cannot be found.
+/// See <https://eips.ethereum.org/EIPS/eip-1898>.
+pub const RESOURCE_NOT_FOUND_CODE: i32 = -32001;
 
 pub fn internal_err<T: ToString>(message: T) -> jsonrpsee::types::error::ErrorObjectOwned {
 	err(jsonrpsee::types::error::INTERNAL_ERROR_CODE, message, None)


### PR DESCRIPTION
## Summary

Two related fixes so that a 32-byte **block hash** supplied as the `eth` JSON-RPC block parameter is parsed and resolved correctly, instead of silently degrading to a wrong result. Both were hit using EIP-1898 tooling (e.g. op-deployer's forking layer, which passes a bare block-hash string as the block param).

### 1. `fc-rpc-core`: accept a bare block-hash string as a block param
The block-param visitor parsed *every* `0x`-prefixed string as a hex `u64`, so a bare 32-byte block hash overflowed with `number too large to fit in target type`. The fix detects 64-hex-char values and deserializes them to the `Hash` variant. Number / tag / object-form params are unchanged.

### 2. `fc-rpc`: return an error when an explicit block hash can't be resolved
`native_block_id` returned `None` for an unresolvable explicit block hash, and the callers in `eth/state.rs` (`balance`, `storage_at`, `code_at`) swallowed that into a zero/default/empty result — making a query against an unknown block look like a real, empty account.

Per [EIP-1898](https://eips.ethereum.org/EIPS/eip-1898), an explicit block hash that cannot be found must raise a JSON-RPC error (recommended code `-32001`, "Resource not found"). The error is now propagated from `native_block_id` and surfaced by those callers. `execute.rs` comments are updated to reflect that `None` now only means `pending`.

## Testing
- Added a unit test (`bare_block_hash_string_deserialize`) covering hash-variant deserialization.
- `cargo test -p fc-rpc-core` passes; `cargo build -p fc-rpc -p fc-rpc-core` is clean.

## Changelog
Entries added to `client/rpc/CHANGELOG.md` and `client/rpc-core/CHANGELOG.md` under `## Unreleased`.